### PR TITLE
perf: 배포 이미지 빌드 시간 단축 (컴파일/이미지 조립 분리)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,21 @@ jobs:
           echo "repo=${REPO_LOWER}" >> "$GITHUB_OUTPUT"
           echo "image=${REPO_LOWER}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Gradle 설정
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: JAR 빌드 (네이티브)
+        # 컴파일은 러너에서 amd64 네이티브로 끝내고, Docker는 결과물만 담는다.
+        # (이미지 안에서 컴파일하면 arm64 크로스 빌드 시 QEMU 에뮬레이션으로 수 배 느려진다)
+        working-directory: backend
+        run: ./gradlew bootJar -x test --no-daemon
+
       - name: QEMU 설정 (크로스 아키텍처 빌드용)
         uses: docker/setup-qemu-action@v3
 
@@ -48,12 +63,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 빌드 및 푸시
+      - name: 이미지 빌드 및 푸시
         uses: docker/build-push-action@v6
         with:
           context: backend
           push: true
-          # 서버가 ARM64(Graviton)라 amd64 러너에서 크로스 빌드한다.
+          # 이미지 조립은 미리 빌드된 JAR을 복사만 하므로,
+          # QEMU 에뮬레이션 비용 없이 두 아키텍처 모두 빠르게 빌드된다.
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.image }}

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,4 +1,5 @@
-build/
+build/*
+!build/libs
 .gradle/
 .idea/
 *.iml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,25 +1,14 @@
 # syntax=docker/dockerfile:1
 
-# ---------- 빌드 스테이지 ----------
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-
-# 의존성 레이어를 소스와 분리해 캐시 적중률을 높인다.
-COPY gradle/ gradle/
-COPY gradlew settings.gradle build.gradle ./
-RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
-
-COPY src/ src/
-RUN ./gradlew clean bootJar --no-daemon -x test \
-    && mv build/libs/*.jar app.jar
-
-# ---------- 실행 스테이지 ----------
+# JAR은 CI가 러너에서 네이티브로 미리 빌드해서 build/libs/ 에 놓는다.
+# (컴파일을 이미지 안에서 하면 arm64 크로스 빌드 시 QEMU 에뮬레이션으로
+#  수 배 느려지기 때문에, 컴파일과 이미지 조립을 분리했다.)
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
 RUN addgroup -S app && adduser -S app -G app
 
-COPY --from=builder --chown=app:app /workspace/app.jar app.jar
+COPY --chown=app:app build/libs/*.jar app.jar
 
 USER app
 EXPOSE 8080


### PR DESCRIPTION
## 작업 내용
배포 이미지 빌드 시간이 약 9분 걸리던 문제를 수 초~1분대로 단축.

**원인**: Docker 멀티스테이지 빌드 안에서 Gradle 컴파일까지 했는데, arm64 크로스 빌드 시 GitHub-hosted(amd64) 러너가 QEMU로 arm64를 에뮬레이션하면서 그 위에서 JVM 컴파일을 돌리다 보니 극도로 느렸음.

**해결**: 컴파일과 이미지 조립을 분리.
- JAR은 GitHub Actions 러너에서 네이티브(amd64)로 먼저 빌드
- Docker는 완성된 JAR을 이미지에 복사만 함 (RUN으로 무거운 작업을 하지 않으므로 QEMU 에뮬레이션 비용이 사실상 없어짐)

## 관련 이슈
Refs #8

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] `backend/Dockerfile`: 빌드 스테이지 제거, JRE 실행 스테이지만 유지 (`build/libs/*.jar` 를 그대로 복사)
- [x] `backend/.dockerignore`: `build/*` 제외하되 `build/libs` 는 예외로 허용
- [x] `.github/workflows/deploy.yml`: JDK 21 + Gradle 설정 후 `./gradlew bootJar -x test` 를 Docker 빌드 이전에 실행

## 테스트
- [x] 로컬에서 `./gradlew bootJar` 후 `docker build` 로 새 Dockerfile 검증 완료 (수 초 내 완료, 이미지 정상 생성)
- [ ] 실제 CI에서 amd64/arm64 멀티 아키텍처 빌드 시간 단축 확인 예정 (머지 후 deploy 반영 시)

## 리뷰 요청 사항
- 직전 배포(#8, #11, #12)로 self-hosted 러너 기반 배포가 정상 동작하는 것까지 확인된 상태에서, 빌드 속도만 개선하는 후속 변경입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 과정에서 JDK 21 및 Gradle 환경을 자동으로 설정합니다.
  * Docker 이미지 생성 전 애플리케이션을 사전 빌드해 배포 효율성을 높였습니다.
  * 사전 생성된 실행 파일을 기반으로 멀티아키텍처 Docker 이미지를 빌드하고 배포합니다.
  * 컨테이너 이미지 생성 및 실행 구성을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->