### PR TITLE
chore: Swagger(springdoc-openapi) 기본 세팅

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // API 문서화 (Swagger UI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.9.0'
+
     // DB 마이그레이션
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'

--- a/backend/src/main/java/com/sssok/infrastructure/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.sssok.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openApi() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("sssOK API")
+                .description("링크 하나로 여는 단발성 이미지·영상 공유 공간, sssOK의 백엔드 API 명세")
+                .version("v0.0.1")
+                .contact(new Contact()
+                    .name("sssOK Backend")
+                    .url("https://github.com/woowacourse-teams/2026-sssOK")));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,3 +48,8 @@ media:
   resize-target-width: 1600
   # GIF는 애니메이션이 깨지므로 리사이즈/압축 대상에서 제외한다
   skip-formats: gif
+
+springdoc:
+  swagger-ui:
+    operations-sorter: method
+    tags-sorter: alpha


### PR DESCRIPTION
## 작업 내용
springdoc-openapi를 도입해서, 로컬 개발 환경에서 API 명세를 웹 UI로 확인할 수 있도록 기본 세팅 완료

## 관련 이슈
Closes #15

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] `build.gradle`에 springdoc-openapi-starter-webmvc-ui 2.9.0 추가
- [x] `OpenApiConfig`로 API 제목/설명/버전/연락처 커스터마이징
- [x] Swagger UI 정렬 옵션(`operationsSorter: method`, `tagsSorter: alpha`) 적용

## 테스트
- [x] 로컬에서 `/swagger-ui/index.html` 200 확인
- [x] `/v3/api-docs`에서 title/description/version/contact 정상 노출 확인
- [ ] 운영 서버(deploy) 접속 확인은 머지 후 배포 시 진행 예정

## 리뷰 요청 사항
- 인증 스킴(JWT Bearer)은 이번 PR에 넣지 않았습니다. 
- 아직 실제 인증 로직이 없어서, 나중에 인증 API를 구현할 때 그 자리에서 같이 추가하는게 좋을거 같음
- 운영 서버에 Swagger UI를 계속 열어둘지 여부는 이슈 #15에 남겨둔 대로 팀 논의가 필요합니다.
