### PR TITLE
feat: Room·Folder 도메인 모델링 (담당 A)

### DIFF
--- a/backend/src/main/java/com/sssok/application/port/out/RoomPermissionPort.java
+++ b/backend/src/main/java/com/sssok/application/port/out/RoomPermissionPort.java
@@ -1,0 +1,16 @@
+package com.sssok.application.port.out;
+
+// Room 컨텍스트(담당 A)가 Member/File 컨텍스트(담당 B)에 노출하는 조회 전용 포트.
+// B는 이 인터페이스에만 의존하고, Room 내부 구현은 몰라도 된다.
+// 구현체는 이 이슈 범위가 아니며, RoomRepository를 사용해 이후에 채운다.
+public interface RoomPermissionPort {
+
+    boolean isHost(Long roomId, Long memberId);
+
+    boolean canUpload(Long roomId, Long memberId);
+
+    boolean isRoomUsable(Long roomId);
+
+    // zip 다운로드 파일명(ShareDrop_방코드.zip)에 쓰인다.
+    String getRoomCode(Long roomId);
+}

--- a/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
@@ -3,6 +3,7 @@ package com.sssok.application.room;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomName;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.random.RandomGenerator;
@@ -17,9 +18,12 @@ public class CreateRoomService {
     private final RoomRepository roomRepository;
     private final RandomGenerator randomGenerator = new SecureRandom();
 
-    public Room create() {
+    public Room create(String name) {
         RoomCode code = RoomCode.generate(randomGenerator);
-        Room room = Room.create(code, Instant.now());
+        // TODO: 실제 방장 식별자는 입장/인증(JWT) 흐름이 붙으면 그걸로 대체한다.
+        // 아직 인증 체계가 없어, 방 생성 시점에 임시로 새 식별자를 발급해 방장으로 지정한다.
+        Long hostId = randomGenerator.nextLong(1L, Long.MAX_VALUE);
+        Room room = Room.create(code, new RoomName(name), hostId, Instant.now());
         return roomRepository.save(room);
     }
 }

--- a/backend/src/main/java/com/sssok/application/room/GetRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/GetRoomService.java
@@ -1,5 +1,6 @@
 package com.sssok.application.room;
 
+import com.sssok.application.room.exception.RoomNotFoundException;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;

--- a/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
@@ -1,4 +1,4 @@
-package com.sssok.application.room;
+package com.sssok.application.room.exception;
 
 import com.sssok.domain.room.RoomCode;
 

--- a/backend/src/main/java/com/sssok/domain/folder/Folder.java
+++ b/backend/src/main/java/com/sssok/domain/folder/Folder.java
@@ -1,5 +1,36 @@
 package com.sssok.domain.folder;
 
-// 방 안에서 파일을 묶는 폴더.
+import lombok.Getter;
+
+// 방 안에서 파일을 묶는 폴더. 지금 요구사항은 폴더 안에 폴더가 없는 1depth 구조라,
+// 재귀 구조 없이 "존재한다는 사실"과 "이름"만 책임진다.
+// Room과는 서로 다른 애그리거트이며 roomId(ID)로만 참조한다.
+@Getter
 public class Folder {
+
+    private final Long id;
+    private final Long roomId;
+    private FolderName name;
+
+    private Folder(Long id, Long roomId, FolderName name) {
+        this.id = id;
+        this.roomId = roomId;
+        this.name = name;
+    }
+
+    public static Folder create(Long roomId, FolderName name) {
+        return new Folder(null, roomId, name);
+    }
+
+    public static Folder reconstruct(Long id, Long roomId, FolderName name) {
+        return new Folder(id, roomId, name);
+    }
+
+    public void rename(FolderName newName) {
+        this.name = newName;
+    }
+
+    public boolean belongsTo(Long roomId) {
+        return this.roomId.equals(roomId);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/folder/FolderName.java
+++ b/backend/src/main/java/com/sssok/domain/folder/FolderName.java
@@ -1,5 +1,17 @@
 package com.sssok.domain.folder;
 
+import com.sssok.domain.folder.exception.InvalidFolderNameException;
 // 폴더 이름 값 객체.
-public class FolderName {
+public record FolderName(String value) {
+
+    private static final int MAX_LENGTH = 20;
+
+    public FolderName {
+        if (value == null || value.isBlank()) {
+            throw new InvalidFolderNameException(value);
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new InvalidFolderNameException(value);
+        }
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/folder/exception/InvalidFolderNameException.java
+++ b/backend/src/main/java/com/sssok/domain/folder/exception/InvalidFolderNameException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.folder.exception;
+
+public class InvalidFolderNameException extends RuntimeException {
+
+    public InvalidFolderNameException(String value) {
+        super("올바르지 않은 폴더 이름입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/Expiration.java
+++ b/backend/src/main/java/com/sssok/domain/room/Expiration.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.room;
-
-// 방 만료 시각을 담는 값 객체.
-public class Expiration {
-}

--- a/backend/src/main/java/com/sssok/domain/room/Room.java
+++ b/backend/src/main/java/com/sssok/domain/room/Room.java
@@ -1,32 +1,116 @@
 package com.sssok.domain.room;
 
+import com.sssok.domain.room.exception.RoomHostRequiredException;
+import java.time.Duration;
 import java.time.Instant;
+
+import com.sssok.domain.room.roomstatus.RoomStatus;
 import lombok.Getter;
 
 // 방 애그리거트 루트. 코드, 상태, 만료, 업로드 권한을 관리한다.
-// 이 단계(#17)에서는 생성/조회에 필요한 최소 형태만 다루고, 나머지 규칙은 #24에서 확장한다.
 @Getter
 public class Room {
 
+    private static final Duration RETENTION_AFTER_DELETE = Duration.ofDays(30);
+
     private final Long id;
     private final RoomCode code;
-    private final RoomStatus status;
+    private RoomName name;
+    private RoomStatus status;
+    private RoomExpiration expiration;
+    private UploadPolicy uploadPolicy;
+    private final Long hostId;
     private final Instant createdAt;
+    private Instant deletedAt;
 
-    private Room(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
+    private Room(
+        Long id,
+        RoomCode code,
+        RoomName name,
+        RoomStatus status,
+        RoomExpiration expiration,
+        UploadPolicy uploadPolicy,
+        Long hostId,
+        Instant createdAt,
+        Instant deletedAt
+    ) {
         this.id = id;
         this.code = code;
+        this.name = name;
         this.status = status;
+        this.expiration = expiration;
+        this.uploadPolicy = uploadPolicy;
+        this.hostId = hostId;
         this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
     }
 
-    // 신규 생성 (아직 저장 전이라 id 없음)
-    public static Room create(RoomCode code, Instant now) {
-        return new Room(null, code, RoomStatus.ACTIVE, now);
+    // 신규 생성. 만료 시간은 생성 시점에 24시간 뒤로 고정하고, 업로드 권한은 ANYONE으로 시작한다.
+    // (방장이 이후 설정 변경으로 만료 시간을 늘릴 수 있는 여지는 updateSettings 에 남겨둔다.)
+    public static Room create(RoomCode code, RoomName name, Long hostId, Instant now) {
+        return new Room(null, code, name, RoomStatus.initial(),
+            RoomExpiration.defaultFrom(now), UploadPolicy.ANYONE, hostId, now, null);
     }
 
     // 저장소에서 불러온 값으로 복원
-    public static Room reconstruct(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
-        return new Room(id, code, status, createdAt);
+    public static Room reconstruct(
+        Long id,
+        RoomCode code,
+        RoomName name,
+        RoomStatus status,
+        RoomExpiration expiration,
+        UploadPolicy uploadPolicy,
+        Long hostId,
+        Instant createdAt,
+        Instant deletedAt
+    ) {
+        return new Room(id, code, name, status, expiration, uploadPolicy, hostId, createdAt, deletedAt);
+    }
+
+    public boolean isHost(Long memberId) {
+        return hostId.equals(memberId);
+    }
+
+    // 상태(ACTIVE)뿐 아니라 실제 만료 시각도 함께 본다 — 만료 배치가 아직
+    // 상태를 EXPIRED로 못 바꿨어도, 만료 시각이 지났으면 즉시 입장을 막는다.
+    public boolean canEnter(Instant now) {
+        return status.canEnter() && !expiration.isExpired(now);
+    }
+
+    public boolean canUpload(Long requester, Instant now) {
+        return canEnter(now) && status.canUpload(uploadPolicy, isHost(requester));
+    }
+
+    public void updateSettings(Long requester, RoomName newName, RoomExpiration newExpiration, UploadPolicy newUploadPolicy) {
+        requireHost(requester);
+        this.name = newName;
+        this.expiration = newExpiration;
+        this.uploadPolicy = newUploadPolicy;
+    }
+
+    public void delete(Long requester, Instant now) {
+        requireHost(requester);
+        this.status = status.toDeleted();
+        this.deletedAt = now;
+    }
+
+    // 만료 배치가 호출 — 만료 시각이 지난 ACTIVE 방을 EXPIRED로 전이시킨다.
+    public void expire() {
+        this.status = status.toExpired();
+    }
+
+    // 정리 배치가 호출 — 30일 지난 DELETED 방만 영구 삭제 대상.
+    public void purge() {
+        this.status = status.toPurged();
+    }
+
+    public boolean isPurgeable(Instant now) {
+        return deletedAt != null && !now.isBefore(deletedAt.plus(RETENTION_AFTER_DELETE));
+    }
+
+    private void requireHost(Long requester) {
+        if (!isHost(requester)) {
+            throw new RoomHostRequiredException();
+        }
     }
 }

--- a/backend/src/main/java/com/sssok/domain/room/RoomCode.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomCode.java
@@ -1,5 +1,6 @@
 package com.sssok.domain.room;
 
+import com.sssok.domain.room.exception.InvalidRoomCodeException;
 import java.util.random.RandomGenerator;
 
 // 방 참여에 쓰이는 8자리 코드 값 객체.

--- a/backend/src/main/java/com/sssok/domain/room/RoomExpiration.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomExpiration.java
@@ -1,0 +1,27 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomExpirationException;
+import java.time.Duration;
+import java.time.Instant;
+
+// 방 만료 시각을 담는 값 객체.
+// 기획상 만료 시간은 생성 시 24시간으로 고정되지만, 방장이 설정 변경으로 늘릴 수 있는 여지를 둔다.
+public record RoomExpiration(Instant expiresAt) {
+
+    private static final Duration DEFAULT_DURATION = Duration.ofHours(24);
+
+    public RoomExpiration {
+        if (expiresAt == null) {
+            throw new InvalidRoomExpirationException(null);
+        }
+    }
+
+    // 방 생성 시 기본 만료 시각 (지금부터 24시간 뒤)
+    public static RoomExpiration defaultFrom(Instant now) {
+        return new RoomExpiration(now.plus(DEFAULT_DURATION));
+    }
+
+    public boolean isExpired(Instant now) {
+        return !now.isBefore(expiresAt);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/RoomName.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomName.java
@@ -1,0 +1,17 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomNameException;
+// 방 이름 값 객체.
+public record RoomName(String value) {
+
+    private static final int MAX_LENGTH = 30;
+
+    public RoomName {
+        if (value == null || value.isBlank()) {
+            throw new InvalidRoomNameException(value);
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new InvalidRoomNameException(value);
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/RoomPermissionPolicy.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomPermissionPolicy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.room;
+
+import java.time.Instant;
+
+// 방 설정 변경/삭제/업로드 권한 판정을 한곳에 모은 정책 객체.
+// 전부 Room.hostId 비교로 판별되므로 Member 객체를 몰라도 된다.
+public class RoomPermissionPolicy {
+
+    public boolean canChangeSettings(Room room, Long requesterId) {
+        return room.isHost(requesterId);
+    }
+
+    public boolean canDeleteRoom(Room room, Long requesterId) {
+        return room.isHost(requesterId);
+    }
+
+    public boolean canUploadTo(Room room, Long requesterId, Instant now) {
+        return room.canUpload(requesterId, now);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
@@ -1,7 +1,0 @@
-package com.sssok.domain.room;
-
-// 방의 생명주기 상태(활성/만료/삭제/영구삭제).
-// 이 단계(#17)에서는 생성 직후 상태만 다루고, 전체 전이 규칙은 #24에서 확장한다.
-public enum RoomStatus {
-    ACTIVE
-}

--- a/backend/src/main/java/com/sssok/domain/room/UploadPermission.java
+++ b/backend/src/main/java/com/sssok/domain/room/UploadPermission.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.room;
-
-// 방에서 누가 파일을 올릴 수 있는지 나타내는 권한.
-public enum UploadPermission {
-}

--- a/backend/src/main/java/com/sssok/domain/room/UploadPolicy.java
+++ b/backend/src/main/java/com/sssok/domain/room/UploadPolicy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.room;
+
+// 방에서 누가 파일을 올릴 수 있는지 나타내는 권한.
+public enum UploadPolicy {
+
+    ANYONE {
+        @Override
+        public boolean allows(boolean requesterIsHost) {
+            return true;
+        }
+    },
+    HOST_ONLY {
+        @Override
+        public boolean allows(boolean requesterIsHost) {
+            return requesterIsHost;
+        }
+    };
+
+    public abstract boolean allows(boolean requesterIsHost);
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/IllegalRoomStatusTransitionException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/IllegalRoomStatusTransitionException.java
@@ -1,0 +1,10 @@
+package com.sssok.domain.room.exception;
+
+import com.sssok.domain.room.roomstatus.RoomStatus;
+
+public class IllegalRoomStatusTransitionException extends RuntimeException {
+
+    public IllegalRoomStatusTransitionException(RoomStatus from, String to) {
+        super("허용되지 않는 상태 전이입니다: " + from.name() + " -> " + to);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomCodeException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomCodeException.java
@@ -1,4 +1,4 @@
-package com.sssok.domain.room;
+package com.sssok.domain.room.exception;
 
 public class InvalidRoomCodeException extends RuntimeException {
 

--- a/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomExpirationException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomExpirationException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room.exception;
+
+public class InvalidRoomExpirationException extends RuntimeException {
+
+    public InvalidRoomExpirationException(Object value) {
+        super("올바르지 않은 방 만료 시각입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomNameException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomNameException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room.exception;
+
+public class InvalidRoomNameException extends RuntimeException {
+
+    public InvalidRoomNameException(String value) {
+        super("올바르지 않은 방 이름입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/RoomHostRequiredException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/RoomHostRequiredException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room.exception;
+
+public class RoomHostRequiredException extends RuntimeException {
+
+    public RoomHostRequiredException() {
+        super("방장만 수행할 수 있는 작업입니다.");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/ActiveRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/ActiveRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 활성 상태 — 입장·업로드 가능, 만료·삭제로만 전이할 수 있다.
+public final class ActiveRoomStatus implements RoomStatus {
+
+    public static final ActiveRoomStatus INSTANCE = new ActiveRoomStatus();
+
+    private ActiveRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "ACTIVE";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return true;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return uploadPolicy.allows(requesterIsHost);
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        return ExpiredRoomStatus.INSTANCE;
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        return DeletedRoomStatus.INSTANCE;
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        throw new IllegalRoomStatusTransitionException(this, "PURGED");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/DeletedRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/DeletedRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 소프트 삭제 상태 — 30일 보관 기간 동안 머무는 상태. 영구 삭제로만 전이할 수 있다.
+public final class DeletedRoomStatus implements RoomStatus {
+
+    public static final DeletedRoomStatus INSTANCE = new DeletedRoomStatus();
+
+    private DeletedRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "DELETED";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return false;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return false;
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        throw new IllegalRoomStatusTransitionException(this, "EXPIRED");
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        throw new IllegalRoomStatusTransitionException(this, "DELETED");
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        return PurgedRoomStatus.INSTANCE;
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/ExpiredRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/ExpiredRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 만료 상태 — 입장·업로드 불가, 데이터는 아직 존재. 삭제로만 전이할 수 있다.
+public final class ExpiredRoomStatus implements RoomStatus {
+
+    public static final ExpiredRoomStatus INSTANCE = new ExpiredRoomStatus();
+
+    private ExpiredRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "EXPIRED";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return false;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return false;
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        throw new IllegalRoomStatusTransitionException(this, "EXPIRED");
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        return DeletedRoomStatus.INSTANCE;
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        throw new IllegalRoomStatusTransitionException(this, "PURGED");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/PurgedRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/PurgedRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 영구 삭제 완료 상태 — 종단 상태, 더 이상 전이할 수 없다.
+public final class PurgedRoomStatus implements RoomStatus {
+
+    public static final PurgedRoomStatus INSTANCE = new PurgedRoomStatus();
+
+    private PurgedRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "PURGED";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return false;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return false;
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        throw new IllegalRoomStatusTransitionException(this, "EXPIRED");
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        throw new IllegalRoomStatusTransitionException(this, "DELETED");
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        throw new IllegalRoomStatusTransitionException(this, "PURGED");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/RoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/RoomStatus.java
@@ -1,0 +1,35 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+
+// 방의 생명주기 상태 (GoF 상태 패턴).
+// 각 구현체는 자기가 허용하는 전이만 정의하고, 그 외의 전이를 시도하면 예외를 던진다.
+// 상태별 인스턴스는 하나씩만 존재한다 (싱글톤) — Room 여러 개가 같은 ACTIVE 상태 객체를 공유한다.
+public interface RoomStatus {
+
+    String name();
+
+    boolean canEnter();
+
+    boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost);
+
+    RoomStatus toExpired();
+
+    RoomStatus toDeleted();
+
+    RoomStatus toPurged();
+
+    static RoomStatus initial() {
+        return ActiveRoomStatus.INSTANCE;
+    }
+
+    static RoomStatus from(String name) {
+        return switch (name) {
+            case "ACTIVE" -> ActiveRoomStatus.INSTANCE;
+            case "EXPIRED" -> ExpiredRoomStatus.INSTANCE;
+            case "DELETED" -> DeletedRoomStatus.INSTANCE;
+            case "PURGED" -> PurgedRoomStatus.INSTANCE;
+            default -> throw new IllegalArgumentException("알 수 없는 방 상태입니다: " + name);
+        };
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
@@ -24,16 +24,46 @@ public class RoomJpaEntity {
     @Column(nullable = false, unique = true, length = 8)
     private String code;
 
+    @Column(nullable = false, length = 30)
+    private String name;
+
     @Column(nullable = false, length = 20)
     private String status;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "upload_policy", nullable = false, length = 20)
+    private String uploadPolicy;
+
+    @Column(name = "host_id", nullable = false)
+    private Long hostId;
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    public RoomJpaEntity(Long id, String code, String status, Instant createdAt) {
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    public RoomJpaEntity(
+        Long id,
+        String code,
+        String name,
+        String status,
+        Instant expiresAt,
+        String uploadPolicy,
+        Long hostId,
+        Instant createdAt,
+        Instant deletedAt
+    ) {
         this.id = id;
         this.code = code;
+        this.name = name;
         this.status = status;
+        this.expiresAt = expiresAt;
+        this.uploadPolicy = uploadPolicy;
+        this.hostId = hostId;
         this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
@@ -3,7 +3,10 @@ package com.sssok.infrastructure.persistence.room;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
-import com.sssok.domain.room.RoomStatus;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import com.sssok.domain.room.UploadPolicy;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -29,8 +32,13 @@ public class RoomRepositoryAdapter implements RoomRepository {
         return new RoomJpaEntity(
             room.getId(),
             room.getCode().value(),
+            room.getName().value(),
             room.getStatus().name(),
-            room.getCreatedAt()
+            room.getExpiration().expiresAt(),
+            room.getUploadPolicy().name(),
+            room.getHostId(),
+            room.getCreatedAt(),
+            room.getDeletedAt()
         );
     }
 
@@ -38,8 +46,13 @@ public class RoomRepositoryAdapter implements RoomRepository {
         return Room.reconstruct(
             entity.getId(),
             new RoomCode(entity.getCode()),
-            RoomStatus.valueOf(entity.getStatus()),
-            entity.getCreatedAt()
+            new RoomName(entity.getName()),
+            RoomStatus.from(entity.getStatus()),
+            new RoomExpiration(entity.getExpiresAt()),
+            UploadPolicy.valueOf(entity.getUploadPolicy()),
+            entity.getHostId(),
+            entity.getCreatedAt(),
+            entity.getDeletedAt()
         );
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.sssok.presentation.api.common;
 
-import com.sssok.application.room.RoomNotFoundException;
-import com.sssok.domain.room.InvalidRoomCodeException;
+import com.sssok.domain.room.exception.InvalidRoomNameException;
+import com.sssok.application.room.exception.RoomNotFoundException;
+import com.sssok.domain.room.exception.InvalidRoomCodeException;
+import com.sssok.domain.room.exception.RoomHostRequiredException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,5 +22,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidRoomCode(InvalidRoomCodeException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse("INVALID_ROOM_CODE", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRoomNameException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRoomName(InvalidRoomNameException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("INVALID_ROOM_NAME", e.getMessage()));
+    }
+
+    @ExceptionHandler(RoomHostRequiredException.class)
+    public ResponseEntity<ErrorResponse> handleRoomHostRequired(RoomHostRequiredException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(new ErrorResponse("ROOM_HOST_REQUIRED", e.getMessage()));
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/room/CreateRoomRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/CreateRoomRequest.java
@@ -1,0 +1,5 @@
+package com.sssok.presentation.api.room;
+
+// 형식 검증(필수값 여부 등)은 RoomName 값 객체가 담당한다 (도메인 규칙을 한곳에 모아둠).
+public record CreateRoomRequest(String name) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,8 +24,8 @@ public class RoomController {
     private final GetRoomService getRoomService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<RoomResponse>> createRoom() {
-        Room room = createRoomService.create();
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom(@RequestBody CreateRoomRequest request) {
+        Room room = createRoomService.create(request.name());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(RoomResponse.from(room)));
     }

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
@@ -3,9 +3,14 @@ package com.sssok.presentation.api.room;
 import com.sssok.domain.room.Room;
 import java.time.Instant;
 
-public record RoomResponse(String code, String status, Instant createdAt) {
+public record RoomResponse(String code, String name, String status, Instant createdAt) {
 
     public static RoomResponse from(Room room) {
-        return new RoomResponse(room.getCode().value(), room.getStatus().name(), room.getCreatedAt());
+        return new RoomResponse(
+            room.getCode().value(),
+            room.getName().value(),
+            room.getStatus().name(),
+            room.getCreatedAt()
+        );
     }
 }

--- a/backend/src/main/resources/db/migration/V2__add_room_details.sql
+++ b/backend/src/main/resources/db/migration/V2__add_room_details.sql
@@ -1,0 +1,14 @@
+-- #24 Room 도메인 확장(이름/만료/업로드권한/방장/삭제시각)에 맞춰 컬럼을 추가한다.
+-- V1은 이미 적용된 마이그레이션이라 수정하지 않고 새 버전으로 쌓는다.
+ALTER TABLE room
+    ADD COLUMN name          VARCHAR(30)  NOT NULL DEFAULT '',
+    ADD COLUMN expires_at    TIMESTAMPTZ  NOT NULL DEFAULT (now() + interval '24 hours'),
+    ADD COLUMN upload_policy VARCHAR(20)  NOT NULL DEFAULT 'ANYONE',
+    ADD COLUMN host_id       BIGINT       NOT NULL DEFAULT 0,
+    ADD COLUMN deleted_at    TIMESTAMPTZ;
+
+-- 기본값은 기존 행을 채우기 위한 것일 뿐, 이후로는 애플리케이션이 항상 값을 채운다.
+ALTER TABLE room ALTER COLUMN name DROP DEFAULT;
+ALTER TABLE room ALTER COLUMN expires_at DROP DEFAULT;
+ALTER TABLE room ALTER COLUMN upload_policy DROP DEFAULT;
+ALTER TABLE room ALTER COLUMN host_id DROP DEFAULT;

--- a/backend/src/test/java/com/sssok/domain/folder/FolderNameTest.java
+++ b/backend/src/test/java/com/sssok/domain/folder/FolderNameTest.java
@@ -1,0 +1,36 @@
+package com.sssok.domain.folder;
+
+import com.sssok.domain.folder.exception.InvalidFolderNameException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FolderNameTest {
+
+    @Test
+    void 정상적인_이름은_생성된다() {
+        FolderName name = new FolderName("맛집");
+
+        assertThat(name.value()).isEqualTo("맛집");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void 빈_문자열이거나_공백뿐이면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new FolderName(invalidValue))
+            .isInstanceOf(InvalidFolderNameException.class);
+    }
+
+    @Test
+    void 최대_길이를_넘으면_예외() {
+        String tooLong = "가".repeat(21);
+
+        assertThatThrownBy(() -> new FolderName(tooLong))
+            .isInstanceOf(InvalidFolderNameException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/folder/FolderTest.java
+++ b/backend/src/test/java/com/sssok/domain/folder/FolderTest.java
@@ -1,0 +1,34 @@
+package com.sssok.domain.folder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FolderTest {
+
+    @Test
+    void 방_ID와_이름으로_생성된다() {
+        Folder folder = Folder.create(1L, new FolderName("맛집"));
+
+        assertThat(folder.getRoomId()).isEqualTo(1L);
+        assertThat(folder.getName().value()).isEqualTo("맛집");
+        assertThat(folder.getId()).isNull();
+    }
+
+    @Test
+    void 이름을_바꿀_수_있다() {
+        Folder folder = Folder.create(1L, new FolderName("맛집"));
+
+        folder.rename(new FolderName("카페"));
+
+        assertThat(folder.getName().value()).isEqualTo("카페");
+    }
+
+    @Test
+    void 자신이_속한_방인지_확인할_수_있다() {
+        Folder folder = Folder.reconstruct(10L, 1L, new FolderName("맛집"));
+
+        assertThat(folder.belongsTo(1L)).isTrue();
+        assertThat(folder.belongsTo(2L)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
@@ -1,5 +1,6 @@
 package com.sssok.domain.room;
 
+import com.sssok.domain.room.exception.InvalidRoomCodeException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/backend/src/test/java/com/sssok/domain/room/RoomExpirationTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomExpirationTest.java
@@ -1,0 +1,44 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomExpirationException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RoomExpirationTest {
+
+    @Test
+    void 기본_만료_시각은_생성_시점으로부터_24시간_뒤다() {
+        Instant now = Instant.parse("2026-08-13T00:00:00Z");
+
+        RoomExpiration expiration = RoomExpiration.defaultFrom(now);
+
+        assertThat(expiration.expiresAt()).isEqualTo(now.plus(Duration.ofHours(24)));
+    }
+
+    @Test
+    void 만료_시각_이전이면_만료가_아니다() {
+        Instant now = Instant.parse("2026-08-13T00:00:00Z");
+        RoomExpiration expiration = RoomExpiration.defaultFrom(now);
+
+        assertThat(expiration.isExpired(now.plus(Duration.ofHours(23)))).isFalse();
+    }
+
+    @Test
+    void 만료_시각과_같거나_지나면_만료다() {
+        Instant now = Instant.parse("2026-08-13T00:00:00Z");
+        RoomExpiration expiration = RoomExpiration.defaultFrom(now);
+
+        assertThat(expiration.isExpired(now.plus(Duration.ofHours(24)))).isTrue();
+        assertThat(expiration.isExpired(now.plus(Duration.ofHours(25)))).isTrue();
+    }
+
+    @Test
+    void 만료_시각이_null이면_예외() {
+        assertThatThrownBy(() -> new RoomExpiration(null))
+            .isInstanceOf(InvalidRoomExpirationException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomNameTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomNameTest.java
@@ -1,0 +1,43 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomNameException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RoomNameTest {
+
+    @Test
+    void 정상적인_이름은_생성된다() {
+        RoomName name = new RoomName("우테코 회식");
+
+        assertThat(name.value()).isEqualTo("우테코 회식");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void 빈_문자열이거나_공백뿐이면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new RoomName(invalidValue))
+            .isInstanceOf(InvalidRoomNameException.class);
+    }
+
+    @Test
+    void 최대_길이를_넘으면_예외() {
+        String tooLong = "가".repeat(31);
+
+        assertThatThrownBy(() -> new RoomName(tooLong))
+            .isInstanceOf(InvalidRoomNameException.class);
+    }
+
+    @Test
+    void 최대_길이까지는_허용된다() {
+        String exactly30 = "가".repeat(30);
+
+        assertThat(new RoomName(exactly30).value()).hasSize(30);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomPermissionPolicyTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomPermissionPolicyTest.java
@@ -1,0 +1,45 @@
+package com.sssok.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RoomPermissionPolicyTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T00:00:00Z");
+    private static final Long HOST = 1L;
+    private static final Long GUEST = 2L;
+
+    private final RoomPermissionPolicy policy = new RoomPermissionPolicy();
+
+    private Room createRoom() {
+        return Room.create(RoomCode.generate(new SecureRandom()), new RoomName("우테코 회식"), HOST, NOW);
+    }
+
+    @Test
+    void 설정_변경은_방장만_가능하다() {
+        Room room = createRoom();
+
+        assertThat(policy.canChangeSettings(room, HOST)).isTrue();
+        assertThat(policy.canChangeSettings(room, GUEST)).isFalse();
+    }
+
+    @Test
+    void 방_삭제는_방장만_가능하다() {
+        Room room = createRoom();
+
+        assertThat(policy.canDeleteRoom(room, HOST)).isTrue();
+        assertThat(policy.canDeleteRoom(room, GUEST)).isFalse();
+    }
+
+    @Test
+    void 업로드_권한은_Room의_규칙을_그대로_따른다() {
+        Room room = createRoom();
+        room.updateSettings(HOST, room.getName(), room.getExpiration(), UploadPolicy.HOST_ONLY);
+
+        assertThat(policy.canUploadTo(room, HOST, NOW)).isTrue();
+        assertThat(policy.canUploadTo(room, GUEST, NOW)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomStatusTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomStatusTest.java
@@ -1,0 +1,80 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.room.roomstatus.*;
+import org.junit.jupiter.api.Test;
+
+class RoomStatusTest {
+
+    @Test
+    void 초기_상태는_ACTIVE다() {
+        assertThat(RoomStatus.initial()).isSameAs(ActiveRoomStatus.INSTANCE);
+    }
+
+    @Test
+    void 같은_이름으로_찾은_상태는_항상_같은_인스턴스다_싱글톤() {
+        assertThat(RoomStatus.from("ACTIVE")).isSameAs(ActiveRoomStatus.INSTANCE);
+        assertThat(RoomStatus.from("ACTIVE")).isSameAs(RoomStatus.from("ACTIVE"));
+        assertThat(RoomStatus.from("EXPIRED")).isSameAs(ExpiredRoomStatus.INSTANCE);
+        assertThat(RoomStatus.from("DELETED")).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThat(RoomStatus.from("PURGED")).isSameAs(PurgedRoomStatus.INSTANCE);
+    }
+
+    @Test
+    void 알수없는_이름이면_예외() {
+        assertThatThrownBy(() -> RoomStatus.from("UNKNOWN"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void ACTIVE는_EXPIRED와_DELETED로만_전이할_수_있다() {
+        RoomStatus active = ActiveRoomStatus.INSTANCE;
+
+        assertThat(active.toExpired()).isSameAs(ExpiredRoomStatus.INSTANCE);
+        assertThat(active.toDeleted()).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThatThrownBy(active::toPurged).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void EXPIRED는_DELETED로만_전이할_수_있다() {
+        RoomStatus expired = ExpiredRoomStatus.INSTANCE;
+
+        assertThat(expired.toDeleted()).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThatThrownBy(expired::toExpired).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(expired::toPurged).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void DELETED는_PURGED로만_전이할_수_있다() {
+        RoomStatus deleted = DeletedRoomStatus.INSTANCE;
+
+        assertThat(deleted.toPurged()).isSameAs(PurgedRoomStatus.INSTANCE);
+        assertThatThrownBy(deleted::toExpired).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(deleted::toDeleted).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void PURGED는_종단_상태라_더_전이할_수_없다() {
+        RoomStatus purged = PurgedRoomStatus.INSTANCE;
+
+        assertThatThrownBy(purged::toExpired).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(purged::toDeleted).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(purged::toPurged).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void ACTIVE만_입장_및_업로드가_가능하다() {
+        assertThat(ActiveRoomStatus.INSTANCE.canEnter()).isTrue();
+        assertThat(ExpiredRoomStatus.INSTANCE.canEnter()).isFalse();
+        assertThat(DeletedRoomStatus.INSTANCE.canEnter()).isFalse();
+        assertThat(PurgedRoomStatus.INSTANCE.canEnter()).isFalse();
+
+        assertThat(ActiveRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isTrue();
+        assertThat(ExpiredRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isFalse();
+        assertThat(DeletedRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isFalse();
+        assertThat(PurgedRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomTest.java
@@ -1,0 +1,185 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.RoomHostRequiredException;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+
+import com.sssok.domain.room.roomstatus.ActiveRoomStatus;
+import com.sssok.domain.room.roomstatus.DeletedRoomStatus;
+import com.sssok.domain.room.roomstatus.ExpiredRoomStatus;
+import com.sssok.domain.room.roomstatus.PurgedRoomStatus;
+import org.junit.jupiter.api.Test;
+
+class RoomTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T00:00:00Z");
+    private static final Long HOST = 1L;
+    private static final Long GUEST = 2L;
+
+    private Room createRoom() {
+        RoomCode code = RoomCode.generate(new SecureRandom());
+        return Room.create(code, new RoomName("우테코 회식"), HOST, NOW);
+    }
+
+    @Test
+    void 생성_직후엔_ACTIVE_상태이고_만료_시간은_24시간_뒤이며_업로드_권한은_ANYONE이다() {
+        Room room = createRoom();
+
+        assertThat(room.getStatus()).isSameAs(ActiveRoomStatus.INSTANCE);
+        assertThat(room.getExpiration().expiresAt()).isEqualTo(NOW.plus(Duration.ofHours(24)));
+        assertThat(room.getUploadPolicy()).isEqualTo(UploadPolicy.ANYONE);
+    }
+
+    @Test
+    void 방장_여부를_판별할_수_있다() {
+        Room room = createRoom();
+
+        assertThat(room.isHost(HOST)).isTrue();
+        assertThat(room.isHost(GUEST)).isFalse();
+    }
+
+    @Test
+    void ACTIVE_상태이고_만료_전이면_입장할_수_있다() {
+        Room room = createRoom();
+
+        assertThat(room.canEnter(NOW.plus(Duration.ofHours(1)))).isTrue();
+    }
+
+    @Test
+    void 만료_시각이_지나면_상태_전이와_무관하게_입장할_수_없다() {
+        Room room = createRoom();
+
+        // 배치가 아직 expire()를 호출하지 않아 상태는 여전히 ACTIVE 이지만,
+        // 실제 만료 시각은 지난 상황을 가정한다.
+        boolean canEnterAfterExpiry = room.canEnter(NOW.plus(Duration.ofHours(25)));
+
+        assertThat(room.getStatus()).isSameAs(ActiveRoomStatus.INSTANCE);
+        assertThat(canEnterAfterExpiry).isFalse();
+    }
+
+    @Test
+    void ANYONE_방은_방장도_게스트도_업로드할_수_있다() {
+        Room room = createRoom();
+        Instant soon = NOW.plus(Duration.ofMinutes(1));
+
+        assertThat(room.canUpload(HOST, soon)).isTrue();
+        assertThat(room.canUpload(GUEST, soon)).isTrue();
+    }
+
+    @Test
+    void HOST_ONLY_방은_방장만_업로드할_수_있다() {
+        Room room = createRoom();
+        Instant soon = NOW.plus(Duration.ofMinutes(1));
+        room.updateSettings(HOST, room.getName(), room.getExpiration(), UploadPolicy.HOST_ONLY);
+
+        assertThat(room.canUpload(HOST, soon)).isTrue();
+        assertThat(room.canUpload(GUEST, soon)).isFalse();
+    }
+
+    @Test
+    void 만료된_방은_업로드_권한과_무관하게_업로드할_수_없다() {
+        Room room = createRoom();
+        Instant afterExpiry = NOW.plus(Duration.ofHours(25));
+
+        assertThat(room.canUpload(HOST, afterExpiry)).isFalse();
+    }
+
+    @Test
+    void 방장만_설정을_변경할_수_있다() {
+        Room room = createRoom();
+        RoomName newName = new RoomName("2차 회식");
+
+        room.updateSettings(HOST, newName, room.getExpiration(), UploadPolicy.HOST_ONLY);
+
+        assertThat(room.getName()).isEqualTo(newName);
+        assertThat(room.getUploadPolicy()).isEqualTo(UploadPolicy.HOST_ONLY);
+    }
+
+    @Test
+    void 방장이_아니면_설정을_변경할_수_없다() {
+        Room room = createRoom();
+
+        assertThatThrownBy(() ->
+            room.updateSettings(GUEST, room.getName(), room.getExpiration(), UploadPolicy.HOST_ONLY)
+        ).isInstanceOf(RoomHostRequiredException.class);
+    }
+
+    @Test
+    void 방장은_설정_변경으로_만료_시간을_늘릴_수_있다() {
+        Room room = createRoom();
+        RoomExpiration extended = new RoomExpiration(NOW.plus(Duration.ofHours(48)));
+
+        room.updateSettings(HOST, room.getName(), extended, room.getUploadPolicy());
+
+        assertThat(room.getExpiration()).isEqualTo(extended);
+    }
+
+    @Test
+    void 방장만_방을_삭제할_수_있다() {
+        Room room = createRoom();
+
+        assertThatThrownBy(() -> room.delete(GUEST, NOW))
+            .isInstanceOf(RoomHostRequiredException.class);
+    }
+
+    @Test
+    void 방을_삭제하면_즉시_입장할_수_없고_DELETED_상태가_된다() {
+        Room room = createRoom();
+
+        room.delete(HOST, NOW.plus(Duration.ofMinutes(10)));
+
+        assertThat(room.getStatus()).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThat(room.canEnter(NOW.plus(Duration.ofMinutes(11)))).isFalse();
+    }
+
+    @Test
+    void 삭제_후_30일이_지나지_않으면_퍼지_대상이_아니다() {
+        Room room = createRoom();
+        Instant deletedAt = NOW;
+        room.delete(HOST, deletedAt);
+
+        assertThat(room.isPurgeable(deletedAt.plus(Duration.ofDays(29)))).isFalse();
+    }
+
+    @Test
+    void 삭제_후_30일이_지나면_퍼지_대상이다() {
+        Room room = createRoom();
+        Instant deletedAt = NOW;
+        room.delete(HOST, deletedAt);
+
+        assertThat(room.isPurgeable(deletedAt.plus(Duration.ofDays(30)))).isTrue();
+    }
+
+    @Test
+    void 삭제되지_않은_방은_퍼지_대상이_아니다() {
+        Room room = createRoom();
+
+        assertThat(room.isPurgeable(NOW.plus(Duration.ofDays(365)))).isFalse();
+    }
+
+    @Test
+    void expire_호출하면_EXPIRED_상태로_전이한다() {
+        Room room = createRoom();
+
+        room.expire();
+
+        assertThat(room.getStatus()).isSameAs(ExpiredRoomStatus.INSTANCE);
+    }
+
+    @Test
+    void purge는_DELETED_상태에서만_가능하다() {
+        Room room = createRoom();
+
+        assertThatThrownBy(room::purge).isInstanceOf(IllegalRoomStatusTransitionException.class);
+
+        room.delete(HOST, NOW);
+        room.purge();
+
+        assertThat(room.getStatus()).isSameAs(PurgedRoomStatus.INSTANCE);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/UploadPolicyTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/UploadPolicyTest.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UploadPolicyTest {
+
+    @Test
+    void ANYONE은_누구나_업로드할_수_있다() {
+        assertThat(UploadPolicy.ANYONE.allows(true)).isTrue();
+        assertThat(UploadPolicy.ANYONE.allows(false)).isTrue();
+    }
+
+    @Test
+    void HOST_ONLY는_방장만_업로드할_수_있다() {
+        assertThat(UploadPolicy.HOST_ONLY.allows(true)).isTrue();
+        assertThat(UploadPolicy.HOST_ONLY.allows(false)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -39,9 +40,12 @@ class RoomApiTest {
 
     @Test
     void 방을_생성하고_코드로_조회한다() throws Exception {
-        MvcResult createResult = mockMvc.perform(post("/rooms"))
+        MvcResult createResult = mockMvc.perform(post("/rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"우테코 회식\"}"))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.code").value(matchesPattern("[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{8}")))
+            .andExpect(jsonPath("$.data.name").value("우테코 회식"))
             .andExpect(jsonPath("$.data.status").value("ACTIVE"))
             .andReturn();
 
@@ -51,7 +55,17 @@ class RoomApiTest {
         mockMvc.perform(get("/rooms/{code}", code))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.code").value(code))
+            .andExpect(jsonPath("$.data.name").value("우테코 회식"))
             .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void 이름_없이_생성하면_400() throws Exception {
+        mockMvc.perform(post("/rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_ROOM_NAME"));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
Room·Folder 컨텍스트(공간 구조)의 도메인 모델을 설계·구현했다. `Room`의 생명주기 상태는 GoF 상태 패턴(싱글톤)으로 구현했다.

## 관련 이슈
Closes #24

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항

### RoomStatus — 상태 패턴(싱글톤)
- `RoomStatus`(인터페이스) + `ActiveRoomStatus`/`ExpiredRoomStatus`/`DeletedRoomStatus`/`PurgedRoomStatus` 싱글톤 구현체 (`domain/room/roomstatus`)
- 각 상태가 자신이 허용하는 전이만 정의하고, 그 외 전이는 `IllegalRoomStatusTransitionException`
- 싱글톤 보장(`isSameAs`)과 전이 규칙을 `RoomStatusTest`로 검증

### 값 객체
- `RoomName`
- `RoomExpiration`(기본 24시간)
- `UploadPolicy`(ANYONE/HOST_ONLY, enum + 추상 메서드로 규칙 내장)
- 기존 스텁(`Expiration`, `UploadPermission`)을 이슈 명세 이름으로 재작성

### Room 애그리거트
- `isHost`
- `canEnter(now)`
- `canUpload(requester, now)`
- `updateSettings`(방장만)
- `delete`(방장만)
- `expire`
- `purge`
- `isPurgeable`
- `canEnter`/`canUpload`는 상태뿐 아니라 실제 만료 시각도 함께 확인한다. 만료 배치가 아직 `EXPIRED`로 못 바꿨어도 `expiresAt`이 지났으면 즉시 차단

### Folder 애그리거트
- `roomId`로만 참조하는 독립된 애그리거트 (1depth라 계층 구조 없음)
- 생성/이름변경/`belongsTo`

### RoomPermissionPolicy / RoomPermissionPort
- `RoomPermissionPolicy`: 설정변경/삭제/업로드 권한 판정을 한곳에 모은 정책 객체
- `RoomPermissionPort`: 이슈 명시대로 인터페이스만 (B가 이후 이슈에서 씀)

### 예외 클래스 정리
- 도메인/애플리케이션 패키지마다 예외 클래스가 하나씩 늘어나 `exception/` 서브패키지로 모음 (`domain/room/exception`, `domain/folder/exception`, `application/room/exception`)
- #17에서 만든 `InvalidRoomCodeException`, `RoomNotFoundException`도 함께 정리
- `GlobalExceptionHandler`에 `InvalidRoomNameException`(400), `RoomHostRequiredException`(403) 처리 추가

### #17 인프라 호환 업데이트
`Room`이 이름/방장을 필수로 요구하게 되면서, 이미 병합된 #17의 API/영속화 코드도 같이 업데이트했다 (도메인만으로는 컴파일이 안 깨지게 유지할 수 없어서).
- `room` 테이블에 `name`/`host_id`/`expires_at`/`upload_policy`/`deleted_at` 컬럼 추가 (V2 — V1은 이미 적용된 마이그레이션이라 수정하지 않음)
- `RoomJpaEntity`/`RoomRepositoryAdapter`를 확장된 `Room`에 맞춰 매핑
- `POST /rooms` 요청에 `name` 필수화 (`CreateRoomRequest`)
- `CreateRoomService`: 아직 인증 흐름이 없어 방 생성 시 임시 방장 식별자를 발급 (`TODO` 표시, 입장/인증 API가 붙으면 대체)

## 도메인 관계도

```mermaid
classDiagram
    direction LR

    class Room {
        <<Aggregate Root>>
        Long hostId
        RoomStatus status
        UploadPolicy uploadPolicy
    }

    class RoomStatus {
        <<interface, 상태 패턴>>
    }
    class ActiveRoomStatus { <<singleton>> }
    class ExpiredRoomStatus { <<singleton>> }
    class DeletedRoomStatus { <<singleton>> }
    class PurgedRoomStatus { <<singleton>> }

    class UploadPolicy {
        <<enum>>
        ANYONE
        HOST_ONLY
    }

    class Folder {
        <<Aggregate>>
        Long roomId
    }

    class RoomPermissionPolicy {
        <<Policy Object>>
    }

    class RoomPermissionPort {
        <<Port, 인터페이스만>>
    }

    class Member {
        <<#25 담당 B, 아직 스텁>>
    }

    RoomStatus <|.. ActiveRoomStatus
    RoomStatus <|.. ExpiredRoomStatus
    RoomStatus <|.. DeletedRoomStatus
    RoomStatus <|.. PurgedRoomStatus

    Room *-- RoomStatus
    Room *-- UploadPolicy
    Room ..> Member : hostId (ID만 참조, 객체 참조 아님)
    Folder ..> Room : roomId (ID만 참조, 객체 참조 아님)
    RoomPermissionPolicy --> Room : 판정 위임
    RoomPermissionPort ..> RoomPermissionPolicy : 나중에 구현체가 사용
```

<img width="2160" height="1400" alt="image" src="https://github.com/user-attachments/assets/55d03dd3-4fd1-4c18-baf3-08f1151013ad" />



**읽는 법**
- `Room`과 `Folder`는 서로 다른 애그리거트라 객체 참조가 아니라 ID(`roomId`)로만 연결된다.
- `hostId`도 마찬가지로 `Member`를 ID로만 참조한다 — `Member`는 #25(담당 B)가 만들 예정이라 아직 스텁이고, 이번 PR에서 타입을 미리 정의하지 않았다 (자세한 이유는 리뷰 요청 사항 참고).
- `RoomStatus`는 실선 다이아몬드(컴포지션)로 `Room`에 속해 있고, 그 아래 4개 구현체는 전부 싱글톤이다.
- `RoomPermissionPort`는 점선(의존)으로만 이어져 있다 — 인터페이스만 정의했고 구현체는 이 PR 범위가 아니다.

## 테스트
- 도메인 전부 `@SpringBootTest` 없이 순수 JUnit (`RoomStatusTest`, `RoomNameTest`, `RoomExpirationTest`, `UploadPolicyTest`, `RoomTest`, `FolderTest`, `FolderNameTest`, `RoomPermissionPolicyTest`)
- `RoomApiTest`(Testcontainers): 이름 없이 생성 시 400 케이스 추가, 기존 케이스도 갱신된 응답 포맷에 맞춰 수정
- `./gradlew build` 로컬 전체 통과 확인

## 리뷰 요청 사항

### canEnter()가 상태와 별개로 만료 시각도 직접 확인한다.

상태 패턴만으로는 "타이머가 0이 됐는데 배치가 안 돌아서 여전히 입장된다"는 틈이 생길 수 있어서입니다, 배치가 아직 `EXPIRED`로 못 바꿨어도 `expiresAt`이 지났으면 즉시 입장을 막도록 했음.

### CreateRoomService가 임시 방장 ID를 무작위로 발급합니다
`Room`이 이제 `hostId`를 필수로 요구하는데, 아직 로그인/입장 인증 흐름이 없어서 방 생성 시점에 임시 식별자를 만들어 방장으로 지정했습니다. 코드에 `TODO`로 표시해뒀고, 나중에 실제 입장 API가 붙으면 그걸로 대체해야 함.

