### PR TITLE
feat: Member·StoredFile 도메인 모델링 (담당 B)

### DIFF
--- a/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
@@ -10,4 +10,6 @@ public interface RoomRepository {
     Room save(Room room);
 
     Optional<Room> findByCode(RoomCode code);
+
+    Optional<Room> findById(Long id);
 }

--- a/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
@@ -7,4 +7,8 @@ public class RoomNotFoundException extends RuntimeException {
     public RoomNotFoundException(RoomCode code) {
         super("존재하지 않는 방입니다: " + code.value());
     }
+
+    public RoomNotFoundException(Long roomId) {
+        super("존재하지 않는 방입니다: " + roomId);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/DownloadFileNames.java
+++ b/backend/src/main/java/com/sssok/domain/file/DownloadFileNames.java
@@ -1,0 +1,55 @@
+package com.sssok.domain.file;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class DownloadFileNames {
+
+    private static final String ZIP_NAME_FORMAT = "ShareDrop_%s.zip";
+
+    private DownloadFileNames() {
+    }
+
+    public static String zipNameOf(String roomCode) {
+        return ZIP_NAME_FORMAT.formatted(roomCode);
+    }
+
+    public static List<String> deduplicate(List<String> fileNames) {
+        Map<String, Integer> usedCounts = new HashMap<>();
+        List<String> result = new ArrayList<>(fileNames.size());
+
+        for (String fileName : fileNames) {
+            result.add(nextAvailableName(fileName, usedCounts));
+        }
+        return result;
+    }
+
+    private static String nextAvailableName(String fileName, Map<String, Integer> usedCounts) {
+        if (!usedCounts.containsKey(fileName)) {
+            usedCounts.put(fileName, 0);
+            return fileName;
+        }
+
+        int sequence = usedCounts.get(fileName);
+        String candidate;
+        do {
+            sequence++;
+            candidate = numbered(fileName, sequence);
+        } while (usedCounts.containsKey(candidate));
+
+        usedCounts.put(fileName, sequence);
+        usedCounts.put(candidate, 0);
+        return candidate;
+    }
+
+    private static String numbered(String fileName, int sequence) {
+        int extensionIndex = fileName.lastIndexOf('.');
+        if (extensionIndex <= 0) {
+            return "%s (%d)".formatted(fileName, sequence);
+        }
+        return "%s (%d)%s".formatted(
+                fileName.substring(0, extensionIndex), sequence, fileName.substring(extensionIndex));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/FilePermissionPolicy.java
+++ b/backend/src/main/java/com/sssok/domain/file/FilePermissionPolicy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.file;
+
+import java.util.List;
+
+public final class FilePermissionPolicy {
+
+    private FilePermissionPolicy() {
+    }
+
+    public static boolean canDelete(StoredFile file, Long requesterId, boolean requesterIsHost) {
+        return requesterIsHost || file.isUploadedBy(requesterId);
+    }
+
+    public static List<StoredFile> filterDeletable(List<StoredFile> files, Long requesterId,
+                                                   boolean requesterIsHost) {
+        return files.stream()
+                .filter(file -> canDelete(file, requesterId, requesterIsHost))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/FileSize.java
+++ b/backend/src/main/java/com/sssok/domain/file/FileSize.java
@@ -1,5 +1,30 @@
 package com.sssok.domain.file;
 
-// 파일 크기 값 객체. 종류별 업로드 상한을 검증한다.
-public class FileSize {
+import com.sssok.domain.file.exception.InvalidFileSizeException;
+
+public record FileSize(long bytes) {
+
+    private static final long COMPRESSION_THRESHOLD_BYTES = 500L * 1024;
+
+    public FileSize {
+        if (bytes <= 0) {
+            throw new InvalidFileSizeException("파일 크기는 0보다 커야 합니다: " + bytes);
+        }
+    }
+
+    public static FileSize ofKilobytes(long kilobytes) {
+        return new FileSize(kilobytes * 1024);
+    }
+
+    public static FileSize ofMegabytes(long megabytes) {
+        return new FileSize(megabytes * 1024 * 1024);
+    }
+
+    public boolean exceeds(long limitBytes) {
+        return bytes > limitBytes;
+    }
+
+    public boolean isBelowCompressionThreshold() {
+        return bytes < COMPRESSION_THRESHOLD_BYTES;
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/FileStatus.java
+++ b/backend/src/main/java/com/sssok/domain/file/FileStatus.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.file;
-
-// 파일의 업로드 진행 및 삭제 상태.
-public enum FileStatus {
-}

--- a/backend/src/main/java/com/sssok/domain/file/MediaOptimizationStrategy.java
+++ b/backend/src/main/java/com/sssok/domain/file/MediaOptimizationStrategy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.file;
+
+public final class MediaOptimizationStrategy {
+
+    private MediaOptimizationStrategy() {
+    }
+
+    public static OptimizationPlan decide(MediaType mediaType, FileSize fileSize) {
+        if (mediaType.isVideo()) {
+            return OptimizationPlan.skip();
+        }
+        if (mediaType.preservesAnimation()) {
+            return OptimizationPlan.skip();
+        }
+        if (fileSize.isBelowCompressionThreshold()) {
+            return OptimizationPlan.skip();
+        }
+        return OptimizationPlan.resizeThenCompress();
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/MediaType.java
+++ b/backend/src/main/java/com/sssok/domain/file/MediaType.java
@@ -1,5 +1,86 @@
 package com.sssok.domain.file;
 
-// 파일의 미디어 종류(이미지/영상/기타).
+import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+
+import java.util.Arrays;
+import java.util.Locale;
+
 public enum MediaType {
+
+    JPEG("jpg", "image/jpeg", Kind.IMAGE),
+    PNG("png", "image/png", Kind.IMAGE),
+    GIF("gif", "image/gif", Kind.IMAGE),
+    MP4("mp4", "video/mp4", Kind.VIDEO),
+    WEBM("webm", "video/webm", Kind.VIDEO),
+    MOV("mov", "video/quicktime", Kind.VIDEO);
+
+    private static final long IMAGE_MAX_BYTES = 10L * 1024 * 1024;
+    private static final long VIDEO_MAX_BYTES = 1024L * 1024 * 1024;
+
+    private final String extension;
+    private final String contentType;
+    private final Kind kind;
+
+    MediaType(String extension, String contentType, Kind kind) {
+        this.extension = extension;
+        this.contentType = contentType;
+        this.kind = kind;
+    }
+
+    public static MediaType fromExtension(String extension) {
+        String normalized = normalize(extension);
+        return Arrays.stream(values())
+                .filter(type -> type.matchesExtension(normalized))
+                .findFirst()
+                .orElseThrow(() -> new UnsupportedMediaTypeException(extension));
+    }
+
+    public static MediaType fromFileName(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new UnsupportedMediaTypeException(fileName);
+        }
+        return fromExtension(fileName.substring(fileName.lastIndexOf('.') + 1));
+    }
+
+    private static String normalize(String extension) {
+        if (extension == null) {
+            throw new UnsupportedMediaTypeException(null);
+        }
+        return extension.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean matchesExtension(String normalized) {
+        if (this == JPEG) {
+            return normalized.equals("jpg") || normalized.equals("jpeg");
+        }
+        return extension.equals(normalized);
+    }
+
+    public boolean isImage() {
+        return kind == Kind.IMAGE;
+    }
+
+    public boolean isVideo() {
+        return kind == Kind.VIDEO;
+    }
+
+    public boolean preservesAnimation() {
+        return this == GIF;
+    }
+
+    public long maxBytes() {
+        return isImage() ? IMAGE_MAX_BYTES : VIDEO_MAX_BYTES;
+    }
+
+    public String extension() {
+        return extension;
+    }
+
+    public String contentType() {
+        return contentType;
+    }
+
+    private enum Kind {
+        IMAGE, VIDEO
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/OptimizationPlan.java
+++ b/backend/src/main/java/com/sssok/domain/file/OptimizationPlan.java
@@ -1,0 +1,24 @@
+package com.sssok.domain.file;
+
+import java.util.List;
+
+public record OptimizationPlan(boolean skipped, List<OptimizationStep> steps) {
+
+    private static final OptimizationStep PRIMARY = new OptimizationStep(1600, 0.8);
+    private static final OptimizationStep SECONDARY = new OptimizationStep(1200, 0.7);
+
+    public OptimizationPlan {
+        steps = List.copyOf(steps);
+    }
+
+    public static OptimizationPlan skip() {
+        return new OptimizationPlan(true, List.of());
+    }
+
+    public static OptimizationPlan resizeThenCompress() {
+        return new OptimizationPlan(false, List.of(PRIMARY, SECONDARY));
+    }
+
+    public record OptimizationStep(int maxWidth, double quality) {
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/StorageKey.java
+++ b/backend/src/main/java/com/sssok/domain/file/StorageKey.java
@@ -1,5 +1,19 @@
 package com.sssok.domain.file;
 
-// 오브젝트 스토리지에 저장된 파일의 키 값 객체.
-public class StorageKey {
+import com.sssok.domain.file.exception.InvalidStorageKeyException;
+
+import java.util.UUID;
+
+public record StorageKey(String value) {
+
+    public StorageKey {
+        if (value == null || value.isBlank()) {
+            throw new InvalidStorageKeyException("스토리지 키는 비어 있을 수 없습니다.");
+        }
+    }
+
+    public static StorageKey generate(Long roomId, MediaType mediaType) {
+        return new StorageKey("rooms/%d/%s.%s".formatted(
+                roomId, UUID.randomUUID(), mediaType.extension()));
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/StoredFile.java
+++ b/backend/src/main/java/com/sssok/domain/file/StoredFile.java
@@ -1,5 +1,107 @@
 package com.sssok.domain.file;
 
-// 방에 업로드된 파일.
+import java.time.Instant;
+
+import com.sssok.domain.file.exception.FileSizeExceededException;
+import com.sssok.domain.file.exception.IllegalUploadStatusException;
+import lombok.Getter;
+
+@Getter
 public class StoredFile {
+
+    private final Long id;
+    private final Long roomId;
+    private final Long uploaderId;
+    private final String originalFileName;
+    private final MediaType mediaType;
+    private final FileSize fileSize;
+    private final StorageKey storageKey;
+    private final Instant createdAt;
+
+    private Long folderId;
+    private UploadStatus status;
+
+    private StoredFile(Long id, Long roomId, Long uploaderId, String originalFileName,
+                       MediaType mediaType, FileSize fileSize, StorageKey storageKey,
+                       Long folderId, UploadStatus status, Instant createdAt) {
+        this.id = id;
+        this.roomId = roomId;
+        this.uploaderId = uploaderId;
+        this.originalFileName = originalFileName;
+        this.mediaType = mediaType;
+        this.fileSize = fileSize;
+        this.storageKey = storageKey;
+        this.folderId = folderId;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static StoredFile beginUpload(Long roomId, Long uploaderId, String originalFileName,
+                                         FileSize fileSize, Long folderId, Instant now) {
+        MediaType mediaType = MediaType.fromFileName(originalFileName);
+        validateSize(mediaType, fileSize);
+
+        return new StoredFile(null, roomId, uploaderId, originalFileName, mediaType, fileSize,
+                StorageKey.generate(roomId, mediaType), folderId, UploadStatus.PENDING, now);
+    }
+
+    public static StoredFile reconstruct(Long id, Long roomId, Long uploaderId,
+                                         String originalFileName, MediaType mediaType,
+                                         FileSize fileSize, StorageKey storageKey, Long folderId,
+                                         UploadStatus status, Instant createdAt) {
+        return new StoredFile(id, roomId, uploaderId, originalFileName, mediaType, fileSize,
+                storageKey, folderId, status, createdAt);
+    }
+
+    private static void validateSize(MediaType mediaType, FileSize fileSize) {
+        if (fileSize.exceeds(mediaType.maxBytes())) {
+            throw new FileSizeExceededException(mediaType, fileSize);
+        }
+    }
+
+    public void startUploading() {
+        transitionTo(UploadStatus.UPLOADING);
+    }
+
+    public void completeUpload() {
+        transitionTo(UploadStatus.COMPLETED);
+    }
+
+    public void failUpload() {
+        transitionTo(UploadStatus.FAILED);
+    }
+
+    public void retryUpload() {
+        if (!status.isRetryable()) {
+            throw new IllegalUploadStatusException(status, UploadStatus.UPLOADING);
+        }
+        transitionTo(UploadStatus.UPLOADING);
+    }
+
+    private void transitionTo(UploadStatus next) {
+        if (!status.canTransitionTo(next)) {
+            throw new IllegalUploadStatusException(status, next);
+        }
+        status = next;
+    }
+
+    public void moveToFolder(Long folderId) {
+        this.folderId = folderId;
+    }
+
+    public void moveToRoot() {
+        this.folderId = null;
+    }
+
+    public boolean isInRoot() {
+        return folderId == null;
+    }
+
+    public boolean isUploadedBy(Long memberId) {
+        return uploaderId.equals(memberId);
+    }
+
+    public OptimizationPlan optimizationPlan() {
+        return MediaOptimizationStrategy.decide(mediaType, fileSize);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
+++ b/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
@@ -1,0 +1,28 @@
+package com.sssok.domain.file;
+
+import java.util.Set;
+
+public enum UploadStatus {
+
+    PENDING,
+    UPLOADING,
+    COMPLETED,
+    FAILED;
+
+    private static final Set<UploadStatus> FROM_PENDING = Set.of(UPLOADING, FAILED);
+    private static final Set<UploadStatus> FROM_UPLOADING = Set.of(COMPLETED, FAILED);
+    private static final Set<UploadStatus> FROM_FAILED = Set.of(UPLOADING);
+
+    public boolean canTransitionTo(UploadStatus next) {
+        return switch (this) {
+            case PENDING -> FROM_PENDING.contains(next);
+            case UPLOADING -> FROM_UPLOADING.contains(next);
+            case FAILED -> FROM_FAILED.contains(next);
+            case COMPLETED -> false;
+        };
+    }
+
+    public boolean isRetryable() {
+        return this == FAILED;
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/FileSizeExceededException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/FileSizeExceededException.java
@@ -1,0 +1,12 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.MediaType;
+
+public class FileSizeExceededException extends RuntimeException {
+
+    public FileSizeExceededException(MediaType mediaType, FileSize fileSize) {
+        super("%s 파일은 최대 %d바이트까지 업로드할 수 있습니다. (요청: %d바이트)"
+                .formatted(mediaType.name(), mediaType.maxBytes(), fileSize.bytes()));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/IllegalUploadStatusException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/IllegalUploadStatusException.java
@@ -1,0 +1,10 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.domain.file.UploadStatus;
+
+public class IllegalUploadStatusException extends RuntimeException {
+
+    public IllegalUploadStatusException(UploadStatus current, UploadStatus next) {
+        super("업로드 상태를 %s 에서 %s 로 바꿀 수 없습니다.".formatted(current, next));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/InvalidFileSizeException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/InvalidFileSizeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.file.exception;
+
+public class InvalidFileSizeException extends RuntimeException {
+
+    public InvalidFileSizeException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/InvalidStorageKeyException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/InvalidStorageKeyException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.file.exception;
+
+public class InvalidStorageKeyException extends RuntimeException {
+
+    public InvalidStorageKeyException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/UnsupportedMediaTypeException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/UnsupportedMediaTypeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.file.exception;
+
+public class UnsupportedMediaTypeException extends RuntimeException {
+
+    public UnsupportedMediaTypeException(String value) {
+        super("지원하지 않는 파일 형식입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/member/Member.java
+++ b/backend/src/main/java/com/sssok/domain/member/Member.java
@@ -1,5 +1,32 @@
 package com.sssok.domain.member;
 
-// 방에 참여한 참여자.
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
 public class Member {
+
+    private final Long id;
+    private final Long roomId;
+    private final Nickname displayName;
+    private final Instant joinedAt;
+
+    private Member(Long id, Long roomId, Nickname displayName, Instant joinedAt) {
+        this.id = id;
+        this.roomId = roomId;
+        this.displayName = displayName;
+        this.joinedAt = joinedAt;
+    }
+
+    public static Member join(Long roomId, Nickname displayName, Instant now) {
+        return new Member(null, roomId, displayName, now);
+    }
+
+    public static Member reconstruct(Long id, Long roomId, Nickname displayName, Instant joinedAt) {
+        return new Member(id, roomId, displayName, joinedAt);
+    }
+
+    public boolean isSame(Long memberId) {
+        return id != null && id.equals(memberId);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/member/MemberRole.java
+++ b/backend/src/main/java/com/sssok/domain/member/MemberRole.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.member;
-
-// 참여자 역할(방장/게스트).
-public enum MemberRole {
-}

--- a/backend/src/main/java/com/sssok/domain/member/Nickname.java
+++ b/backend/src/main/java/com/sssok/domain/member/Nickname.java
@@ -1,5 +1,20 @@
 package com.sssok.domain.member;
 
-// 참여자 닉네임 값 객체.
-public class Nickname {
+import com.sssok.domain.member.exception.InvalidNicknameException;
+
+public record Nickname(String value) {
+
+    private static final int MIN_LENGTH = 1;
+    private static final int MAX_LENGTH = 12;
+
+    public Nickname {
+        if (value == null) {
+            throw new InvalidNicknameException("닉네임은 필수입니다.");
+        }
+        value = value.trim();
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new InvalidNicknameException(
+                    "닉네임은 %d자 이상 %d자 이하여야 합니다.".formatted(MIN_LENGTH, MAX_LENGTH));
+        }
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/member/exception/InvalidNicknameException.java
+++ b/backend/src/main/java/com/sssok/domain/member/exception/InvalidNicknameException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.member.exception;
+
+public class InvalidNicknameException extends RuntimeException {
+
+    public InvalidNicknameException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
@@ -28,6 +28,11 @@ public class RoomRepositoryAdapter implements RoomRepository {
         return jpaRepository.findByCode(code.value()).map(this::toDomain);
     }
 
+    @Override
+    public Optional<Room> findById(Long id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
     private RoomJpaEntity toEntity(Room room) {
         return new RoomJpaEntity(
             room.getId(),

--- a/backend/src/main/java/com/sssok/infrastructure/room/RoomPermissionPortAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/room/RoomPermissionPortAdapter.java
@@ -1,0 +1,52 @@
+package com.sssok.infrastructure.room;
+
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.room.exception.RoomNotFoundException;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomPermissionPolicy;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomPermissionPortAdapter implements RoomPermissionPort {
+
+    private final RoomRepository roomRepository;
+
+    private final RoomPermissionPolicy permissionPolicy = new RoomPermissionPolicy();
+
+    @Override
+    public boolean isHost(Long roomId, Long memberId) {
+        return findRoom(roomId)
+                .map(room -> room.isHost(memberId))
+                .orElse(false);
+    }
+
+    @Override
+    public boolean canUpload(Long roomId, Long memberId) {
+        return findRoom(roomId)
+                .map(room -> permissionPolicy.canUploadTo(room, memberId, Instant.now()))
+                .orElse(false);
+    }
+
+    @Override
+    public boolean isRoomUsable(Long roomId) {
+        return findRoom(roomId)
+                .map(room -> room.canEnter(Instant.now()))
+                .orElse(false);
+    }
+
+    @Override
+    public String getRoomCode(Long roomId) {
+        return findRoom(roomId)
+                .map(room -> room.getCode().value())
+                .orElseThrow(() -> new RoomNotFoundException(roomId));
+    }
+
+    private Optional<Room> findRoom(Long roomId) {
+        return roomRepository.findById(roomId);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/DownloadFileNamesTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/DownloadFileNamesTest.java
@@ -1,0 +1,60 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DownloadFileNamesTest {
+
+    @Test
+    void zip_파일명은_방코드를_포함한다() {
+        assertThat(DownloadFileNames.zipNameOf("A3F9K2M7")).isEqualTo("ShareDrop_A3F9K2M7.zip");
+    }
+
+    @Test
+    void 겹치지_않으면_원본_파일명을_그대로_유지한다() {
+        List<String> names = DownloadFileNames.deduplicate(List.of("cat.jpg", "dog.png"));
+
+        assertThat(names).containsExactly("cat.jpg", "dog.png");
+    }
+
+    @Test
+    void 이름이_겹치면_번호를_붙인다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("cat.jpg", "cat.jpg", "cat.jpg"));
+
+        assertThat(names).containsExactly("cat.jpg", "cat (1).jpg", "cat (2).jpg");
+    }
+
+    @Test
+    void 확장자가_없어도_번호를_붙일_수_있다() {
+        List<String> names = DownloadFileNames.deduplicate(List.of("사진", "사진"));
+
+        assertThat(names).containsExactly("사진", "사진 (1)");
+    }
+
+    @Test
+    void 이름에_점이_여러_개면_마지막_확장자_앞에_번호가_붙는다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("2026.여름.png", "2026.여름.png"));
+
+        assertThat(names).containsExactly("2026.여름.png", "2026.여름 (1).png");
+    }
+
+    @Test
+    void 이미_번호가_붙은_이름이_섞여_있어도_겹치지_않는다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("cat.jpg", "cat (1).jpg", "cat.jpg"));
+
+        assertThat(names).containsExactly("cat.jpg", "cat (1).jpg", "cat (2).jpg");
+    }
+
+    @Test
+    void 서로_다른_이름은_각자_번호를_센다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("cat.jpg", "dog.jpg", "cat.jpg", "dog.jpg"));
+
+        assertThat(names).containsExactly("cat.jpg", "dog.jpg", "cat (1).jpg", "dog (1).jpg");
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/FilePermissionPolicyTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/FilePermissionPolicyTest.java
@@ -1,0 +1,75 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FilePermissionPolicyTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
+    private static final Long ME = 100L;
+    private static final Long OTHER = 200L;
+
+    private static final boolean HOST = true;
+    private static final boolean NOT_HOST = false;
+
+    private static StoredFile fileOf(Long uploaderId) {
+        return StoredFile.beginUpload(1L, uploaderId, "cat.png", FileSize.ofMegabytes(1), null, NOW);
+    }
+
+    @Test
+    void 본인이_올린_파일은_본인이_삭제할_수_있다() {
+        StoredFile myFile = fileOf(ME);
+
+        assertThat(FilePermissionPolicy.canDelete(myFile, ME, NOT_HOST)).isTrue();
+    }
+
+    @Test
+    void 남이_올린_파일은_삭제할_수_없다() {
+        StoredFile othersFile = fileOf(OTHER);
+
+        assertThat(FilePermissionPolicy.canDelete(othersFile, ME, NOT_HOST)).isFalse();
+    }
+
+    @Test
+    void 방장은_남이_올린_파일도_삭제할_수_있다() {
+        StoredFile othersFile = fileOf(OTHER);
+
+        assertThat(FilePermissionPolicy.canDelete(othersFile, ME, HOST)).isTrue();
+    }
+
+    @Test
+    void 선택_삭제할_때_권한_없는_항목만_빼고_나머지는_처리한다() {
+        StoredFile mine = fileOf(ME);
+        StoredFile others = fileOf(OTHER);
+        StoredFile mineAgain = fileOf(ME);
+
+        List<StoredFile> deletable =
+            FilePermissionPolicy.filterDeletable(List.of(mine, others, mineAgain), ME, NOT_HOST);
+
+        assertThat(deletable).containsExactly(mine, mineAgain);
+    }
+
+    @Test
+    void 방장이_선택_삭제하면_전부_대상이_된다() {
+        StoredFile mine = fileOf(ME);
+        StoredFile others = fileOf(OTHER);
+
+        List<StoredFile> deletable =
+            FilePermissionPolicy.filterDeletable(List.of(mine, others), ME, HOST);
+
+        assertThat(deletable).containsExactly(mine, others);
+    }
+
+    @Test
+    void 전부_권한이_없으면_빈_목록이_된다() {
+        StoredFile others = fileOf(OTHER);
+
+        List<StoredFile> deletable =
+            FilePermissionPolicy.filterDeletable(List.of(others), ME, NOT_HOST);
+
+        assertThat(deletable).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/FileSizeTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/FileSizeTest.java
@@ -1,0 +1,39 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.file.exception.InvalidFileSizeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FileSizeTest {
+
+    @Test
+    void 킬로바이트와_메가바이트로_만들_수_있다() {
+        assertThat(FileSize.ofKilobytes(1).bytes()).isEqualTo(1024);
+        assertThat(FileSize.ofMegabytes(1).bytes()).isEqualTo(1024 * 1024);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void 크기가_0_이하면_예외(long bytes) {
+        assertThatThrownBy(() -> new FileSize(bytes))
+            .isInstanceOf(InvalidFileSizeException.class);
+    }
+
+    @Test
+    void 상한_초과_여부를_판별한다() {
+        FileSize size = FileSize.ofMegabytes(11);
+
+        assertThat(size.exceeds(FileSize.ofMegabytes(10).bytes())).isTrue();
+        assertThat(size.exceeds(FileSize.ofMegabytes(11).bytes())).isFalse();
+    }
+
+    @Test
+    void 크기가_500KB_미만인지_판별한다() {
+        assertThat(FileSize.ofKilobytes(499).isBelowCompressionThreshold()).isTrue();
+        assertThat(FileSize.ofKilobytes(500).isBelowCompressionThreshold()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/MediaOptimizationStrategyTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/MediaOptimizationStrategyTest.java
@@ -1,0 +1,62 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sssok.domain.file.OptimizationPlan.OptimizationStep;
+import org.junit.jupiter.api.Test;
+
+class MediaOptimizationStrategyTest {
+
+    @Test
+    void 일반_이미지는_1600px_0_8_로_줄인_뒤_필요하면_1200px_0_7_로_재압축한다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.JPEG, FileSize.ofMegabytes(5));
+
+        assertThat(plan.skipped()).isFalse();
+        assertThat(plan.steps()).containsExactly(
+            new OptimizationStep(1600, 0.8),
+            new OptimizationStep(1200, 0.7)
+        );
+    }
+
+    @Test
+    void GIF_는_애니메이션_보존을_위해_압축하지_않는다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.GIF, FileSize.ofMegabytes(5));
+
+        assertThat(plan.skipped()).isTrue();
+        assertThat(plan.steps()).isEmpty();
+    }
+
+    @Test
+    void 크기가_500KB_미만인_원본은_압축하지_않는다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.JPEG, FileSize.ofKilobytes(499));
+
+        assertThat(plan.skipped()).isTrue();
+    }
+
+    @Test
+    void 크기가_정확히_500KB_이면_압축_대상이다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.JPEG, FileSize.ofKilobytes(500));
+
+        assertThat(plan.skipped()).isFalse();
+    }
+
+    @Test
+    void 영상은_리사이즈_대상이_아니다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.MP4, FileSize.ofMegabytes(100));
+
+        assertThat(plan.skipped()).isTrue();
+    }
+
+    @Test
+    void 계획의_단계_목록은_바꿀_수_없다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.PNG, FileSize.ofMegabytes(2));
+
+        assertThat(plan.steps()).isUnmodifiable();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/MediaTypeTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/MediaTypeTest.java
@@ -1,0 +1,77 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MediaTypeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "cat.jpg, JPEG",
+        "cat.jpeg, JPEG",
+        "cat.png, PNG",
+        "cat.gif, GIF",
+        "clip.mp4, MP4",
+        "clip.webm, WEBM",
+        "clip.mov, MOV",
+    })
+    void 파일명에서_형식을_판별한다(String fileName, MediaType expected) {
+        assertThat(MediaType.fromFileName(fileName)).isEqualTo(expected);
+    }
+
+    @Test
+    void 확장자_대소문자를_가리지_않는다() {
+        assertThat(MediaType.fromFileName("CAT.JPG")).isEqualTo(MediaType.JPEG);
+    }
+
+    @Test
+    void 이름에_점이_여러_개면_마지막_확장자를_쓴다() {
+        assertThat(MediaType.fromFileName("2026.여름.휴가.png")).isEqualTo(MediaType.PNG);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document.pdf",
+        "archive.zip",
+        "확장자없음",
+    })
+    void 지원하지_않는_형식이면_예외(String fileName) {
+        assertThatThrownBy(() -> MediaType.fromFileName(fileName))
+            .isInstanceOf(UnsupportedMediaTypeException.class);
+    }
+
+    @Test
+    void 파일명이_null_이면_예외() {
+        assertThatThrownBy(() -> MediaType.fromFileName(null))
+            .isInstanceOf(UnsupportedMediaTypeException.class);
+    }
+
+    @Test
+    void 이미지_상한은_10MB_다() {
+        assertThat(MediaType.JPEG.maxBytes()).isEqualTo(10L * 1024 * 1024);
+    }
+
+    @Test
+    void 영상_상한은_1GB_다() {
+        assertThat(MediaType.MP4.maxBytes()).isEqualTo(1024L * 1024 * 1024);
+    }
+
+    @Test
+    void GIF_만_애니메이션_보존_대상이다() {
+        assertThat(MediaType.GIF.preservesAnimation()).isTrue();
+        assertThat(MediaType.PNG.preservesAnimation()).isFalse();
+    }
+
+    @Test
+    void 이미지와_영상을_구분한다() {
+        assertThat(MediaType.PNG.isImage()).isTrue();
+        assertThat(MediaType.PNG.isVideo()).isFalse();
+        assertThat(MediaType.MP4.isVideo()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/StoredFileTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/StoredFileTest.java
@@ -1,0 +1,197 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import com.sssok.domain.file.exception.FileSizeExceededException;
+import com.sssok.domain.file.exception.IllegalUploadStatusException;
+import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class StoredFileTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
+    private static final Long ROOM_ID = 1L;
+    private static final Long UPLOADER_ID = 100L;
+
+    private static StoredFile beginUpload(String fileName, FileSize size, Long folderId) {
+        return StoredFile.beginUpload(ROOM_ID, UPLOADER_ID, fileName, size, folderId, NOW);
+    }
+
+    private static StoredFile uploading() {
+        StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+        file.startUploading();
+        return file;
+    }
+
+    @Nested
+    class 업로드_시작 {
+
+        @Test
+        void 대기_상태로_시작하고_스토리지_키가_발급된다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.PENDING);
+            assertThat(file.getMediaType()).isEqualTo(MediaType.PNG);
+            assertThat(file.getStorageKey().value()).startsWith("rooms/1/").endsWith(".png");
+        }
+
+        @Test
+        void 같은_이름을_두_번_올려도_스토리지_키는_겹치지_않는다() {
+            StoredFile first = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+            StoredFile second = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThat(first.getStorageKey()).isNotEqualTo(second.getStorageKey());
+        }
+
+        @Test
+        void 폴더를_지정하지_않으면_루트에_저장된다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThat(file.isInRoot()).isTrue();
+        }
+
+        @Test
+        void 폴더를_지정하면_그_폴더로_저장된다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), 7L);
+
+            assertThat(file.getFolderId()).isEqualTo(7L);
+            assertThat(file.isInRoot()).isFalse();
+        }
+
+        @Test
+        void 이미지가_10MB_를_넘으면_예외() {
+            assertThatThrownBy(() ->
+                beginUpload("cat.png", FileSize.ofMegabytes(11), null))
+                .isInstanceOf(FileSizeExceededException.class);
+        }
+
+        @Test
+        void 영상은_1GB_까지_허용된다() {
+            StoredFile file = beginUpload("clip.mp4", FileSize.ofMegabytes(1024), null);
+
+            assertThat(file.getMediaType()).isEqualTo(MediaType.MP4);
+        }
+
+        @Test
+        void 영상이_1GB_를_넘으면_예외() {
+            assertThatThrownBy(() ->
+                beginUpload("clip.mp4", FileSize.ofMegabytes(1025), null))
+                .isInstanceOf(FileSizeExceededException.class);
+        }
+
+        @Test
+        void 지원하지_않는_형식이면_예외() {
+            assertThatThrownBy(() ->
+                beginUpload("report.pdf", FileSize.ofMegabytes(1), null))
+                .isInstanceOf(UnsupportedMediaTypeException.class);
+        }
+    }
+
+    @Nested
+    class 상태_전이 {
+
+        @Test
+        void 대기에서_업로드중을_거쳐_완료된다() {
+            StoredFile file = uploading();
+            file.completeUpload();
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.COMPLETED);
+        }
+
+        @Test
+        void 업로드에_실패할_수_있다() {
+            StoredFile file = uploading();
+            file.failUpload();
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.FAILED);
+        }
+
+        @Test
+        void 실패한_파일만_재시도할_수_있다() {
+            StoredFile file = uploading();
+            file.failUpload();
+
+            file.retryUpload();
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.UPLOADING);
+        }
+
+        @Test
+        void 완료된_파일은_재시도할_수_없다() {
+            StoredFile file = uploading();
+            file.completeUpload();
+
+            assertThatThrownBy(file::retryUpload)
+                .isInstanceOf(IllegalUploadStatusException.class);
+        }
+
+        @Test
+        void 대기_상태에서_바로_완료할_수_없다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThatThrownBy(file::completeUpload)
+                .isInstanceOf(IllegalUploadStatusException.class);
+        }
+
+        @Test
+        void 완료된_파일은_다시_실패할_수_없다() {
+            StoredFile file = uploading();
+            file.completeUpload();
+
+            assertThatThrownBy(file::failUpload)
+                .isInstanceOf(IllegalUploadStatusException.class);
+        }
+    }
+
+    @Nested
+    class 폴더_이동 {
+
+        @Test
+        void 기존_폴더로_이동할_수_있다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            file.moveToFolder(7L);
+
+            assertThat(file.getFolderId()).isEqualTo(7L);
+        }
+
+        @Test
+        void 다른_폴더로_옮길_수_있다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), 7L);
+
+            file.moveToFolder(8L);
+
+            assertThat(file.getFolderId()).isEqualTo(8L);
+        }
+
+        @Test
+        void 폴더에서_꺼내면_루트로_간다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), 7L);
+
+            file.moveToRoot();
+
+            assertThat(file.isInRoot()).isTrue();
+        }
+    }
+
+    @Test
+    void 업로더_본인인지_판별할_수_있다() {
+        StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+        assertThat(file.isUploadedBy(UPLOADER_ID)).isTrue();
+        assertThat(file.isUploadedBy(999L)).isFalse();
+    }
+
+    @Test
+    void 자신의_최적화_계획을_알려준다() {
+        StoredFile gif = beginUpload("anim.gif", FileSize.ofMegabytes(5), null);
+        StoredFile png = beginUpload("cat.png", FileSize.ofMegabytes(5), null);
+
+        assertThat(gif.optimizationPlan().skipped()).isTrue();
+        assertThat(png.optimizationPlan().skipped()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/sssok/domain/member/MemberTest.java
@@ -1,0 +1,43 @@
+package com.sssok.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
+
+    @Test
+    void 최초_입장하면_아직_식별자가_없다() {
+        Member member = Member.join(1L, new Nickname("로지"), NOW);
+
+        assertThat(member.getId()).isNull();
+        assertThat(member.getRoomId()).isEqualTo(1L);
+        assertThat(member.getDisplayName().value()).isEqualTo("로지");
+        assertThat(member.getJoinedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void 저장된_값으로_복원할_수_있다() {
+        Member member = Member.reconstruct(10L, 1L, new Nickname("로지"), NOW);
+
+        assertThat(member.getId()).isEqualTo(10L);
+    }
+
+    @Test
+    void 같은_식별자인지_판별할_수_있다() {
+        Member member = Member.reconstruct(10L, 1L, new Nickname("로지"), NOW);
+
+        assertThat(member.isSame(10L)).isTrue();
+        assertThat(member.isSame(11L)).isFalse();
+    }
+
+    @Test
+    void 저장되지_않은_참여자는_어떤_식별자와도_같지_않다() {
+        Member member = Member.join(1L, new Nickname("로지"), NOW);
+
+        assertThat(member.isSame(10L)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/member/NicknameTest.java
+++ b/backend/src/test/java/com/sssok/domain/member/NicknameTest.java
@@ -1,0 +1,56 @@
+package com.sssok.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.member.exception.InvalidNicknameException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NicknameTest {
+
+    @Test
+    void 유효한_닉네임은_정상_생성된다() {
+        Nickname nickname = new Nickname("로지");
+        assertThat(nickname.value()).isEqualTo("로지");
+    }
+
+    @Test
+    void 앞뒤_공백은_제거된다() {
+        Nickname nickname = new Nickname("  로지  ");
+
+        assertThat(nickname.value()).isEqualTo("로지");
+    }
+
+    @Test
+    void 최대_길이인_12자는_허용된다() {
+        String twelveChars = "가".repeat(12);
+
+        assertThat(new Nickname(twelveChars).value()).hasSize(12);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        "   ",
+    })
+    void 비어있으면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new Nickname(invalidValue))
+            .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    void 길이_제한을_넘으면_예외() {
+        String thirteenChars = "가".repeat(13);
+
+        assertThatThrownBy(() -> new Nickname(thirteenChars))
+            .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    void null_이면_예외() {
+        assertThatThrownBy(() -> new Nickname(null))
+            .isInstanceOf(InvalidNicknameException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/infrastructure/room/RoomPermissionPortAdapterTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/room/RoomPermissionPortAdapterTest.java
@@ -1,0 +1,150 @@
+package com.sssok.infrastructure.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.room.exception.RoomNotFoundException;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoomPermissionPortAdapterTest {
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long HOST_ID = 100L;
+    private static final Long GUEST_ID = 200L;
+    private static final Long MISSING_ROOM_ID = 999L;
+
+    private FakeRoomRepository roomRepository;
+    private RoomPermissionPortAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        roomRepository = new FakeRoomRepository();
+        adapter = new RoomPermissionPortAdapter(roomRepository);
+    }
+
+    private Room roomWith(UploadPolicy uploadPolicy, Instant expiresAt) {
+        return Room.reconstruct(
+            ROOM_ID,
+            new RoomCode("A3F9K2M7"),
+            new RoomName("우테코 데모데이"),
+            RoomStatus.initial(),
+            new RoomExpiration(expiresAt),
+            uploadPolicy,
+            HOST_ID,
+            Instant.now().minusSeconds(60),
+            null
+        );
+    }
+
+    private void givenRoom(Room room) {
+        roomRepository.save(room);
+    }
+
+    private Instant farFuture() {
+        return Instant.now().plusSeconds(3600);
+    }
+
+    private Instant past() {
+        return Instant.now().minusSeconds(1);
+    }
+
+    @Test
+    void 방장이면_isHost_가_참이다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.isHost(ROOM_ID, HOST_ID)).isTrue();
+        assertThat(adapter.isHost(ROOM_ID, GUEST_ID)).isFalse();
+    }
+
+    @Test
+    void ANYONE_방에서는_누구나_업로드할_수_있다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.canUpload(ROOM_ID, GUEST_ID)).isTrue();
+    }
+
+    @Test
+    void HOST_ONLY_방에서는_방장만_업로드할_수_있다() {
+        givenRoom(roomWith(UploadPolicy.HOST_ONLY, farFuture()));
+
+        assertThat(adapter.canUpload(ROOM_ID, HOST_ID)).isTrue();
+        assertThat(adapter.canUpload(ROOM_ID, GUEST_ID)).isFalse();
+    }
+
+    @Test
+    void 만료된_방에는_방장도_업로드할_수_없다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, past()));
+
+        assertThat(adapter.canUpload(ROOM_ID, HOST_ID)).isFalse();
+    }
+
+    @Test
+    void 살아있는_방은_사용_가능하다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.isRoomUsable(ROOM_ID)).isTrue();
+    }
+
+    @Test
+    void 만료된_방은_사용할_수_없다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, past()));
+
+        assertThat(adapter.isRoomUsable(ROOM_ID)).isFalse();
+    }
+
+    @Test
+    void 방_코드를_조회할_수_있다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.getRoomCode(ROOM_ID)).isEqualTo("A3F9K2M7");
+    }
+
+    @Test
+    void 없는_방은_모든_판별이_거짓이다() {
+        assertThat(adapter.isHost(MISSING_ROOM_ID, HOST_ID)).isFalse();
+        assertThat(adapter.canUpload(MISSING_ROOM_ID, HOST_ID)).isFalse();
+        assertThat(adapter.isRoomUsable(MISSING_ROOM_ID)).isFalse();
+    }
+
+    @Test
+    void 없는_방의_코드를_조회하면_예외() {
+        assertThatThrownBy(() -> adapter.getRoomCode(MISSING_ROOM_ID))
+            .isInstanceOf(RoomNotFoundException.class);
+    }
+
+    // DB 없이 검증하기 위한 최소 구현
+    private static class FakeRoomRepository implements RoomRepository {
+
+        private final Map<Long, Room> rooms = new HashMap<>();
+
+        @Override
+        public Room save(Room room) {
+            rooms.put(room.getId(), room);
+            return room;
+        }
+
+        @Override
+        public Optional<Room> findByCode(RoomCode code) {
+            return rooms.values().stream()
+                .filter(room -> room.getCode().equals(code))
+                .findFirst();
+        }
+
+        @Override
+        public Optional<Room> findById(Long id) {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Media·Member 컨텍스트의 도메인 모델을 설계·구현했다. 
- 권한 판별은 도메인이 아니라 응용 계층에서 포트로 질의하도록 두고, #24가 인터페이스만 남겨둔 RoomPermissionPort의 구현체를 함께 추가했다.

## 관련 이슈
Closes #25

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항

### Member 엔티티
- `id` / `roomId` / `displayName` / `joinedAt`
- `Nickname`: 앞뒤 공백을 제거한 뒤 1~12자 검증

### StoredFile 애그리거트
- `beginUpload()`에서 파일명으로 형식을 판별하고 용량을 검증한 뒤 `StorageKey`를 발급하고 `PENDING`으로 시작
- `moveToFolder()` / `moveToRoot()` — 폴더 미지정 시 루트(`folderId = null`)
- 업로드 권한은 확인하지 않는다 (응용 계층이 포트로 미리 확인하는 것을 전제 — 리뷰 요청 사항 참고)

### UploadStatus — 상태 머신
- `PENDING → UPLOADING → COMPLETED | FAILED`
- `FAILED → UPLOADING` 만 열어 “실패한 파일만 재시도” 를 지원하고, `COMPLETED`는 종착 상태
- 허용되지 않은 전이는 `IllegalUploadStatusException`

### 값 객체
- `MediaType`: 이미지(JPG/PNG/GIF)·영상(MP4/WebM/MOV) 6종. 종류별 상한(이미지 10MB, 영상 1GB)을 형식 자신이 들고 있다. `jpg`/`jpeg`는 같은 형식으로 취급
- `FileSize`: 0 이하 거부, 500KB 압축 기준선 판별
- `StorageKey`: `rooms/{roomId}/{UUID}.{확장자}` — 같은 이름 파일을 여러 번 올려도 덮어쓰지 않는다

### MediaOptimizationStrategy
- 1600px/품질 0.8 → 1200px/0.7 재압축 단계를 정의
- GIF(애니메이션 보존)·500KB 미만(이득 없음)·영상은 원본 유지
- **2차 압축 여부는 도메인이 판단하지 않는다.** “여전히 크면”은 실제로 압축해봐야 아는 값이라, 도메인은 시도할 단계 목록만 주고 중단 시점은 미디어 처리기가 정하도록 `OptimizationPlan`으로 넘긴다

### FilePermissionPolicy
- `canDelete` = 본인 업로드(`uploaderId` 비교) **or** 방장
- `filterDeletable`: 여러 장 선택 삭제 시 권한 없는 항목만 제외하고 나머지는 처리 (전체 실패 없음)
- 방장 여부를 포트가 아닌 `boolean`으로 받는다 — 파일마다 포트를 부르면 N번 질의하게 되어, 유스케이스당 한 번만 묻고 결과를 넘기는 것을 전제로 한다

### DownloadFileNames
- zip 이름 `ShareDrop_{방코드}.zip`
- zip 안에서 이름이 겹치면 `파일명 (1).jpg` 로 회피. 이미 `(1)`이 있으면 건너뛰고 `(2)`를 쓴다

### RoomPermissionPort 구현체 추가 (#24 파일 일부 수정)
`RoomPermissionPortAdapter` — 방을 조회해 `RoomPermissionPolicy`에 판정을 위임한다. 방이 없으면 입장·업로드 판별은 모두 `false`(없는 방엔 들어갈 수도 올릴 수도 없으므로 막는 쪽), `getRoomCode`만 대체할 값이 없어 예외. 구현하려면 `roomId`로 방을 꺼낼 수 있어야 해서 #24 파일 3개를 함께 수정했다. 
- `RoomRepository`에 `findById(Long)` 추가 (기존엔 `findByCode`만 있었다)
- `RoomRepositoryAdapter`에 구현 추가
- `RoomNotFoundException`에 `(Long roomId)` 생성자 추가

## 도메인 관계도
<img width="2601" height="2012" alt="image" src="https://github.com/user-attachments/assets/c7702c09-e01a-4b2a-9af1-ef86786de3a8" />

## 테스트
- - 도메인 전부 `@SpringBootTest` 없이 순수 JUnit (`NicknameTest`, `MemberTest`, `MediaTypeTest`, `FileSizeTest`, `StoredFileTest`, `MediaOptimizationStrategyTest`, `FilePermissionPolicyTest`, `DownloadFileNamesTest`)
- `RoomPermissionPortAdapterTest`: `RoomRepository`를 `HashMap` 페이크로 대체해 DB 없이 검증. 만료된 방에는 방장도 업로드할 수 없는 것까지 확인
- 이번 PR에서 추가한 테스트 80개, 전체 159개 통과

## 리뷰 요청 사항 (선택)

### #24 파일 3개를 수정했습니다
- `RoomRepository` / `RoomRepositoryAdapter` / `RoomNotFoundException`. `roomId`로 방을 조회할 방법이 없어 포트 구현이 불가능했습니다. 추가만 했고 기존 동작은 그대로입니다.

### 권한 확인을 도메인이 아니라 응용 계층에 두려고 합니다
- 이슈 완료 조건은 `beginUpload()`가 `RoomPermissionPort.canUpload()`를 직접 부르는 형태로 적혀 있는데, 구현해보니 **포트 구현체가 `RoomRepository`로 DB를 칩니다.** 도메인 객체를 만드는 일이 DB 쿼리를 유발하게 되고, 도메인 단위 테스트도 더 이상 순수 JUnit이 아니게 됩니다.
- 그래서 도메인은 포트를 모르게 두고, 응용 서비스가 미리 확인한 뒤 도메인을 호출하는 방향을 제안합니다. 이슈 문구와 달라지는 부분이라 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이미지·동영상 파일 형식과 크기를 검증하고, 조건에 따라 이미지 최적화를 지원합니다.
  * 업로드 진행·완료·실패·재시도 상태를 관리합니다.
  * 파일 업로더와 방장은 파일을 삭제할 수 있으며, 권한에 맞는 파일만 표시됩니다.
  * 다운로드 파일명의 중복을 자동으로 방지합니다.
  * 방 입장·업로드 가능 여부와 방장 권한을 확인합니다.
  * 닉네임의 공백과 길이를 자동 정리하고 유효성을 검증합니다.

* **버그 수정**
  * 존재하지 않는 방이나 지원하지 않는 파일 형식에 대해 명확한 오류를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->