### PR TITLE
fix: 배포 이미지 멀티 아키텍처 빌드 + self-hosted 러너 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,9 @@ jobs:
           echo "repo=${REPO_LOWER}" >> "$GITHUB_OUTPUT"
           echo "image=${REPO_LOWER}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: QEMU 설정 (크로스 아키텍처 빌드용)
+        uses: docker/setup-qemu-action@v3
+
       - name: Buildx 설정
         uses: docker/setup-buildx-action@v3
 
@@ -50,6 +53,8 @@ jobs:
         with:
           context: backend
           push: true
+          # 서버가 ARM64(Graviton)라 amd64 러너에서 크로스 빌드한다.
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.image }}
             ${{ steps.meta.outputs.repo }}:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,76 +64,66 @@ jobs:
   deploy:
     name: 서버 배포
     needs: build
-    runs-on: ubuntu-latest
+    # 러너 자체가 배포 대상 EC2 위에서 돈다 (self-hosted).
+    # 그래서 SSH/SCP 없이 로컬 명령으로 바로 배포한다.
+    runs-on: [self-hosted, linux, ARM64]
     environment: production
 
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
 
-      - name: compose 파일 전송
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_PORT }}
-          source: backend/docker-compose.prod.yml
-          target: ${{ secrets.DEPLOY_PATH }}
-          strip_components: 1
+      - name: compose 파일 배치
+        env:
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          mkdir -p "$DEPLOY_PATH"
+          cp backend/docker-compose.prod.yml "$DEPLOY_PATH/docker-compose.prod.yml"
 
       - name: 이미지 교체 및 헬스체크
-        uses: appleboy/ssh-action@v1.2.0
         env:
           NEW_IMAGE: ${{ needs.build.outputs.image }}
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_PORT }}
-          envs: NEW_IMAGE,GHCR_USER,GHCR_TOKEN,DEPLOY_PATH
-          script_stop: true
-          script: |
-            set -eu
-            cd "$DEPLOY_PATH"
+        run: |
+          set -eu
+          cd "$DEPLOY_PATH"
 
-            COMPOSE="docker compose --env-file .env --env-file image.env -f docker-compose.prod.yml"
+          COMPOSE="docker compose --env-file .env --env-file image.env -f docker-compose.prod.yml"
 
-            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            # 롤백 대비로 직전 이미지 태그를 보관한다.
-            if [ -f image.env ]; then
-              cp image.env image.env.prev
+          # 롤백 대비로 직전 이미지 태그를 보관한다.
+          if [ -f image.env ]; then
+            cp image.env image.env.prev
+          fi
+          echo "BACKEND_IMAGE=$NEW_IMAGE" > image.env
+
+          $COMPOSE pull
+          $COMPOSE up -d
+
+          echo "헬스체크 시작"
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/health > /dev/null 2>&1; then
+              echo "헬스체크 성공 ($i번째 시도)"
+              docker image prune -f > /dev/null 2>&1 || true
+              docker logout ghcr.io > /dev/null 2>&1 || true
+              exit 0
             fi
-            echo "BACKEND_IMAGE=$NEW_IMAGE" > image.env
+            sleep 5
+          done
 
-            $COMPOSE pull
+          echo "헬스체크 실패 - 직전 버전으로 롤백한다"
+          $COMPOSE logs --tail 100 app || true
+
+          if [ -f image.env.prev ]; then
+            mv image.env.prev image.env
             $COMPOSE up -d
+            echo "롤백 완료"
+          else
+            echo "직전 버전이 없어 롤백하지 못했다 (최초 배포로 추정)"
+          fi
 
-            echo "헬스체크 시작"
-            for i in $(seq 1 30); do
-              if curl -fsS http://localhost:8080/health > /dev/null 2>&1; then
-                echo "헬스체크 성공 ($i번째 시도)"
-                docker image prune -f > /dev/null 2>&1 || true
-                docker logout ghcr.io > /dev/null 2>&1 || true
-                exit 0
-              fi
-              sleep 5
-            done
-
-            echo "헬스체크 실패 - 직전 버전으로 롤백한다"
-            docker compose -f docker-compose.prod.yml logs --tail 100 app || true
-
-            if [ -f image.env.prev ]; then
-              mv image.env.prev image.env
-              $COMPOSE up -d
-              echo "롤백 완료"
-            else
-              echo "직전 버전이 없어 롤백하지 못했다 (최초 배포로 추정)"
-            fi
-
-            docker logout ghcr.io > /dev/null 2>&1 || true
-            exit 1
+          docker logout ghcr.io > /dev/null 2>&1 || true
+          exit 1

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -3,21 +3,27 @@
 ## 전체 구조
 
 ```
-main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions
+main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions (GitHub-hosted)
                                             │
                               ┌─────────────┴─────────────┐
                               │ 1. Docker 이미지 빌드      │
                               │ 2. GHCR 에 push           │
                               └─────────────┬─────────────┘
-                                            │ SSH
+                                            │
+                                            ▼
+                              GitHub Actions (self-hosted, EC2 내부)
+                                            │ 로컬 명령 (SSH 없음)
                                             ▼
                                     EC2 (Docker + compose)
                                     ├─ sssok-app       (GHCR 에서 pull)
                                     └─ sssok-postgres  (볼륨 영속)
 ```
 
+- 이미지 빌드는 GitHub-hosted 러너에서, 서버 배포는 **EC2 위에 설치된 self-hosted 러너**에서 실행된다. 배포 잡이 러너 자체이자 배포 대상이므로 SSH/SCP가 필요 없다.
 - 이미지 태그는 커밋 SHA를 사용한다. 롤백은 직전 태그로 되돌리는 것으로 끝난다.
 - 배포 후 `/health` 를 최대 150초간 폴링하고, 실패하면 자동으로 직전 이미지로 롤백한다.
+
+> **왜 self-hosted인가**: GitHub-hosted 러너는 매 실행마다 IP가 바뀌는 임시 VM이라, 보안 그룹에서 특정 IP만 허용하는 정책과 근본적으로 충돌한다. self-hosted 러너를 EC2 안에 두면 배포 스텝이 "밖에서 안으로 접속"하는 게 아니라 "그 자리에서 로컬 실행"이 되므로, 22번 포트를 CI용으로 열어둘 필요가 아예 없어진다.
 
 ## 서버 디렉터리 구조
 
@@ -38,8 +44,10 @@ main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions
 
 | 포트 | 소스 | 용도 |
 | --- | --- | --- |
-| 22 | 내 IP | SSH |
+| 22 | 관리자 IP / VPN | 사람이 직접 접속할 때만 (CI는 이 포트를 쓰지 않음) |
 | 8080 | 0.0.0.0/0 | 백엔드 (Nginx 붙이기 전 임시) |
+
+CI(GitHub Actions)는 self-hosted 러너를 통해 EC2 내부에서 직접 실행되므로, 22번 포트를 CI용으로 별도 개방할 필요가 없다.
 
 ### 2. Docker 설치
 
@@ -80,21 +88,29 @@ EOF
 chmod 600 .env
 ```
 
-### 4. 배포용 SSH 키 발급
+### 4. self-hosted 러너 설치 (EC2 내부)
 
-로컬에서 실행한다. **기존에 노출된 키는 쓰지 않는다.**
-
-```bash
-ssh-keygen -t ed25519 -f ~/.ssh/sssok_deploy -N "" -C "github-actions-deploy"
-```
-
-공개키를 서버에 등록한다.
+`Settings → Actions → Runners → New self-hosted runner` 에서 OS/아키텍처(Linux, ARM64)를 선택하면
+등록 토큰이 포함된 설치 명령이 나온다. 그 명령을 EC2 에서 그대로 실행한다. 등록 토큰은 1시간 안에 써야 한다.
 
 ```bash
-ssh-copy-id -i ~/.ssh/sssok_deploy.pub ubuntu@<EC2_IP>
+mkdir -p ~/actions-runner && cd ~/actions-runner
+curl -o actions-runner-linux-arm64.tar.gz -L https://github.com/actions/runner/releases/download/<버전>/actions-runner-linux-arm64-<버전>.tar.gz
+tar xzf ./actions-runner-linux-arm64.tar.gz
+./config.sh --url https://github.com/woowacourse-teams/2026-sssOK --token <등록_토큰>
 ```
 
-개인키(`~/.ssh/sssok_deploy`) **전문**을 GitHub Secret `DEPLOY_SSH_KEY` 에 넣는다.
+서비스로 등록해서 재부팅 후에도 계속 떠 있게 한다.
+
+```bash
+sudo ./svc.sh install
+sudo ./svc.sh start
+sudo ./svc.sh status   # active (running) 확인
+```
+
+러너 실행 계정이 `docker` 그룹에 속해 있는지 확인한다 (안 되어 있으면 `sudo usermod -aG docker ubuntu` 후 `sudo ./svc.sh stop && sudo ./svc.sh start`).
+
+> **보안**: self-hosted 러너는 그 서버에서 임의 코드를 실행할 권한을 가진다. 이 워크플로는 `deploy` 브랜치 push(이미 리뷰된 코드)에만 반응하므로 위험이 낮지만, 이 리포에서 외부 기여자의 fork PR을 받게 되면 `Settings → Actions → General` 에서 fork PR의 워크플로 자동 실행을 반드시 막아야 한다.
 
 ### 5. GitHub Secrets 등록
 
@@ -102,13 +118,9 @@ ssh-copy-id -i ~/.ssh/sssok_deploy.pub ubuntu@<EC2_IP>
 
 | 이름 | 예시 |
 | --- | --- |
-| `DEPLOY_HOST` | `13.125.x.x` |
-| `DEPLOY_USER` | `ubuntu` |
-| `DEPLOY_SSH_KEY` | `-----BEGIN OPENSSH PRIVATE KEY-----` 로 시작하는 전문 |
-| `DEPLOY_PORT` | `22` |
 | `DEPLOY_PATH` | `/home/ubuntu/app` |
 
-DB·JWT·R2 값은 서버 `.env` 에 있으므로 GitHub Secret으로 넣지 않는다.
+DB·JWT·R2 값은 서버 `.env` 에 있으므로 GitHub Secret으로 넣지 않는다. (SSH 기반이 아니므로 `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_SSH_KEY`/`DEPLOY_PORT` 는 더 이상 사용하지 않는다.)
 
 ### 6. GHCR 패키지 접근 권한
 


### PR DESCRIPTION
## 작업 내용
1. **멀티 아키텍처 이미지 빌드**: 서버(ARM64/Graviton)와 GitHub Actions 러너(amd64) 아키텍처가 달라
   `no matching manifest for linux/arm64/v8` 에러로 이미지 pull이 실패하던 문제 수정
2. **배포를 self-hosted 러너 기반으로 전환**: GitHub-hosted 러너는 매 실행마다 IP가 바뀌어서
   보안 그룹의 IP 화이트리스트 정책과 근본적으로 충돌 (SSH `dial tcp ... i/o timeout`).
   EC2 내부에 self-hosted 러너를 설치해 배포 잡이 그 자리에서 로컬로 실행되도록 변경 (SSH/SCP 제거)

## 관련 이슈
Refs #8

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] QEMU 설정 + `platforms: linux/amd64,linux/arm64`
- [x] deploy 잡 `runs-on`을 `[self-hosted, linux, ARM64]`로 변경
- [x] scp-action / ssh-action 제거, 로컬 `run:` 스텝으로 대체
- [x] DEPLOY_HOST/USER/SSH_KEY/PORT 시크릿 불필요해짐 (DEPLOY_PATH만 유지)
- [x] docs/DEPLOYMENT.md 를 self-hosted 러너 세팅 절차로 갱신

## 테스트
- [x] YAML 파싱 검증
- [x] 이미지 빌드 및 GHCR 푸시 성공 확인 (workflow_dispatch로 이 브랜치에서 실행)
- [x] EC2에 self-hosted 러너 설치 완료, 수동으로 docker compose up 성공 및 /health 확인
- [ ] self-hosted 러너 배포 잡 자체는 이 PR 머지 후 실제 실행으로 확인 예정

## 리뷰 요청 사항
- self-hosted 러너 보안 고려사항: 이 워크플로는 `deploy` 브랜치 push(이미 리뷰된 코드)에만 반응하므로
  현재는 위험이 낮음. 추후 fork PR을 받게 되면 fork PR 워크플로 자동 실행을 막아야 함 (문서에 명시)
