### PR TITLE
deploy: 배포 이미지 빌드 시간 단축 반영

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,21 @@ jobs:
           echo "repo=${REPO_LOWER}" >> "$GITHUB_OUTPUT"
           echo "image=${REPO_LOWER}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Gradle 설정
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: JAR 빌드 (네이티브)
+        # 컴파일은 러너에서 amd64 네이티브로 끝내고, Docker는 결과물만 담는다.
+        # (이미지 안에서 컴파일하면 arm64 크로스 빌드 시 QEMU 에뮬레이션으로 수 배 느려진다)
+        working-directory: backend
+        run: ./gradlew bootJar -x test --no-daemon
+
       - name: QEMU 설정 (크로스 아키텍처 빌드용)
         uses: docker/setup-qemu-action@v3
 
@@ -48,12 +63,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 빌드 및 푸시
+      - name: 이미지 빌드 및 푸시
         uses: docker/build-push-action@v6
         with:
           context: backend
           push: true
-          # 서버가 ARM64(Graviton)라 amd64 러너에서 크로스 빌드한다.
+          # 이미지 조립은 미리 빌드된 JAR을 복사만 하므로,
+          # QEMU 에뮬레이션 비용 없이 두 아키텍처 모두 빠르게 빌드된다.
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.image }}

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,4 +1,5 @@
-build/
+build/*
+!build/libs
 .gradle/
 .idea/
 *.iml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,25 +1,14 @@
 # syntax=docker/dockerfile:1
 
-# ---------- 빌드 스테이지 ----------
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-
-# 의존성 레이어를 소스와 분리해 캐시 적중률을 높인다.
-COPY gradle/ gradle/
-COPY gradlew settings.gradle build.gradle ./
-RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
-
-COPY src/ src/
-RUN ./gradlew clean bootJar --no-daemon -x test \
-    && mv build/libs/*.jar app.jar
-
-# ---------- 실행 스테이지 ----------
+# JAR은 CI가 러너에서 네이티브로 미리 빌드해서 build/libs/ 에 놓는다.
+# (컴파일을 이미지 안에서 하면 arm64 크로스 빌드 시 QEMU 에뮬레이션으로
+#  수 배 느려지기 때문에, 컴파일과 이미지 조립을 분리했다.)
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
 RUN addgroup -S app && adduser -S app -G app
 
-COPY --from=builder --chown=app:app /workspace/app.jar app.jar
+COPY --chown=app:app build/libs/*.jar app.jar
 
 USER app
 EXPOSE 8080


### PR DESCRIPTION
## 작업 내용
main에 머지된 배포 이미지 빌드 시간 단축(#8, #13 — 컴파일/이미지 조립 분리)을 deploy에 반영해 실제 빌드 시간 개선을 확인한다.

## 관련 이슈
Refs #8

## 작업 영역
- [ ] Frontend
- [x] Backend

## 테스트
- [x] main 브랜치에서 리뷰 완료 및 머지 확인
- [ ] deploy 반영 후 실제 빌드 시간 단축 및 배포 성공 확인 예정

## 리뷰 요청 사항
이미 main에서 리뷰된 변경사항이므로 배포 확인 목적의 PR입니다.