### PR TITLE
feat: Walking Skeleton — 방 생성/조회 API 관통

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,11 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // 통합 테스트용 실제 PostgreSQL (H2 금지 — JSONB 등 PostgreSQL 전용 기능 검증 불가)
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
@@ -1,5 +1,13 @@
 package com.sssok.application.port.out;
 
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import java.util.Optional;
+
 // 방 영속화 출력
 public interface RoomRepository {
+
+    Room save(Room room);
+
+    Optional<Room> findByCode(RoomCode code);
 }

--- a/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
@@ -1,5 +1,25 @@
 package com.sssok.application.room;
 
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.random.RandomGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
 // 방 생성
+@Service
+@RequiredArgsConstructor
 public class CreateRoomService {
+
+    private final RoomRepository roomRepository;
+    private final RandomGenerator randomGenerator = new SecureRandom();
+
+    public Room create() {
+        RoomCode code = RoomCode.generate(randomGenerator);
+        Room room = Room.create(code, Instant.now());
+        return roomRepository.save(room);
+    }
 }

--- a/backend/src/main/java/com/sssok/application/room/GetRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/GetRoomService.java
@@ -1,0 +1,20 @@
+package com.sssok.application.room;
+
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 방 코드로 조회
+@Service
+@RequiredArgsConstructor
+public class GetRoomService {
+
+    private final RoomRepository roomRepository;
+
+    public Room getByCode(RoomCode code) {
+        return roomRepository.findByCode(code)
+            .orElseThrow(() -> new RoomNotFoundException(code));
+    }
+}

--- a/backend/src/main/java/com/sssok/application/room/RoomNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/room/RoomNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sssok.application.room;
+
+import com.sssok.domain.room.RoomCode;
+
+public class RoomNotFoundException extends RuntimeException {
+
+    public RoomNotFoundException(RoomCode code) {
+        super("존재하지 않는 방입니다: " + code.value());
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/InvalidRoomCodeException.java
+++ b/backend/src/main/java/com/sssok/domain/room/InvalidRoomCodeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room;
+
+public class InvalidRoomCodeException extends RuntimeException {
+
+    public InvalidRoomCodeException(String value) {
+        super("올바르지 않은 방 코드 형식입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/Room.java
+++ b/backend/src/main/java/com/sssok/domain/room/Room.java
@@ -1,5 +1,32 @@
 package com.sssok.domain.room;
 
+import java.time.Instant;
+import lombok.Getter;
+
 // 방 애그리거트 루트. 코드, 상태, 만료, 업로드 권한을 관리한다.
+// 이 단계(#17)에서는 생성/조회에 필요한 최소 형태만 다루고, 나머지 규칙은 #24에서 확장한다.
+@Getter
 public class Room {
+
+    private final Long id;
+    private final RoomCode code;
+    private final RoomStatus status;
+    private final Instant createdAt;
+
+    private Room(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
+        this.id = id;
+        this.code = code;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    // 신규 생성 (아직 저장 전이라 id 없음)
+    public static Room create(RoomCode code, Instant now) {
+        return new Room(null, code, RoomStatus.ACTIVE, now);
+    }
+
+    // 저장소에서 불러온 값으로 복원
+    public static Room reconstruct(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
+        return new Room(id, code, status, createdAt);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/room/RoomCode.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomCode.java
@@ -1,5 +1,25 @@
 package com.sssok.domain.room;
 
+import java.util.random.RandomGenerator;
+
 // 방 참여에 쓰이는 8자리 코드 값 객체.
-public class RoomCode {
+public record RoomCode(String value) {
+
+    // 혼동하기 쉬운 0, 1, I, O 는 제외한다 (QR·구두 전달 시 헷갈림 방지).
+    private static final String ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+    private static final int LENGTH = 8;
+
+    public RoomCode {
+        if (value == null || !value.matches("[" + ALPHABET + "]{" + LENGTH + "}")) {
+            throw new InvalidRoomCodeException(value);
+        }
+    }
+
+    public static RoomCode generate(RandomGenerator random) {
+        StringBuilder builder = new StringBuilder(LENGTH);
+        for (int i = 0; i < LENGTH; i++) {
+            builder.append(ALPHABET.charAt(random.nextInt(ALPHABET.length())));
+        }
+        return new RoomCode(builder.toString());
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
@@ -1,5 +1,7 @@
 package com.sssok.domain.room;
 
 // 방의 생명주기 상태(활성/만료/삭제/영구삭제).
+// 이 단계(#17)에서는 생성 직후 상태만 다루고, 전체 전이 규칙은 #24에서 확장한다.
 public enum RoomStatus {
+    ACTIVE
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
@@ -1,0 +1,39 @@
+package com.sssok.infrastructure.persistence.room;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 8)
+    private String code;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public RoomJpaEntity(Long id, String code, String status, Instant createdAt) {
+        this.id = id;
+        this.code = code;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaRepository.java
@@ -1,0 +1,9 @@
+package com.sssok.infrastructure.persistence.room;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long> {
+
+    Optional<RoomJpaEntity> findByCode(String code);
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
@@ -1,0 +1,45 @@
+package com.sssok.infrastructure.persistence.room;
+
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomStatus;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomRepositoryAdapter implements RoomRepository {
+
+    private final RoomJpaRepository jpaRepository;
+
+    @Override
+    public Room save(Room room) {
+        RoomJpaEntity saved = jpaRepository.save(toEntity(room));
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<Room> findByCode(RoomCode code) {
+        return jpaRepository.findByCode(code.value()).map(this::toDomain);
+    }
+
+    private RoomJpaEntity toEntity(Room room) {
+        return new RoomJpaEntity(
+            room.getId(),
+            room.getCode().value(),
+            room.getStatus().name(),
+            room.getCreatedAt()
+        );
+    }
+
+    private Room toDomain(RoomJpaEntity entity) {
+        return Room.reconstruct(
+            entity.getId(),
+            new RoomCode(entity.getCode()),
+            RoomStatus.valueOf(entity.getStatus()),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/ApiResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/ApiResponse.java
@@ -1,0 +1,8 @@
+package com.sssok.presentation.api.common;
+
+public record ApiResponse<T>(T data) {
+
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data);
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/ErrorResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.sssok.presentation.api.common;
+
+public record ErrorResponse(String code, String message) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.sssok.presentation.api.common;
+
+import com.sssok.application.room.RoomNotFoundException;
+import com.sssok.domain.room.InvalidRoomCodeException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RoomNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleRoomNotFound(RoomNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse("ROOM_NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRoomCodeException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRoomCode(InvalidRoomCodeException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("INVALID_ROOM_CODE", e.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
@@ -1,0 +1,37 @@
+package com.sssok.presentation.api.room;
+
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.application.room.GetRoomService;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.presentation.api.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final CreateRoomService createRoomService;
+    private final GetRoomService getRoomService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom() {
+        Room room = createRoomService.create();
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.of(RoomResponse.from(room)));
+    }
+
+    @GetMapping("/{code}")
+    public ApiResponse<RoomResponse> getRoom(@PathVariable String code) {
+        Room room = getRoomService.getByCode(new RoomCode(code));
+        return ApiResponse.of(RoomResponse.from(room));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
@@ -1,0 +1,11 @@
+package com.sssok.presentation.api.room;
+
+import com.sssok.domain.room.Room;
+import java.time.Instant;
+
+public record RoomResponse(String code, String status, Instant createdAt) {
+
+    public static RoomResponse from(Room room) {
+        return new RoomResponse(room.getCode().value(), room.getStatus().name(), room.getCreatedAt());
+    }
+}

--- a/backend/src/main/resources/db/migration/V1__create_room.sql
+++ b/backend/src/main/resources/db/migration/V1__create_room.sql
@@ -1,0 +1,6 @@
+CREATE TABLE room (
+    id         BIGSERIAL PRIMARY KEY,
+    code       VARCHAR(8) NOT NULL UNIQUE,
+    status     VARCHAR(20) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);

--- a/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
@@ -1,0 +1,50 @@
+package com.sssok.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.SecureRandom;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RoomCodeTest {
+
+    private static final String VALID_CHARS_REGEX = "[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{8}";
+
+    @RepeatedTest(20)
+    void 생성된_코드는_8자리이고_혼동_문자를_포함하지_않는다() {
+        RoomCode code = RoomCode.generate(new SecureRandom());
+
+        assertThat(code.value()).matches(VALID_CHARS_REGEX);
+    }
+
+    @Test
+    void 유효한_형식의_코드는_정상_생성된다() {
+        RoomCode code = new RoomCode("23456789");
+
+        assertThat(code.value()).isEqualTo("23456789");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "1234567",      // 7자리 (길이 부족)
+        "123456789",    // 9자리 (길이 초과)
+        "ABCDEFG0",     // 혼동 문자 0 포함
+        "ABCDEFG1",     // 혼동 문자 1 포함
+        "ABCDEFGI",     // 혼동 문자 I 포함
+        "ABCDEFGO",     // 혼동 문자 O 포함
+        "abcdefgh",     // 소문자 불허
+    })
+    void 형식에_맞지_않으면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new RoomCode(invalidValue))
+            .isInstanceOf(InvalidRoomCodeException.class);
+    }
+
+    @Test
+    void null_값이면_예외() {
+        assertThatThrownBy(() -> new RoomCode(null))
+            .isInstanceOf(InvalidRoomCodeException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -1,0 +1,70 @@
+package com.sssok.presentation.api.room;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+// Room 생성 -> 코드로 조회까지 컨트롤러/서비스/리포지토리/Flyway 마이그레이션이
+// 실제 PostgreSQL 위에서 전부 맞물려 도는지 확인하는 관통 테스트 (Walking Skeleton).
+// Flyway가 만든 스키마와 엔티티 매핑이 실제로 맞는지까지 검증한다 (운영과 동일한 검증 모드).
+@SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+@AutoConfigureMockMvc
+@Testcontainers
+class RoomApiTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 방을_생성하고_코드로_조회한다() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/rooms"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.code").value(matchesPattern("[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{8}")))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+            .andReturn();
+
+        JsonNode created = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String code = created.get("data").get("code").asText();
+
+        mockMvc.perform(get("/rooms/{code}", code))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.code").value(code))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void 존재하지_않는_코드로_조회하면_404() throws Exception {
+        mockMvc.perform(get("/rooms/{code}", "23456789"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("ROOM_NOT_FOUND"));
+    }
+
+    @Test
+    void 형식이_잘못된_코드로_조회하면_400() throws Exception {
+        mockMvc.perform(get("/rooms/{code}", "invalid-code"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_ROOM_CODE"));
+    }
+}


### PR DESCRIPTION
## 작업 내용
`POST /rooms` → `GET /rooms/{code}`를 관통시켜, #14에서 정리한 계층 구조(domain/application/infrastructure/presentation)가 실제로 맞물려 도는지 확인했다. 이후 다른 API 구현이 따라갈 기준 예시(응답 포맷, 예외 처리, 포트-어댑터 배선)를 여기서 만들었다.

## 관련 이슈
Closes #17

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] `RoomCode` 값 객체 (8자리, 혼동 문자 0/1/I/O 제외) + 단위 테스트
- [x] `Room` 애그리거트, `RoomStatus`(이 단계는 ACTIVE만, 전체 상태 전이는 #24)
- [x] Flyway `V1__create_room.sql` (첫 실제 마이그레이션)
- [x] `RoomRepository` 포트 + `RoomRepositoryAdapter`(JPA) 구현
- [x] `CreateRoomService`, `GetRoomService`
- [x] `RoomController` (`POST /rooms`, `GET /rooms/{code}`)
- [x] `ApiResponse`/`ErrorResponse`/`GlobalExceptionHandler` — 이후 API가 따라갈 공통 응답 규약 (404: ROOM_NOT_FOUND, 400: INVALID_ROOM_CODE)
- [x] Testcontainers 기반 통합 테스트 (`ddl-auto=validate`로 Flyway 스키마-엔티티 매핑까지 검증)

## 테스트
- [x] `RoomCodeTest` — 순수 JUnit, DB 없이 형식/생성 규칙 검증
- [x] `RoomApiTest` — 실제 PostgreSQL(Testcontainers)에서 생성→조회, 404, 400 케이스 검증
- [x] `./gradlew build` CI와 동일 조건(`SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop` 등)으로 로컬에서 전체 통과 확인

## 리뷰 요청 사항
- CI의 `SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop`은 Flyway와 충돌하지 않습니다 (로컬에서 확인). 다만 이 설정에서는 Flyway 스키마 검증이 무의미해지므로, `RoomApiTest`에서 `ddl-auto=validate`를 따로 강제해 검증했습니다. CI 설정은 그대로 뒀습니다.
- `Room`/`RoomRepository`/응답 포맷은 버리는 코드가 아니라, 이후 도메인 확장([#24](https://github.com/woowacourse-teams/2026-sssOK/issues/24))과 API 구현이 그대로 이어받아 씁니다.

### 시간 타입: `Instant` vs `LocalDateTime`
`createdAt`을 `Instant`(DB는 `TIMESTAMPTZ`)로 정했습니다. 고민했던 지점:
- `Instant`는 시간대 정보 없이 전 세계 어디서든 같은 "그 순간"을 가리켜서, 비교·계산이 항상 안전합니다.
- `LocalDateTime`(DB `TIMESTAMP`)은 "벽시계 숫자"만 저장해서, 그 값을 해석하는 모든 구성요소(앱 JVM, DB 세션, 배포 서버)가 같은 시간대를 쓴다고 약속해야만 안전합니다.
- 지금 배포 구조가 Docker 컨테이너(JVM `-Duser.timezone=Asia/Seoul` 명시 설정), PostgreSQL 세션, EC2, 로컬 개발 환경 이렇게 시간대가 섞일 지점이 여러 곳이라, `Instant`로 가는 게 안전하다고 판단했습니다.
- `createdAt`/`expiresAt`/`deletedAt`처럼 서버가 자동으로 찍고 나중에 "지금"과 비교·계산하는 값은 전부 `Instant`로 통일할 예정입니다. 반대로 "매주 화요일 오후 3시" 같은, 시간대와 무관하게 벽시계 값 자체가 의미인 필드가 나중에 생기면 그때는 `LocalDateTime`이 더 맞을 수 있습니다 — 지금 도메인에는 그런 필드가 없어서 일단 전부 `Instant`로 갑니다.

### `RoomRepository` 포트/어댑터 구조

```
RoomRepository        ← 순수 인터페이스, 어노테이션 없음 (application 계층의 계약)
    ↑ 구현
RoomRepositoryAdapter  ← @Component, RoomJpaRepository를 멤버로 보유
    ↓ 위임
RoomJpaRepository      ← JpaRepository만 상속, 본문·어노테이션 없음
```

- `CreateRoomService`/`GetRoomService`는 `RoomRepository`만 알 뿐, 저장 방식(JPA 등)은 모릅니다.
- `RoomJpaRepository`는 구현부가 없는데도 동작합니다. Spring Data JPA가 기동 시 `JpaRepository` 상속 인터페이스를 찾아 런타임에 프록시로 자동 구현해주기 때문입니다. `findByCode`처럼 이름만 선언한 메서드도 이름을 파싱해서(`findBy` + `Code`) 쿼리를 자동 생성합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 방을 생성하고 생성된 방 코드를 확인할 수 있습니다.
  * 방 코드로 방 정보, 상태, 생성 시각을 조회할 수 있습니다.
  * 유효한 8자리 방 코드가 생성되며 혼동하기 쉬운 문자는 제외됩니다.
  * PostgreSQL 기반 방 정보 저장 기능이 추가되었습니다.

* **버그 수정**
  * 존재하지 않는 방 조회 시 404 오류를 제공합니다.
  * 잘못된 방 코드 입력 시 400 오류와 안내 메시지를 제공합니다.

* **테스트**
  * 방 생성·조회 및 오류 응답에 대한 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

