### PR TITLE
deploy: 이번 주 스프린트 반영 (Room·Folder, Member·StoredFile 도메인)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // API 문서화 (Swagger UI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.9.0'
+
     // DB 마이그레이션
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,11 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // 통합 테스트용 실제 PostgreSQL (H2 금지 — JSONB 등 PostgreSQL 전용 기능 검증 불가)
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/sssok/application/port/out/RoomPermissionPort.java
+++ b/backend/src/main/java/com/sssok/application/port/out/RoomPermissionPort.java
@@ -1,0 +1,16 @@
+package com.sssok.application.port.out;
+
+// Room 컨텍스트(담당 A)가 Member/File 컨텍스트(담당 B)에 노출하는 조회 전용 포트.
+// B는 이 인터페이스에만 의존하고, Room 내부 구현은 몰라도 된다.
+// 구현체는 이 이슈 범위가 아니며, RoomRepository를 사용해 이후에 채운다.
+public interface RoomPermissionPort {
+
+    boolean isHost(Long roomId, Long memberId);
+
+    boolean canUpload(Long roomId, Long memberId);
+
+    boolean isRoomUsable(Long roomId);
+
+    // zip 다운로드 파일명(ShareDrop_방코드.zip)에 쓰인다.
+    String getRoomCode(Long roomId);
+}

--- a/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
@@ -1,5 +1,13 @@
 package com.sssok.application.port.out;
 
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import java.util.Optional;
+
 // 방 영속화 출력
 public interface RoomRepository {
+
+    Room save(Room room);
+
+    Optional<Room> findByCode(RoomCode code);
 }

--- a/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/RoomRepository.java
@@ -10,4 +10,6 @@ public interface RoomRepository {
     Room save(Room room);
 
     Optional<Room> findByCode(RoomCode code);
+
+    Optional<Room> findById(Long id);
 }

--- a/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
@@ -1,5 +1,25 @@
 package com.sssok.application.room;
 
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.random.RandomGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
 // 방 생성
+@Service
+@RequiredArgsConstructor
 public class CreateRoomService {
+
+    private final RoomRepository roomRepository;
+    private final RandomGenerator randomGenerator = new SecureRandom();
+
+    public Room create() {
+        RoomCode code = RoomCode.generate(randomGenerator);
+        Room room = Room.create(code, Instant.now());
+        return roomRepository.save(room);
+    }
 }

--- a/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
@@ -3,6 +3,7 @@ package com.sssok.application.room;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomName;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.random.RandomGenerator;
@@ -17,9 +18,12 @@ public class CreateRoomService {
     private final RoomRepository roomRepository;
     private final RandomGenerator randomGenerator = new SecureRandom();
 
-    public Room create() {
+    public Room create(String name) {
         RoomCode code = RoomCode.generate(randomGenerator);
-        Room room = Room.create(code, Instant.now());
+        // TODO: 실제 방장 식별자는 입장/인증(JWT) 흐름이 붙으면 그걸로 대체한다.
+        // 아직 인증 체계가 없어, 방 생성 시점에 임시로 새 식별자를 발급해 방장으로 지정한다.
+        Long hostId = randomGenerator.nextLong(1L, Long.MAX_VALUE);
+        Room room = Room.create(code, new RoomName(name), hostId, Instant.now());
         return roomRepository.save(room);
     }
 }

--- a/backend/src/main/java/com/sssok/application/room/GetRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/GetRoomService.java
@@ -1,0 +1,20 @@
+package com.sssok.application.room;
+
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 방 코드로 조회
+@Service
+@RequiredArgsConstructor
+public class GetRoomService {
+
+    private final RoomRepository roomRepository;
+
+    public Room getByCode(RoomCode code) {
+        return roomRepository.findByCode(code)
+            .orElseThrow(() -> new RoomNotFoundException(code));
+    }
+}

--- a/backend/src/main/java/com/sssok/application/room/GetRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/GetRoomService.java
@@ -1,5 +1,6 @@
 package com.sssok.application.room;
 
+import com.sssok.application.room.exception.RoomNotFoundException;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;

--- a/backend/src/main/java/com/sssok/application/room/RoomNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/room/RoomNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sssok.application.room;
+
+import com.sssok.domain.room.RoomCode;
+
+public class RoomNotFoundException extends RuntimeException {
+
+    public RoomNotFoundException(RoomCode code) {
+        super("존재하지 않는 방입니다: " + code.value());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
@@ -7,4 +7,8 @@ public class RoomNotFoundException extends RuntimeException {
     public RoomNotFoundException(RoomCode code) {
         super("존재하지 않는 방입니다: " + code.value());
     }
+
+    public RoomNotFoundException(Long roomId) {
+        super("존재하지 않는 방입니다: " + roomId);
+    }
 }

--- a/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/room/exception/RoomNotFoundException.java
@@ -1,4 +1,4 @@
-package com.sssok.application.room;
+package com.sssok.application.room.exception;
 
 import com.sssok.domain.room.RoomCode;
 

--- a/backend/src/main/java/com/sssok/domain/file/DownloadFileNames.java
+++ b/backend/src/main/java/com/sssok/domain/file/DownloadFileNames.java
@@ -1,0 +1,55 @@
+package com.sssok.domain.file;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class DownloadFileNames {
+
+    private static final String ZIP_NAME_FORMAT = "ShareDrop_%s.zip";
+
+    private DownloadFileNames() {
+    }
+
+    public static String zipNameOf(String roomCode) {
+        return ZIP_NAME_FORMAT.formatted(roomCode);
+    }
+
+    public static List<String> deduplicate(List<String> fileNames) {
+        Map<String, Integer> usedCounts = new HashMap<>();
+        List<String> result = new ArrayList<>(fileNames.size());
+
+        for (String fileName : fileNames) {
+            result.add(nextAvailableName(fileName, usedCounts));
+        }
+        return result;
+    }
+
+    private static String nextAvailableName(String fileName, Map<String, Integer> usedCounts) {
+        if (!usedCounts.containsKey(fileName)) {
+            usedCounts.put(fileName, 0);
+            return fileName;
+        }
+
+        int sequence = usedCounts.get(fileName);
+        String candidate;
+        do {
+            sequence++;
+            candidate = numbered(fileName, sequence);
+        } while (usedCounts.containsKey(candidate));
+
+        usedCounts.put(fileName, sequence);
+        usedCounts.put(candidate, 0);
+        return candidate;
+    }
+
+    private static String numbered(String fileName, int sequence) {
+        int extensionIndex = fileName.lastIndexOf('.');
+        if (extensionIndex <= 0) {
+            return "%s (%d)".formatted(fileName, sequence);
+        }
+        return "%s (%d)%s".formatted(
+                fileName.substring(0, extensionIndex), sequence, fileName.substring(extensionIndex));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/FilePermissionPolicy.java
+++ b/backend/src/main/java/com/sssok/domain/file/FilePermissionPolicy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.file;
+
+import java.util.List;
+
+public final class FilePermissionPolicy {
+
+    private FilePermissionPolicy() {
+    }
+
+    public static boolean canDelete(StoredFile file, Long requesterId, boolean requesterIsHost) {
+        return requesterIsHost || file.isUploadedBy(requesterId);
+    }
+
+    public static List<StoredFile> filterDeletable(List<StoredFile> files, Long requesterId,
+                                                   boolean requesterIsHost) {
+        return files.stream()
+                .filter(file -> canDelete(file, requesterId, requesterIsHost))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/FileSize.java
+++ b/backend/src/main/java/com/sssok/domain/file/FileSize.java
@@ -1,5 +1,30 @@
 package com.sssok.domain.file;
 
-// 파일 크기 값 객체. 종류별 업로드 상한을 검증한다.
-public class FileSize {
+import com.sssok.domain.file.exception.InvalidFileSizeException;
+
+public record FileSize(long bytes) {
+
+    private static final long COMPRESSION_THRESHOLD_BYTES = 500L * 1024;
+
+    public FileSize {
+        if (bytes <= 0) {
+            throw new InvalidFileSizeException("파일 크기는 0보다 커야 합니다: " + bytes);
+        }
+    }
+
+    public static FileSize ofKilobytes(long kilobytes) {
+        return new FileSize(kilobytes * 1024);
+    }
+
+    public static FileSize ofMegabytes(long megabytes) {
+        return new FileSize(megabytes * 1024 * 1024);
+    }
+
+    public boolean exceeds(long limitBytes) {
+        return bytes > limitBytes;
+    }
+
+    public boolean isBelowCompressionThreshold() {
+        return bytes < COMPRESSION_THRESHOLD_BYTES;
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/FileStatus.java
+++ b/backend/src/main/java/com/sssok/domain/file/FileStatus.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.file;
-
-// 파일의 업로드 진행 및 삭제 상태.
-public enum FileStatus {
-}

--- a/backend/src/main/java/com/sssok/domain/file/MediaOptimizationStrategy.java
+++ b/backend/src/main/java/com/sssok/domain/file/MediaOptimizationStrategy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.file;
+
+public final class MediaOptimizationStrategy {
+
+    private MediaOptimizationStrategy() {
+    }
+
+    public static OptimizationPlan decide(MediaType mediaType, FileSize fileSize) {
+        if (mediaType.isVideo()) {
+            return OptimizationPlan.skip();
+        }
+        if (mediaType.preservesAnimation()) {
+            return OptimizationPlan.skip();
+        }
+        if (fileSize.isBelowCompressionThreshold()) {
+            return OptimizationPlan.skip();
+        }
+        return OptimizationPlan.resizeThenCompress();
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/MediaType.java
+++ b/backend/src/main/java/com/sssok/domain/file/MediaType.java
@@ -1,5 +1,86 @@
 package com.sssok.domain.file;
 
-// 파일의 미디어 종류(이미지/영상/기타).
+import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+
+import java.util.Arrays;
+import java.util.Locale;
+
 public enum MediaType {
+
+    JPEG("jpg", "image/jpeg", Kind.IMAGE),
+    PNG("png", "image/png", Kind.IMAGE),
+    GIF("gif", "image/gif", Kind.IMAGE),
+    MP4("mp4", "video/mp4", Kind.VIDEO),
+    WEBM("webm", "video/webm", Kind.VIDEO),
+    MOV("mov", "video/quicktime", Kind.VIDEO);
+
+    private static final long IMAGE_MAX_BYTES = 10L * 1024 * 1024;
+    private static final long VIDEO_MAX_BYTES = 1024L * 1024 * 1024;
+
+    private final String extension;
+    private final String contentType;
+    private final Kind kind;
+
+    MediaType(String extension, String contentType, Kind kind) {
+        this.extension = extension;
+        this.contentType = contentType;
+        this.kind = kind;
+    }
+
+    public static MediaType fromExtension(String extension) {
+        String normalized = normalize(extension);
+        return Arrays.stream(values())
+                .filter(type -> type.matchesExtension(normalized))
+                .findFirst()
+                .orElseThrow(() -> new UnsupportedMediaTypeException(extension));
+    }
+
+    public static MediaType fromFileName(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new UnsupportedMediaTypeException(fileName);
+        }
+        return fromExtension(fileName.substring(fileName.lastIndexOf('.') + 1));
+    }
+
+    private static String normalize(String extension) {
+        if (extension == null) {
+            throw new UnsupportedMediaTypeException(null);
+        }
+        return extension.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean matchesExtension(String normalized) {
+        if (this == JPEG) {
+            return normalized.equals("jpg") || normalized.equals("jpeg");
+        }
+        return extension.equals(normalized);
+    }
+
+    public boolean isImage() {
+        return kind == Kind.IMAGE;
+    }
+
+    public boolean isVideo() {
+        return kind == Kind.VIDEO;
+    }
+
+    public boolean preservesAnimation() {
+        return this == GIF;
+    }
+
+    public long maxBytes() {
+        return isImage() ? IMAGE_MAX_BYTES : VIDEO_MAX_BYTES;
+    }
+
+    public String extension() {
+        return extension;
+    }
+
+    public String contentType() {
+        return contentType;
+    }
+
+    private enum Kind {
+        IMAGE, VIDEO
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/OptimizationPlan.java
+++ b/backend/src/main/java/com/sssok/domain/file/OptimizationPlan.java
@@ -1,0 +1,24 @@
+package com.sssok.domain.file;
+
+import java.util.List;
+
+public record OptimizationPlan(boolean skipped, List<OptimizationStep> steps) {
+
+    private static final OptimizationStep PRIMARY = new OptimizationStep(1600, 0.8);
+    private static final OptimizationStep SECONDARY = new OptimizationStep(1200, 0.7);
+
+    public OptimizationPlan {
+        steps = List.copyOf(steps);
+    }
+
+    public static OptimizationPlan skip() {
+        return new OptimizationPlan(true, List.of());
+    }
+
+    public static OptimizationPlan resizeThenCompress() {
+        return new OptimizationPlan(false, List.of(PRIMARY, SECONDARY));
+    }
+
+    public record OptimizationStep(int maxWidth, double quality) {
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/StorageKey.java
+++ b/backend/src/main/java/com/sssok/domain/file/StorageKey.java
@@ -1,5 +1,19 @@
 package com.sssok.domain.file;
 
-// 오브젝트 스토리지에 저장된 파일의 키 값 객체.
-public class StorageKey {
+import com.sssok.domain.file.exception.InvalidStorageKeyException;
+
+import java.util.UUID;
+
+public record StorageKey(String value) {
+
+    public StorageKey {
+        if (value == null || value.isBlank()) {
+            throw new InvalidStorageKeyException("스토리지 키는 비어 있을 수 없습니다.");
+        }
+    }
+
+    public static StorageKey generate(Long roomId, MediaType mediaType) {
+        return new StorageKey("rooms/%d/%s.%s".formatted(
+                roomId, UUID.randomUUID(), mediaType.extension()));
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/StoredFile.java
+++ b/backend/src/main/java/com/sssok/domain/file/StoredFile.java
@@ -1,5 +1,107 @@
 package com.sssok.domain.file;
 
-// 방에 업로드된 파일.
+import java.time.Instant;
+
+import com.sssok.domain.file.exception.FileSizeExceededException;
+import com.sssok.domain.file.exception.IllegalUploadStatusException;
+import lombok.Getter;
+
+@Getter
 public class StoredFile {
+
+    private final Long id;
+    private final Long roomId;
+    private final Long uploaderId;
+    private final String originalFileName;
+    private final MediaType mediaType;
+    private final FileSize fileSize;
+    private final StorageKey storageKey;
+    private final Instant createdAt;
+
+    private Long folderId;
+    private UploadStatus status;
+
+    private StoredFile(Long id, Long roomId, Long uploaderId, String originalFileName,
+                       MediaType mediaType, FileSize fileSize, StorageKey storageKey,
+                       Long folderId, UploadStatus status, Instant createdAt) {
+        this.id = id;
+        this.roomId = roomId;
+        this.uploaderId = uploaderId;
+        this.originalFileName = originalFileName;
+        this.mediaType = mediaType;
+        this.fileSize = fileSize;
+        this.storageKey = storageKey;
+        this.folderId = folderId;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static StoredFile beginUpload(Long roomId, Long uploaderId, String originalFileName,
+                                         FileSize fileSize, Long folderId, Instant now) {
+        MediaType mediaType = MediaType.fromFileName(originalFileName);
+        validateSize(mediaType, fileSize);
+
+        return new StoredFile(null, roomId, uploaderId, originalFileName, mediaType, fileSize,
+                StorageKey.generate(roomId, mediaType), folderId, UploadStatus.PENDING, now);
+    }
+
+    public static StoredFile reconstruct(Long id, Long roomId, Long uploaderId,
+                                         String originalFileName, MediaType mediaType,
+                                         FileSize fileSize, StorageKey storageKey, Long folderId,
+                                         UploadStatus status, Instant createdAt) {
+        return new StoredFile(id, roomId, uploaderId, originalFileName, mediaType, fileSize,
+                storageKey, folderId, status, createdAt);
+    }
+
+    private static void validateSize(MediaType mediaType, FileSize fileSize) {
+        if (fileSize.exceeds(mediaType.maxBytes())) {
+            throw new FileSizeExceededException(mediaType, fileSize);
+        }
+    }
+
+    public void startUploading() {
+        transitionTo(UploadStatus.UPLOADING);
+    }
+
+    public void completeUpload() {
+        transitionTo(UploadStatus.COMPLETED);
+    }
+
+    public void failUpload() {
+        transitionTo(UploadStatus.FAILED);
+    }
+
+    public void retryUpload() {
+        if (!status.isRetryable()) {
+            throw new IllegalUploadStatusException(status, UploadStatus.UPLOADING);
+        }
+        transitionTo(UploadStatus.UPLOADING);
+    }
+
+    private void transitionTo(UploadStatus next) {
+        if (!status.canTransitionTo(next)) {
+            throw new IllegalUploadStatusException(status, next);
+        }
+        status = next;
+    }
+
+    public void moveToFolder(Long folderId) {
+        this.folderId = folderId;
+    }
+
+    public void moveToRoot() {
+        this.folderId = null;
+    }
+
+    public boolean isInRoot() {
+        return folderId == null;
+    }
+
+    public boolean isUploadedBy(Long memberId) {
+        return uploaderId.equals(memberId);
+    }
+
+    public OptimizationPlan optimizationPlan() {
+        return MediaOptimizationStrategy.decide(mediaType, fileSize);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
+++ b/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
@@ -1,0 +1,28 @@
+package com.sssok.domain.file;
+
+import java.util.Set;
+
+public enum UploadStatus {
+
+    PENDING,
+    UPLOADING,
+    COMPLETED,
+    FAILED;
+
+    private static final Set<UploadStatus> FROM_PENDING = Set.of(UPLOADING, FAILED);
+    private static final Set<UploadStatus> FROM_UPLOADING = Set.of(COMPLETED, FAILED);
+    private static final Set<UploadStatus> FROM_FAILED = Set.of(UPLOADING);
+
+    public boolean canTransitionTo(UploadStatus next) {
+        return switch (this) {
+            case PENDING -> FROM_PENDING.contains(next);
+            case UPLOADING -> FROM_UPLOADING.contains(next);
+            case FAILED -> FROM_FAILED.contains(next);
+            case COMPLETED -> false;
+        };
+    }
+
+    public boolean isRetryable() {
+        return this == FAILED;
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/FileSizeExceededException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/FileSizeExceededException.java
@@ -1,0 +1,12 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.MediaType;
+
+public class FileSizeExceededException extends RuntimeException {
+
+    public FileSizeExceededException(MediaType mediaType, FileSize fileSize) {
+        super("%s 파일은 최대 %d바이트까지 업로드할 수 있습니다. (요청: %d바이트)"
+                .formatted(mediaType.name(), mediaType.maxBytes(), fileSize.bytes()));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/IllegalUploadStatusException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/IllegalUploadStatusException.java
@@ -1,0 +1,10 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.domain.file.UploadStatus;
+
+public class IllegalUploadStatusException extends RuntimeException {
+
+    public IllegalUploadStatusException(UploadStatus current, UploadStatus next) {
+        super("업로드 상태를 %s 에서 %s 로 바꿀 수 없습니다.".formatted(current, next));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/InvalidFileSizeException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/InvalidFileSizeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.file.exception;
+
+public class InvalidFileSizeException extends RuntimeException {
+
+    public InvalidFileSizeException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/InvalidStorageKeyException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/InvalidStorageKeyException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.file.exception;
+
+public class InvalidStorageKeyException extends RuntimeException {
+
+    public InvalidStorageKeyException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/UnsupportedMediaTypeException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/UnsupportedMediaTypeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.file.exception;
+
+public class UnsupportedMediaTypeException extends RuntimeException {
+
+    public UnsupportedMediaTypeException(String value) {
+        super("지원하지 않는 파일 형식입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/folder/Folder.java
+++ b/backend/src/main/java/com/sssok/domain/folder/Folder.java
@@ -1,5 +1,36 @@
 package com.sssok.domain.folder;
 
-// 방 안에서 파일을 묶는 폴더.
+import lombok.Getter;
+
+// 방 안에서 파일을 묶는 폴더. 지금 요구사항은 폴더 안에 폴더가 없는 1depth 구조라,
+// 재귀 구조 없이 "존재한다는 사실"과 "이름"만 책임진다.
+// Room과는 서로 다른 애그리거트이며 roomId(ID)로만 참조한다.
+@Getter
 public class Folder {
+
+    private final Long id;
+    private final Long roomId;
+    private FolderName name;
+
+    private Folder(Long id, Long roomId, FolderName name) {
+        this.id = id;
+        this.roomId = roomId;
+        this.name = name;
+    }
+
+    public static Folder create(Long roomId, FolderName name) {
+        return new Folder(null, roomId, name);
+    }
+
+    public static Folder reconstruct(Long id, Long roomId, FolderName name) {
+        return new Folder(id, roomId, name);
+    }
+
+    public void rename(FolderName newName) {
+        this.name = newName;
+    }
+
+    public boolean belongsTo(Long roomId) {
+        return this.roomId.equals(roomId);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/folder/FolderName.java
+++ b/backend/src/main/java/com/sssok/domain/folder/FolderName.java
@@ -1,5 +1,17 @@
 package com.sssok.domain.folder;
 
+import com.sssok.domain.folder.exception.InvalidFolderNameException;
 // 폴더 이름 값 객체.
-public class FolderName {
+public record FolderName(String value) {
+
+    private static final int MAX_LENGTH = 20;
+
+    public FolderName {
+        if (value == null || value.isBlank()) {
+            throw new InvalidFolderNameException(value);
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new InvalidFolderNameException(value);
+        }
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/folder/exception/InvalidFolderNameException.java
+++ b/backend/src/main/java/com/sssok/domain/folder/exception/InvalidFolderNameException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.folder.exception;
+
+public class InvalidFolderNameException extends RuntimeException {
+
+    public InvalidFolderNameException(String value) {
+        super("올바르지 않은 폴더 이름입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/member/Member.java
+++ b/backend/src/main/java/com/sssok/domain/member/Member.java
@@ -1,5 +1,32 @@
 package com.sssok.domain.member;
 
-// 방에 참여한 참여자.
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
 public class Member {
+
+    private final Long id;
+    private final Long roomId;
+    private final Nickname displayName;
+    private final Instant joinedAt;
+
+    private Member(Long id, Long roomId, Nickname displayName, Instant joinedAt) {
+        this.id = id;
+        this.roomId = roomId;
+        this.displayName = displayName;
+        this.joinedAt = joinedAt;
+    }
+
+    public static Member join(Long roomId, Nickname displayName, Instant now) {
+        return new Member(null, roomId, displayName, now);
+    }
+
+    public static Member reconstruct(Long id, Long roomId, Nickname displayName, Instant joinedAt) {
+        return new Member(id, roomId, displayName, joinedAt);
+    }
+
+    public boolean isSame(Long memberId) {
+        return id != null && id.equals(memberId);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/member/MemberRole.java
+++ b/backend/src/main/java/com/sssok/domain/member/MemberRole.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.member;
-
-// 참여자 역할(방장/게스트).
-public enum MemberRole {
-}

--- a/backend/src/main/java/com/sssok/domain/member/Nickname.java
+++ b/backend/src/main/java/com/sssok/domain/member/Nickname.java
@@ -1,5 +1,20 @@
 package com.sssok.domain.member;
 
-// 참여자 닉네임 값 객체.
-public class Nickname {
+import com.sssok.domain.member.exception.InvalidNicknameException;
+
+public record Nickname(String value) {
+
+    private static final int MIN_LENGTH = 1;
+    private static final int MAX_LENGTH = 12;
+
+    public Nickname {
+        if (value == null) {
+            throw new InvalidNicknameException("닉네임은 필수입니다.");
+        }
+        value = value.trim();
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new InvalidNicknameException(
+                    "닉네임은 %d자 이상 %d자 이하여야 합니다.".formatted(MIN_LENGTH, MAX_LENGTH));
+        }
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/member/exception/InvalidNicknameException.java
+++ b/backend/src/main/java/com/sssok/domain/member/exception/InvalidNicknameException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.member.exception;
+
+public class InvalidNicknameException extends RuntimeException {
+
+    public InvalidNicknameException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/Expiration.java
+++ b/backend/src/main/java/com/sssok/domain/room/Expiration.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.room;
-
-// 방 만료 시각을 담는 값 객체.
-public class Expiration {
-}

--- a/backend/src/main/java/com/sssok/domain/room/InvalidRoomCodeException.java
+++ b/backend/src/main/java/com/sssok/domain/room/InvalidRoomCodeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room;
+
+public class InvalidRoomCodeException extends RuntimeException {
+
+    public InvalidRoomCodeException(String value) {
+        super("올바르지 않은 방 코드 형식입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/Room.java
+++ b/backend/src/main/java/com/sssok/domain/room/Room.java
@@ -1,32 +1,116 @@
 package com.sssok.domain.room;
 
+import com.sssok.domain.room.exception.RoomHostRequiredException;
+import java.time.Duration;
 import java.time.Instant;
+
+import com.sssok.domain.room.roomstatus.RoomStatus;
 import lombok.Getter;
 
 // 방 애그리거트 루트. 코드, 상태, 만료, 업로드 권한을 관리한다.
-// 이 단계(#17)에서는 생성/조회에 필요한 최소 형태만 다루고, 나머지 규칙은 #24에서 확장한다.
 @Getter
 public class Room {
 
+    private static final Duration RETENTION_AFTER_DELETE = Duration.ofDays(30);
+
     private final Long id;
     private final RoomCode code;
-    private final RoomStatus status;
+    private RoomName name;
+    private RoomStatus status;
+    private RoomExpiration expiration;
+    private UploadPolicy uploadPolicy;
+    private final Long hostId;
     private final Instant createdAt;
+    private Instant deletedAt;
 
-    private Room(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
+    private Room(
+        Long id,
+        RoomCode code,
+        RoomName name,
+        RoomStatus status,
+        RoomExpiration expiration,
+        UploadPolicy uploadPolicy,
+        Long hostId,
+        Instant createdAt,
+        Instant deletedAt
+    ) {
         this.id = id;
         this.code = code;
+        this.name = name;
         this.status = status;
+        this.expiration = expiration;
+        this.uploadPolicy = uploadPolicy;
+        this.hostId = hostId;
         this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
     }
 
-    // 신규 생성 (아직 저장 전이라 id 없음)
-    public static Room create(RoomCode code, Instant now) {
-        return new Room(null, code, RoomStatus.ACTIVE, now);
+    // 신규 생성. 만료 시간은 생성 시점에 24시간 뒤로 고정하고, 업로드 권한은 ANYONE으로 시작한다.
+    // (방장이 이후 설정 변경으로 만료 시간을 늘릴 수 있는 여지는 updateSettings 에 남겨둔다.)
+    public static Room create(RoomCode code, RoomName name, Long hostId, Instant now) {
+        return new Room(null, code, name, RoomStatus.initial(),
+            RoomExpiration.defaultFrom(now), UploadPolicy.ANYONE, hostId, now, null);
     }
 
     // 저장소에서 불러온 값으로 복원
-    public static Room reconstruct(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
-        return new Room(id, code, status, createdAt);
+    public static Room reconstruct(
+        Long id,
+        RoomCode code,
+        RoomName name,
+        RoomStatus status,
+        RoomExpiration expiration,
+        UploadPolicy uploadPolicy,
+        Long hostId,
+        Instant createdAt,
+        Instant deletedAt
+    ) {
+        return new Room(id, code, name, status, expiration, uploadPolicy, hostId, createdAt, deletedAt);
+    }
+
+    public boolean isHost(Long memberId) {
+        return hostId.equals(memberId);
+    }
+
+    // 상태(ACTIVE)뿐 아니라 실제 만료 시각도 함께 본다 — 만료 배치가 아직
+    // 상태를 EXPIRED로 못 바꿨어도, 만료 시각이 지났으면 즉시 입장을 막는다.
+    public boolean canEnter(Instant now) {
+        return status.canEnter() && !expiration.isExpired(now);
+    }
+
+    public boolean canUpload(Long requester, Instant now) {
+        return canEnter(now) && status.canUpload(uploadPolicy, isHost(requester));
+    }
+
+    public void updateSettings(Long requester, RoomName newName, RoomExpiration newExpiration, UploadPolicy newUploadPolicy) {
+        requireHost(requester);
+        this.name = newName;
+        this.expiration = newExpiration;
+        this.uploadPolicy = newUploadPolicy;
+    }
+
+    public void delete(Long requester, Instant now) {
+        requireHost(requester);
+        this.status = status.toDeleted();
+        this.deletedAt = now;
+    }
+
+    // 만료 배치가 호출 — 만료 시각이 지난 ACTIVE 방을 EXPIRED로 전이시킨다.
+    public void expire() {
+        this.status = status.toExpired();
+    }
+
+    // 정리 배치가 호출 — 30일 지난 DELETED 방만 영구 삭제 대상.
+    public void purge() {
+        this.status = status.toPurged();
+    }
+
+    public boolean isPurgeable(Instant now) {
+        return deletedAt != null && !now.isBefore(deletedAt.plus(RETENTION_AFTER_DELETE));
+    }
+
+    private void requireHost(Long requester) {
+        if (!isHost(requester)) {
+            throw new RoomHostRequiredException();
+        }
     }
 }

--- a/backend/src/main/java/com/sssok/domain/room/Room.java
+++ b/backend/src/main/java/com/sssok/domain/room/Room.java
@@ -1,5 +1,32 @@
 package com.sssok.domain.room;
 
+import java.time.Instant;
+import lombok.Getter;
+
 // 방 애그리거트 루트. 코드, 상태, 만료, 업로드 권한을 관리한다.
+// 이 단계(#17)에서는 생성/조회에 필요한 최소 형태만 다루고, 나머지 규칙은 #24에서 확장한다.
+@Getter
 public class Room {
+
+    private final Long id;
+    private final RoomCode code;
+    private final RoomStatus status;
+    private final Instant createdAt;
+
+    private Room(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
+        this.id = id;
+        this.code = code;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    // 신규 생성 (아직 저장 전이라 id 없음)
+    public static Room create(RoomCode code, Instant now) {
+        return new Room(null, code, RoomStatus.ACTIVE, now);
+    }
+
+    // 저장소에서 불러온 값으로 복원
+    public static Room reconstruct(Long id, RoomCode code, RoomStatus status, Instant createdAt) {
+        return new Room(id, code, status, createdAt);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/room/RoomCode.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomCode.java
@@ -1,5 +1,25 @@
 package com.sssok.domain.room;
 
+import java.util.random.RandomGenerator;
+
 // 방 참여에 쓰이는 8자리 코드 값 객체.
-public class RoomCode {
+public record RoomCode(String value) {
+
+    // 혼동하기 쉬운 0, 1, I, O 는 제외한다 (QR·구두 전달 시 헷갈림 방지).
+    private static final String ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+    private static final int LENGTH = 8;
+
+    public RoomCode {
+        if (value == null || !value.matches("[" + ALPHABET + "]{" + LENGTH + "}")) {
+            throw new InvalidRoomCodeException(value);
+        }
+    }
+
+    public static RoomCode generate(RandomGenerator random) {
+        StringBuilder builder = new StringBuilder(LENGTH);
+        for (int i = 0; i < LENGTH; i++) {
+            builder.append(ALPHABET.charAt(random.nextInt(ALPHABET.length())));
+        }
+        return new RoomCode(builder.toString());
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/room/RoomCode.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomCode.java
@@ -1,5 +1,6 @@
 package com.sssok.domain.room;
 
+import com.sssok.domain.room.exception.InvalidRoomCodeException;
 import java.util.random.RandomGenerator;
 
 // 방 참여에 쓰이는 8자리 코드 값 객체.

--- a/backend/src/main/java/com/sssok/domain/room/RoomExpiration.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomExpiration.java
@@ -1,0 +1,27 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomExpirationException;
+import java.time.Duration;
+import java.time.Instant;
+
+// 방 만료 시각을 담는 값 객체.
+// 기획상 만료 시간은 생성 시 24시간으로 고정되지만, 방장이 설정 변경으로 늘릴 수 있는 여지를 둔다.
+public record RoomExpiration(Instant expiresAt) {
+
+    private static final Duration DEFAULT_DURATION = Duration.ofHours(24);
+
+    public RoomExpiration {
+        if (expiresAt == null) {
+            throw new InvalidRoomExpirationException(null);
+        }
+    }
+
+    // 방 생성 시 기본 만료 시각 (지금부터 24시간 뒤)
+    public static RoomExpiration defaultFrom(Instant now) {
+        return new RoomExpiration(now.plus(DEFAULT_DURATION));
+    }
+
+    public boolean isExpired(Instant now) {
+        return !now.isBefore(expiresAt);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/RoomName.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomName.java
@@ -1,0 +1,17 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomNameException;
+// 방 이름 값 객체.
+public record RoomName(String value) {
+
+    private static final int MAX_LENGTH = 30;
+
+    public RoomName {
+        if (value == null || value.isBlank()) {
+            throw new InvalidRoomNameException(value);
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new InvalidRoomNameException(value);
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/RoomPermissionPolicy.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomPermissionPolicy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.room;
+
+import java.time.Instant;
+
+// 방 설정 변경/삭제/업로드 권한 판정을 한곳에 모은 정책 객체.
+// 전부 Room.hostId 비교로 판별되므로 Member 객체를 몰라도 된다.
+public class RoomPermissionPolicy {
+
+    public boolean canChangeSettings(Room room, Long requesterId) {
+        return room.isHost(requesterId);
+    }
+
+    public boolean canDeleteRoom(Room room, Long requesterId) {
+        return room.isHost(requesterId);
+    }
+
+    public boolean canUploadTo(Room room, Long requesterId, Instant now) {
+        return room.canUpload(requesterId, now);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
@@ -1,5 +1,7 @@
 package com.sssok.domain.room;
 
 // 방의 생명주기 상태(활성/만료/삭제/영구삭제).
+// 이 단계(#17)에서는 생성 직후 상태만 다루고, 전체 전이 규칙은 #24에서 확장한다.
 public enum RoomStatus {
+    ACTIVE
 }

--- a/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/RoomStatus.java
@@ -1,7 +1,0 @@
-package com.sssok.domain.room;
-
-// 방의 생명주기 상태(활성/만료/삭제/영구삭제).
-// 이 단계(#17)에서는 생성 직후 상태만 다루고, 전체 전이 규칙은 #24에서 확장한다.
-public enum RoomStatus {
-    ACTIVE
-}

--- a/backend/src/main/java/com/sssok/domain/room/UploadPermission.java
+++ b/backend/src/main/java/com/sssok/domain/room/UploadPermission.java
@@ -1,5 +1,0 @@
-package com.sssok.domain.room;
-
-// 방에서 누가 파일을 올릴 수 있는지 나타내는 권한.
-public enum UploadPermission {
-}

--- a/backend/src/main/java/com/sssok/domain/room/UploadPolicy.java
+++ b/backend/src/main/java/com/sssok/domain/room/UploadPolicy.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.room;
+
+// 방에서 누가 파일을 올릴 수 있는지 나타내는 권한.
+public enum UploadPolicy {
+
+    ANYONE {
+        @Override
+        public boolean allows(boolean requesterIsHost) {
+            return true;
+        }
+    },
+    HOST_ONLY {
+        @Override
+        public boolean allows(boolean requesterIsHost) {
+            return requesterIsHost;
+        }
+    };
+
+    public abstract boolean allows(boolean requesterIsHost);
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/IllegalRoomStatusTransitionException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/IllegalRoomStatusTransitionException.java
@@ -1,0 +1,10 @@
+package com.sssok.domain.room.exception;
+
+import com.sssok.domain.room.roomstatus.RoomStatus;
+
+public class IllegalRoomStatusTransitionException extends RuntimeException {
+
+    public IllegalRoomStatusTransitionException(RoomStatus from, String to) {
+        super("허용되지 않는 상태 전이입니다: " + from.name() + " -> " + to);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomCodeException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomCodeException.java
@@ -1,4 +1,4 @@
-package com.sssok.domain.room;
+package com.sssok.domain.room.exception;
 
 public class InvalidRoomCodeException extends RuntimeException {
 

--- a/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomExpirationException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomExpirationException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room.exception;
+
+public class InvalidRoomExpirationException extends RuntimeException {
+
+    public InvalidRoomExpirationException(Object value) {
+        super("올바르지 않은 방 만료 시각입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomNameException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/InvalidRoomNameException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room.exception;
+
+public class InvalidRoomNameException extends RuntimeException {
+
+    public InvalidRoomNameException(String value) {
+        super("올바르지 않은 방 이름입니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/exception/RoomHostRequiredException.java
+++ b/backend/src/main/java/com/sssok/domain/room/exception/RoomHostRequiredException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.room.exception;
+
+public class RoomHostRequiredException extends RuntimeException {
+
+    public RoomHostRequiredException() {
+        super("방장만 수행할 수 있는 작업입니다.");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/ActiveRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/ActiveRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 활성 상태 — 입장·업로드 가능, 만료·삭제로만 전이할 수 있다.
+public final class ActiveRoomStatus implements RoomStatus {
+
+    public static final ActiveRoomStatus INSTANCE = new ActiveRoomStatus();
+
+    private ActiveRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "ACTIVE";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return true;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return uploadPolicy.allows(requesterIsHost);
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        return ExpiredRoomStatus.INSTANCE;
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        return DeletedRoomStatus.INSTANCE;
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        throw new IllegalRoomStatusTransitionException(this, "PURGED");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/DeletedRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/DeletedRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 소프트 삭제 상태 — 30일 보관 기간 동안 머무는 상태. 영구 삭제로만 전이할 수 있다.
+public final class DeletedRoomStatus implements RoomStatus {
+
+    public static final DeletedRoomStatus INSTANCE = new DeletedRoomStatus();
+
+    private DeletedRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "DELETED";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return false;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return false;
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        throw new IllegalRoomStatusTransitionException(this, "EXPIRED");
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        throw new IllegalRoomStatusTransitionException(this, "DELETED");
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        return PurgedRoomStatus.INSTANCE;
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/ExpiredRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/ExpiredRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 만료 상태 — 입장·업로드 불가, 데이터는 아직 존재. 삭제로만 전이할 수 있다.
+public final class ExpiredRoomStatus implements RoomStatus {
+
+    public static final ExpiredRoomStatus INSTANCE = new ExpiredRoomStatus();
+
+    private ExpiredRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "EXPIRED";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return false;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return false;
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        throw new IllegalRoomStatusTransitionException(this, "EXPIRED");
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        return DeletedRoomStatus.INSTANCE;
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        throw new IllegalRoomStatusTransitionException(this, "PURGED");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/PurgedRoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/PurgedRoomStatus.java
@@ -1,0 +1,42 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+// 영구 삭제 완료 상태 — 종단 상태, 더 이상 전이할 수 없다.
+public final class PurgedRoomStatus implements RoomStatus {
+
+    public static final PurgedRoomStatus INSTANCE = new PurgedRoomStatus();
+
+    private PurgedRoomStatus() {
+    }
+
+    @Override
+    public String name() {
+        return "PURGED";
+    }
+
+    @Override
+    public boolean canEnter() {
+        return false;
+    }
+
+    @Override
+    public boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost) {
+        return false;
+    }
+
+    @Override
+    public RoomStatus toExpired() {
+        throw new IllegalRoomStatusTransitionException(this, "EXPIRED");
+    }
+
+    @Override
+    public RoomStatus toDeleted() {
+        throw new IllegalRoomStatusTransitionException(this, "DELETED");
+    }
+
+    @Override
+    public RoomStatus toPurged() {
+        throw new IllegalRoomStatusTransitionException(this, "PURGED");
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/room/roomstatus/RoomStatus.java
+++ b/backend/src/main/java/com/sssok/domain/room/roomstatus/RoomStatus.java
@@ -1,0 +1,35 @@
+package com.sssok.domain.room.roomstatus;
+
+import com.sssok.domain.room.UploadPolicy;
+
+// 방의 생명주기 상태 (GoF 상태 패턴).
+// 각 구현체는 자기가 허용하는 전이만 정의하고, 그 외의 전이를 시도하면 예외를 던진다.
+// 상태별 인스턴스는 하나씩만 존재한다 (싱글톤) — Room 여러 개가 같은 ACTIVE 상태 객체를 공유한다.
+public interface RoomStatus {
+
+    String name();
+
+    boolean canEnter();
+
+    boolean canUpload(UploadPolicy uploadPolicy, boolean requesterIsHost);
+
+    RoomStatus toExpired();
+
+    RoomStatus toDeleted();
+
+    RoomStatus toPurged();
+
+    static RoomStatus initial() {
+        return ActiveRoomStatus.INSTANCE;
+    }
+
+    static RoomStatus from(String name) {
+        return switch (name) {
+            case "ACTIVE" -> ActiveRoomStatus.INSTANCE;
+            case "EXPIRED" -> ExpiredRoomStatus.INSTANCE;
+            case "DELETED" -> DeletedRoomStatus.INSTANCE;
+            case "PURGED" -> PurgedRoomStatus.INSTANCE;
+            default -> throw new IllegalArgumentException("알 수 없는 방 상태입니다: " + name);
+        };
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.sssok.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openApi() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("sssOK API")
+                .description("링크 하나로 여는 단발성 이미지·영상 공유 공간, sssOK의 백엔드 API 명세")
+                .version("v0.0.1")
+                .contact(new Contact()
+                    .name("sssOK Backend")
+                    .url("https://github.com/woowacourse-teams/2026-sssOK")));
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
@@ -1,0 +1,39 @@
+package com.sssok.infrastructure.persistence.room;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 8)
+    private String code;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public RoomJpaEntity(Long id, String code, String status, Instant createdAt) {
+        this.id = id;
+        this.code = code;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
@@ -24,16 +24,46 @@ public class RoomJpaEntity {
     @Column(nullable = false, unique = true, length = 8)
     private String code;
 
+    @Column(nullable = false, length = 30)
+    private String name;
+
     @Column(nullable = false, length = 20)
     private String status;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "upload_policy", nullable = false, length = 20)
+    private String uploadPolicy;
+
+    @Column(name = "host_id", nullable = false)
+    private Long hostId;
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    public RoomJpaEntity(Long id, String code, String status, Instant createdAt) {
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    public RoomJpaEntity(
+        Long id,
+        String code,
+        String name,
+        String status,
+        Instant expiresAt,
+        String uploadPolicy,
+        Long hostId,
+        Instant createdAt,
+        Instant deletedAt
+    ) {
         this.id = id;
         this.code = code;
+        this.name = name;
         this.status = status;
+        this.expiresAt = expiresAt;
+        this.uploadPolicy = uploadPolicy;
+        this.hostId = hostId;
         this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaRepository.java
@@ -1,0 +1,9 @@
+package com.sssok.infrastructure.persistence.room;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long> {
+
+    Optional<RoomJpaEntity> findByCode(String code);
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
@@ -3,7 +3,10 @@ package com.sssok.infrastructure.persistence.room;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
-import com.sssok.domain.room.RoomStatus;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import com.sssok.domain.room.UploadPolicy;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -29,8 +32,13 @@ public class RoomRepositoryAdapter implements RoomRepository {
         return new RoomJpaEntity(
             room.getId(),
             room.getCode().value(),
+            room.getName().value(),
             room.getStatus().name(),
-            room.getCreatedAt()
+            room.getExpiration().expiresAt(),
+            room.getUploadPolicy().name(),
+            room.getHostId(),
+            room.getCreatedAt(),
+            room.getDeletedAt()
         );
     }
 
@@ -38,8 +46,13 @@ public class RoomRepositoryAdapter implements RoomRepository {
         return Room.reconstruct(
             entity.getId(),
             new RoomCode(entity.getCode()),
-            RoomStatus.valueOf(entity.getStatus()),
-            entity.getCreatedAt()
+            new RoomName(entity.getName()),
+            RoomStatus.from(entity.getStatus()),
+            new RoomExpiration(entity.getExpiresAt()),
+            UploadPolicy.valueOf(entity.getUploadPolicy()),
+            entity.getHostId(),
+            entity.getCreatedAt(),
+            entity.getDeletedAt()
         );
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
@@ -1,0 +1,45 @@
+package com.sssok.infrastructure.persistence.room;
+
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomStatus;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomRepositoryAdapter implements RoomRepository {
+
+    private final RoomJpaRepository jpaRepository;
+
+    @Override
+    public Room save(Room room) {
+        RoomJpaEntity saved = jpaRepository.save(toEntity(room));
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<Room> findByCode(RoomCode code) {
+        return jpaRepository.findByCode(code.value()).map(this::toDomain);
+    }
+
+    private RoomJpaEntity toEntity(Room room) {
+        return new RoomJpaEntity(
+            room.getId(),
+            room.getCode().value(),
+            room.getStatus().name(),
+            room.getCreatedAt()
+        );
+    }
+
+    private Room toDomain(RoomJpaEntity entity) {
+        return Room.reconstruct(
+            entity.getId(),
+            new RoomCode(entity.getCode()),
+            RoomStatus.valueOf(entity.getStatus()),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomRepositoryAdapter.java
@@ -28,6 +28,11 @@ public class RoomRepositoryAdapter implements RoomRepository {
         return jpaRepository.findByCode(code.value()).map(this::toDomain);
     }
 
+    @Override
+    public Optional<Room> findById(Long id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
     private RoomJpaEntity toEntity(Room room) {
         return new RoomJpaEntity(
             room.getId(),

--- a/backend/src/main/java/com/sssok/infrastructure/room/RoomPermissionPortAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/room/RoomPermissionPortAdapter.java
@@ -1,0 +1,52 @@
+package com.sssok.infrastructure.room;
+
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.room.exception.RoomNotFoundException;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomPermissionPolicy;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomPermissionPortAdapter implements RoomPermissionPort {
+
+    private final RoomRepository roomRepository;
+
+    private final RoomPermissionPolicy permissionPolicy = new RoomPermissionPolicy();
+
+    @Override
+    public boolean isHost(Long roomId, Long memberId) {
+        return findRoom(roomId)
+                .map(room -> room.isHost(memberId))
+                .orElse(false);
+    }
+
+    @Override
+    public boolean canUpload(Long roomId, Long memberId) {
+        return findRoom(roomId)
+                .map(room -> permissionPolicy.canUploadTo(room, memberId, Instant.now()))
+                .orElse(false);
+    }
+
+    @Override
+    public boolean isRoomUsable(Long roomId) {
+        return findRoom(roomId)
+                .map(room -> room.canEnter(Instant.now()))
+                .orElse(false);
+    }
+
+    @Override
+    public String getRoomCode(Long roomId) {
+        return findRoom(roomId)
+                .map(room -> room.getCode().value())
+                .orElseThrow(() -> new RoomNotFoundException(roomId));
+    }
+
+    private Optional<Room> findRoom(Long roomId) {
+        return roomRepository.findById(roomId);
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/ApiResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/ApiResponse.java
@@ -1,0 +1,8 @@
+package com.sssok.presentation.api.common;
+
+public record ApiResponse<T>(T data) {
+
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data);
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/ErrorResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.sssok.presentation.api.common;
+
+public record ErrorResponse(String code, String message) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.sssok.presentation.api.common;
+
+import com.sssok.application.room.RoomNotFoundException;
+import com.sssok.domain.room.InvalidRoomCodeException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RoomNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleRoomNotFound(RoomNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse("ROOM_NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRoomCodeException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRoomCode(InvalidRoomCodeException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("INVALID_ROOM_CODE", e.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.sssok.presentation.api.common;
 
-import com.sssok.application.room.RoomNotFoundException;
-import com.sssok.domain.room.InvalidRoomCodeException;
+import com.sssok.domain.room.exception.InvalidRoomNameException;
+import com.sssok.application.room.exception.RoomNotFoundException;
+import com.sssok.domain.room.exception.InvalidRoomCodeException;
+import com.sssok.domain.room.exception.RoomHostRequiredException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,5 +22,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidRoomCode(InvalidRoomCodeException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse("INVALID_ROOM_CODE", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRoomNameException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRoomName(InvalidRoomNameException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("INVALID_ROOM_NAME", e.getMessage()));
+    }
+
+    @ExceptionHandler(RoomHostRequiredException.class)
+    public ResponseEntity<ErrorResponse> handleRoomHostRequired(RoomHostRequiredException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(new ErrorResponse("ROOM_HOST_REQUIRED", e.getMessage()));
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/room/CreateRoomRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/CreateRoomRequest.java
@@ -1,0 +1,5 @@
+package com.sssok.presentation.api.room;
+
+// 형식 검증(필수값 여부 등)은 RoomName 값 객체가 담당한다 (도메인 규칙을 한곳에 모아둠).
+public record CreateRoomRequest(String name) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
@@ -1,0 +1,37 @@
+package com.sssok.presentation.api.room;
+
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.application.room.GetRoomService;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.presentation.api.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final CreateRoomService createRoomService;
+    private final GetRoomService getRoomService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom() {
+        Room room = createRoomService.create();
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.of(RoomResponse.from(room)));
+    }
+
+    @GetMapping("/{code}")
+    public ApiResponse<RoomResponse> getRoom(@PathVariable String code) {
+        Room room = getRoomService.getByCode(new RoomCode(code));
+        return ApiResponse.of(RoomResponse.from(room));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,8 +24,8 @@ public class RoomController {
     private final GetRoomService getRoomService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<RoomResponse>> createRoom() {
-        Room room = createRoomService.create();
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom(@RequestBody CreateRoomRequest request) {
+        Room room = createRoomService.create(request.name());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(RoomResponse.from(room)));
     }

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
@@ -1,0 +1,11 @@
+package com.sssok.presentation.api.room;
+
+import com.sssok.domain.room.Room;
+import java.time.Instant;
+
+public record RoomResponse(String code, String status, Instant createdAt) {
+
+    public static RoomResponse from(Room room) {
+        return new RoomResponse(room.getCode().value(), room.getStatus().name(), room.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomResponse.java
@@ -3,9 +3,14 @@ package com.sssok.presentation.api.room;
 import com.sssok.domain.room.Room;
 import java.time.Instant;
 
-public record RoomResponse(String code, String status, Instant createdAt) {
+public record RoomResponse(String code, String name, String status, Instant createdAt) {
 
     public static RoomResponse from(Room room) {
-        return new RoomResponse(room.getCode().value(), room.getStatus().name(), room.getCreatedAt());
+        return new RoomResponse(
+            room.getCode().value(),
+            room.getName().value(),
+            room.getStatus().name(),
+            room.getCreatedAt()
+        );
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,3 +48,8 @@ media:
   resize-target-width: 1600
   # GIF는 애니메이션이 깨지므로 리사이즈/압축 대상에서 제외한다
   skip-formats: gif
+
+springdoc:
+  swagger-ui:
+    operations-sorter: method
+    tags-sorter: alpha

--- a/backend/src/main/resources/db/migration/V1__create_room.sql
+++ b/backend/src/main/resources/db/migration/V1__create_room.sql
@@ -1,0 +1,6 @@
+CREATE TABLE room (
+    id         BIGSERIAL PRIMARY KEY,
+    code       VARCHAR(8) NOT NULL UNIQUE,
+    status     VARCHAR(20) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);

--- a/backend/src/main/resources/db/migration/V2__add_room_details.sql
+++ b/backend/src/main/resources/db/migration/V2__add_room_details.sql
@@ -1,0 +1,14 @@
+-- #24 Room 도메인 확장(이름/만료/업로드권한/방장/삭제시각)에 맞춰 컬럼을 추가한다.
+-- V1은 이미 적용된 마이그레이션이라 수정하지 않고 새 버전으로 쌓는다.
+ALTER TABLE room
+    ADD COLUMN name          VARCHAR(30)  NOT NULL DEFAULT '',
+    ADD COLUMN expires_at    TIMESTAMPTZ  NOT NULL DEFAULT (now() + interval '24 hours'),
+    ADD COLUMN upload_policy VARCHAR(20)  NOT NULL DEFAULT 'ANYONE',
+    ADD COLUMN host_id       BIGINT       NOT NULL DEFAULT 0,
+    ADD COLUMN deleted_at    TIMESTAMPTZ;
+
+-- 기본값은 기존 행을 채우기 위한 것일 뿐, 이후로는 애플리케이션이 항상 값을 채운다.
+ALTER TABLE room ALTER COLUMN name DROP DEFAULT;
+ALTER TABLE room ALTER COLUMN expires_at DROP DEFAULT;
+ALTER TABLE room ALTER COLUMN upload_policy DROP DEFAULT;
+ALTER TABLE room ALTER COLUMN host_id DROP DEFAULT;

--- a/backend/src/test/java/com/sssok/domain/file/DownloadFileNamesTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/DownloadFileNamesTest.java
@@ -1,0 +1,60 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DownloadFileNamesTest {
+
+    @Test
+    void zip_파일명은_방코드를_포함한다() {
+        assertThat(DownloadFileNames.zipNameOf("A3F9K2M7")).isEqualTo("ShareDrop_A3F9K2M7.zip");
+    }
+
+    @Test
+    void 겹치지_않으면_원본_파일명을_그대로_유지한다() {
+        List<String> names = DownloadFileNames.deduplicate(List.of("cat.jpg", "dog.png"));
+
+        assertThat(names).containsExactly("cat.jpg", "dog.png");
+    }
+
+    @Test
+    void 이름이_겹치면_번호를_붙인다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("cat.jpg", "cat.jpg", "cat.jpg"));
+
+        assertThat(names).containsExactly("cat.jpg", "cat (1).jpg", "cat (2).jpg");
+    }
+
+    @Test
+    void 확장자가_없어도_번호를_붙일_수_있다() {
+        List<String> names = DownloadFileNames.deduplicate(List.of("사진", "사진"));
+
+        assertThat(names).containsExactly("사진", "사진 (1)");
+    }
+
+    @Test
+    void 이름에_점이_여러_개면_마지막_확장자_앞에_번호가_붙는다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("2026.여름.png", "2026.여름.png"));
+
+        assertThat(names).containsExactly("2026.여름.png", "2026.여름 (1).png");
+    }
+
+    @Test
+    void 이미_번호가_붙은_이름이_섞여_있어도_겹치지_않는다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("cat.jpg", "cat (1).jpg", "cat.jpg"));
+
+        assertThat(names).containsExactly("cat.jpg", "cat (1).jpg", "cat (2).jpg");
+    }
+
+    @Test
+    void 서로_다른_이름은_각자_번호를_센다() {
+        List<String> names =
+            DownloadFileNames.deduplicate(List.of("cat.jpg", "dog.jpg", "cat.jpg", "dog.jpg"));
+
+        assertThat(names).containsExactly("cat.jpg", "dog.jpg", "cat (1).jpg", "dog (1).jpg");
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/FilePermissionPolicyTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/FilePermissionPolicyTest.java
@@ -1,0 +1,75 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FilePermissionPolicyTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
+    private static final Long ME = 100L;
+    private static final Long OTHER = 200L;
+
+    private static final boolean HOST = true;
+    private static final boolean NOT_HOST = false;
+
+    private static StoredFile fileOf(Long uploaderId) {
+        return StoredFile.beginUpload(1L, uploaderId, "cat.png", FileSize.ofMegabytes(1), null, NOW);
+    }
+
+    @Test
+    void 본인이_올린_파일은_본인이_삭제할_수_있다() {
+        StoredFile myFile = fileOf(ME);
+
+        assertThat(FilePermissionPolicy.canDelete(myFile, ME, NOT_HOST)).isTrue();
+    }
+
+    @Test
+    void 남이_올린_파일은_삭제할_수_없다() {
+        StoredFile othersFile = fileOf(OTHER);
+
+        assertThat(FilePermissionPolicy.canDelete(othersFile, ME, NOT_HOST)).isFalse();
+    }
+
+    @Test
+    void 방장은_남이_올린_파일도_삭제할_수_있다() {
+        StoredFile othersFile = fileOf(OTHER);
+
+        assertThat(FilePermissionPolicy.canDelete(othersFile, ME, HOST)).isTrue();
+    }
+
+    @Test
+    void 선택_삭제할_때_권한_없는_항목만_빼고_나머지는_처리한다() {
+        StoredFile mine = fileOf(ME);
+        StoredFile others = fileOf(OTHER);
+        StoredFile mineAgain = fileOf(ME);
+
+        List<StoredFile> deletable =
+            FilePermissionPolicy.filterDeletable(List.of(mine, others, mineAgain), ME, NOT_HOST);
+
+        assertThat(deletable).containsExactly(mine, mineAgain);
+    }
+
+    @Test
+    void 방장이_선택_삭제하면_전부_대상이_된다() {
+        StoredFile mine = fileOf(ME);
+        StoredFile others = fileOf(OTHER);
+
+        List<StoredFile> deletable =
+            FilePermissionPolicy.filterDeletable(List.of(mine, others), ME, HOST);
+
+        assertThat(deletable).containsExactly(mine, others);
+    }
+
+    @Test
+    void 전부_권한이_없으면_빈_목록이_된다() {
+        StoredFile others = fileOf(OTHER);
+
+        List<StoredFile> deletable =
+            FilePermissionPolicy.filterDeletable(List.of(others), ME, NOT_HOST);
+
+        assertThat(deletable).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/FileSizeTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/FileSizeTest.java
@@ -1,0 +1,39 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.file.exception.InvalidFileSizeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FileSizeTest {
+
+    @Test
+    void 킬로바이트와_메가바이트로_만들_수_있다() {
+        assertThat(FileSize.ofKilobytes(1).bytes()).isEqualTo(1024);
+        assertThat(FileSize.ofMegabytes(1).bytes()).isEqualTo(1024 * 1024);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void 크기가_0_이하면_예외(long bytes) {
+        assertThatThrownBy(() -> new FileSize(bytes))
+            .isInstanceOf(InvalidFileSizeException.class);
+    }
+
+    @Test
+    void 상한_초과_여부를_판별한다() {
+        FileSize size = FileSize.ofMegabytes(11);
+
+        assertThat(size.exceeds(FileSize.ofMegabytes(10).bytes())).isTrue();
+        assertThat(size.exceeds(FileSize.ofMegabytes(11).bytes())).isFalse();
+    }
+
+    @Test
+    void 크기가_500KB_미만인지_판별한다() {
+        assertThat(FileSize.ofKilobytes(499).isBelowCompressionThreshold()).isTrue();
+        assertThat(FileSize.ofKilobytes(500).isBelowCompressionThreshold()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/MediaOptimizationStrategyTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/MediaOptimizationStrategyTest.java
@@ -1,0 +1,62 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sssok.domain.file.OptimizationPlan.OptimizationStep;
+import org.junit.jupiter.api.Test;
+
+class MediaOptimizationStrategyTest {
+
+    @Test
+    void 일반_이미지는_1600px_0_8_로_줄인_뒤_필요하면_1200px_0_7_로_재압축한다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.JPEG, FileSize.ofMegabytes(5));
+
+        assertThat(plan.skipped()).isFalse();
+        assertThat(plan.steps()).containsExactly(
+            new OptimizationStep(1600, 0.8),
+            new OptimizationStep(1200, 0.7)
+        );
+    }
+
+    @Test
+    void GIF_는_애니메이션_보존을_위해_압축하지_않는다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.GIF, FileSize.ofMegabytes(5));
+
+        assertThat(plan.skipped()).isTrue();
+        assertThat(plan.steps()).isEmpty();
+    }
+
+    @Test
+    void 크기가_500KB_미만인_원본은_압축하지_않는다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.JPEG, FileSize.ofKilobytes(499));
+
+        assertThat(plan.skipped()).isTrue();
+    }
+
+    @Test
+    void 크기가_정확히_500KB_이면_압축_대상이다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.JPEG, FileSize.ofKilobytes(500));
+
+        assertThat(plan.skipped()).isFalse();
+    }
+
+    @Test
+    void 영상은_리사이즈_대상이_아니다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.MP4, FileSize.ofMegabytes(100));
+
+        assertThat(plan.skipped()).isTrue();
+    }
+
+    @Test
+    void 계획의_단계_목록은_바꿀_수_없다() {
+        OptimizationPlan plan =
+            MediaOptimizationStrategy.decide(MediaType.PNG, FileSize.ofMegabytes(2));
+
+        assertThat(plan.steps()).isUnmodifiable();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/MediaTypeTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/MediaTypeTest.java
@@ -1,0 +1,77 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MediaTypeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "cat.jpg, JPEG",
+        "cat.jpeg, JPEG",
+        "cat.png, PNG",
+        "cat.gif, GIF",
+        "clip.mp4, MP4",
+        "clip.webm, WEBM",
+        "clip.mov, MOV",
+    })
+    void 파일명에서_형식을_판별한다(String fileName, MediaType expected) {
+        assertThat(MediaType.fromFileName(fileName)).isEqualTo(expected);
+    }
+
+    @Test
+    void 확장자_대소문자를_가리지_않는다() {
+        assertThat(MediaType.fromFileName("CAT.JPG")).isEqualTo(MediaType.JPEG);
+    }
+
+    @Test
+    void 이름에_점이_여러_개면_마지막_확장자를_쓴다() {
+        assertThat(MediaType.fromFileName("2026.여름.휴가.png")).isEqualTo(MediaType.PNG);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document.pdf",
+        "archive.zip",
+        "확장자없음",
+    })
+    void 지원하지_않는_형식이면_예외(String fileName) {
+        assertThatThrownBy(() -> MediaType.fromFileName(fileName))
+            .isInstanceOf(UnsupportedMediaTypeException.class);
+    }
+
+    @Test
+    void 파일명이_null_이면_예외() {
+        assertThatThrownBy(() -> MediaType.fromFileName(null))
+            .isInstanceOf(UnsupportedMediaTypeException.class);
+    }
+
+    @Test
+    void 이미지_상한은_10MB_다() {
+        assertThat(MediaType.JPEG.maxBytes()).isEqualTo(10L * 1024 * 1024);
+    }
+
+    @Test
+    void 영상_상한은_1GB_다() {
+        assertThat(MediaType.MP4.maxBytes()).isEqualTo(1024L * 1024 * 1024);
+    }
+
+    @Test
+    void GIF_만_애니메이션_보존_대상이다() {
+        assertThat(MediaType.GIF.preservesAnimation()).isTrue();
+        assertThat(MediaType.PNG.preservesAnimation()).isFalse();
+    }
+
+    @Test
+    void 이미지와_영상을_구분한다() {
+        assertThat(MediaType.PNG.isImage()).isTrue();
+        assertThat(MediaType.PNG.isVideo()).isFalse();
+        assertThat(MediaType.MP4.isVideo()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/StoredFileTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/StoredFileTest.java
@@ -1,0 +1,197 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import com.sssok.domain.file.exception.FileSizeExceededException;
+import com.sssok.domain.file.exception.IllegalUploadStatusException;
+import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class StoredFileTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
+    private static final Long ROOM_ID = 1L;
+    private static final Long UPLOADER_ID = 100L;
+
+    private static StoredFile beginUpload(String fileName, FileSize size, Long folderId) {
+        return StoredFile.beginUpload(ROOM_ID, UPLOADER_ID, fileName, size, folderId, NOW);
+    }
+
+    private static StoredFile uploading() {
+        StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+        file.startUploading();
+        return file;
+    }
+
+    @Nested
+    class 업로드_시작 {
+
+        @Test
+        void 대기_상태로_시작하고_스토리지_키가_발급된다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.PENDING);
+            assertThat(file.getMediaType()).isEqualTo(MediaType.PNG);
+            assertThat(file.getStorageKey().value()).startsWith("rooms/1/").endsWith(".png");
+        }
+
+        @Test
+        void 같은_이름을_두_번_올려도_스토리지_키는_겹치지_않는다() {
+            StoredFile first = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+            StoredFile second = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThat(first.getStorageKey()).isNotEqualTo(second.getStorageKey());
+        }
+
+        @Test
+        void 폴더를_지정하지_않으면_루트에_저장된다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThat(file.isInRoot()).isTrue();
+        }
+
+        @Test
+        void 폴더를_지정하면_그_폴더로_저장된다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), 7L);
+
+            assertThat(file.getFolderId()).isEqualTo(7L);
+            assertThat(file.isInRoot()).isFalse();
+        }
+
+        @Test
+        void 이미지가_10MB_를_넘으면_예외() {
+            assertThatThrownBy(() ->
+                beginUpload("cat.png", FileSize.ofMegabytes(11), null))
+                .isInstanceOf(FileSizeExceededException.class);
+        }
+
+        @Test
+        void 영상은_1GB_까지_허용된다() {
+            StoredFile file = beginUpload("clip.mp4", FileSize.ofMegabytes(1024), null);
+
+            assertThat(file.getMediaType()).isEqualTo(MediaType.MP4);
+        }
+
+        @Test
+        void 영상이_1GB_를_넘으면_예외() {
+            assertThatThrownBy(() ->
+                beginUpload("clip.mp4", FileSize.ofMegabytes(1025), null))
+                .isInstanceOf(FileSizeExceededException.class);
+        }
+
+        @Test
+        void 지원하지_않는_형식이면_예외() {
+            assertThatThrownBy(() ->
+                beginUpload("report.pdf", FileSize.ofMegabytes(1), null))
+                .isInstanceOf(UnsupportedMediaTypeException.class);
+        }
+    }
+
+    @Nested
+    class 상태_전이 {
+
+        @Test
+        void 대기에서_업로드중을_거쳐_완료된다() {
+            StoredFile file = uploading();
+            file.completeUpload();
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.COMPLETED);
+        }
+
+        @Test
+        void 업로드에_실패할_수_있다() {
+            StoredFile file = uploading();
+            file.failUpload();
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.FAILED);
+        }
+
+        @Test
+        void 실패한_파일만_재시도할_수_있다() {
+            StoredFile file = uploading();
+            file.failUpload();
+
+            file.retryUpload();
+
+            assertThat(file.getStatus()).isEqualTo(UploadStatus.UPLOADING);
+        }
+
+        @Test
+        void 완료된_파일은_재시도할_수_없다() {
+            StoredFile file = uploading();
+            file.completeUpload();
+
+            assertThatThrownBy(file::retryUpload)
+                .isInstanceOf(IllegalUploadStatusException.class);
+        }
+
+        @Test
+        void 대기_상태에서_바로_완료할_수_없다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            assertThatThrownBy(file::completeUpload)
+                .isInstanceOf(IllegalUploadStatusException.class);
+        }
+
+        @Test
+        void 완료된_파일은_다시_실패할_수_없다() {
+            StoredFile file = uploading();
+            file.completeUpload();
+
+            assertThatThrownBy(file::failUpload)
+                .isInstanceOf(IllegalUploadStatusException.class);
+        }
+    }
+
+    @Nested
+    class 폴더_이동 {
+
+        @Test
+        void 기존_폴더로_이동할_수_있다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+            file.moveToFolder(7L);
+
+            assertThat(file.getFolderId()).isEqualTo(7L);
+        }
+
+        @Test
+        void 다른_폴더로_옮길_수_있다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), 7L);
+
+            file.moveToFolder(8L);
+
+            assertThat(file.getFolderId()).isEqualTo(8L);
+        }
+
+        @Test
+        void 폴더에서_꺼내면_루트로_간다() {
+            StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), 7L);
+
+            file.moveToRoot();
+
+            assertThat(file.isInRoot()).isTrue();
+        }
+    }
+
+    @Test
+    void 업로더_본인인지_판별할_수_있다() {
+        StoredFile file = beginUpload("cat.png", FileSize.ofMegabytes(1), null);
+
+        assertThat(file.isUploadedBy(UPLOADER_ID)).isTrue();
+        assertThat(file.isUploadedBy(999L)).isFalse();
+    }
+
+    @Test
+    void 자신의_최적화_계획을_알려준다() {
+        StoredFile gif = beginUpload("anim.gif", FileSize.ofMegabytes(5), null);
+        StoredFile png = beginUpload("cat.png", FileSize.ofMegabytes(5), null);
+
+        assertThat(gif.optimizationPlan().skipped()).isTrue();
+        assertThat(png.optimizationPlan().skipped()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/folder/FolderNameTest.java
+++ b/backend/src/test/java/com/sssok/domain/folder/FolderNameTest.java
@@ -1,0 +1,36 @@
+package com.sssok.domain.folder;
+
+import com.sssok.domain.folder.exception.InvalidFolderNameException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FolderNameTest {
+
+    @Test
+    void 정상적인_이름은_생성된다() {
+        FolderName name = new FolderName("맛집");
+
+        assertThat(name.value()).isEqualTo("맛집");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void 빈_문자열이거나_공백뿐이면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new FolderName(invalidValue))
+            .isInstanceOf(InvalidFolderNameException.class);
+    }
+
+    @Test
+    void 최대_길이를_넘으면_예외() {
+        String tooLong = "가".repeat(21);
+
+        assertThatThrownBy(() -> new FolderName(tooLong))
+            .isInstanceOf(InvalidFolderNameException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/folder/FolderTest.java
+++ b/backend/src/test/java/com/sssok/domain/folder/FolderTest.java
@@ -1,0 +1,34 @@
+package com.sssok.domain.folder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FolderTest {
+
+    @Test
+    void 방_ID와_이름으로_생성된다() {
+        Folder folder = Folder.create(1L, new FolderName("맛집"));
+
+        assertThat(folder.getRoomId()).isEqualTo(1L);
+        assertThat(folder.getName().value()).isEqualTo("맛집");
+        assertThat(folder.getId()).isNull();
+    }
+
+    @Test
+    void 이름을_바꿀_수_있다() {
+        Folder folder = Folder.create(1L, new FolderName("맛집"));
+
+        folder.rename(new FolderName("카페"));
+
+        assertThat(folder.getName().value()).isEqualTo("카페");
+    }
+
+    @Test
+    void 자신이_속한_방인지_확인할_수_있다() {
+        Folder folder = Folder.reconstruct(10L, 1L, new FolderName("맛집"));
+
+        assertThat(folder.belongsTo(1L)).isTrue();
+        assertThat(folder.belongsTo(2L)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/sssok/domain/member/MemberTest.java
@@ -1,0 +1,43 @@
+package com.sssok.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
+
+    @Test
+    void 최초_입장하면_아직_식별자가_없다() {
+        Member member = Member.join(1L, new Nickname("로지"), NOW);
+
+        assertThat(member.getId()).isNull();
+        assertThat(member.getRoomId()).isEqualTo(1L);
+        assertThat(member.getDisplayName().value()).isEqualTo("로지");
+        assertThat(member.getJoinedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void 저장된_값으로_복원할_수_있다() {
+        Member member = Member.reconstruct(10L, 1L, new Nickname("로지"), NOW);
+
+        assertThat(member.getId()).isEqualTo(10L);
+    }
+
+    @Test
+    void 같은_식별자인지_판별할_수_있다() {
+        Member member = Member.reconstruct(10L, 1L, new Nickname("로지"), NOW);
+
+        assertThat(member.isSame(10L)).isTrue();
+        assertThat(member.isSame(11L)).isFalse();
+    }
+
+    @Test
+    void 저장되지_않은_참여자는_어떤_식별자와도_같지_않다() {
+        Member member = Member.join(1L, new Nickname("로지"), NOW);
+
+        assertThat(member.isSame(10L)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/member/NicknameTest.java
+++ b/backend/src/test/java/com/sssok/domain/member/NicknameTest.java
@@ -1,0 +1,56 @@
+package com.sssok.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.member.exception.InvalidNicknameException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NicknameTest {
+
+    @Test
+    void 유효한_닉네임은_정상_생성된다() {
+        Nickname nickname = new Nickname("로지");
+        assertThat(nickname.value()).isEqualTo("로지");
+    }
+
+    @Test
+    void 앞뒤_공백은_제거된다() {
+        Nickname nickname = new Nickname("  로지  ");
+
+        assertThat(nickname.value()).isEqualTo("로지");
+    }
+
+    @Test
+    void 최대_길이인_12자는_허용된다() {
+        String twelveChars = "가".repeat(12);
+
+        assertThat(new Nickname(twelveChars).value()).hasSize(12);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        "   ",
+    })
+    void 비어있으면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new Nickname(invalidValue))
+            .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    void 길이_제한을_넘으면_예외() {
+        String thirteenChars = "가".repeat(13);
+
+        assertThatThrownBy(() -> new Nickname(thirteenChars))
+            .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    void null_이면_예외() {
+        assertThatThrownBy(() -> new Nickname(null))
+            .isInstanceOf(InvalidNicknameException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
@@ -1,0 +1,50 @@
+package com.sssok.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.SecureRandom;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RoomCodeTest {
+
+    private static final String VALID_CHARS_REGEX = "[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{8}";
+
+    @RepeatedTest(20)
+    void 생성된_코드는_8자리이고_혼동_문자를_포함하지_않는다() {
+        RoomCode code = RoomCode.generate(new SecureRandom());
+
+        assertThat(code.value()).matches(VALID_CHARS_REGEX);
+    }
+
+    @Test
+    void 유효한_형식의_코드는_정상_생성된다() {
+        RoomCode code = new RoomCode("23456789");
+
+        assertThat(code.value()).isEqualTo("23456789");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "1234567",      // 7자리 (길이 부족)
+        "123456789",    // 9자리 (길이 초과)
+        "ABCDEFG0",     // 혼동 문자 0 포함
+        "ABCDEFG1",     // 혼동 문자 1 포함
+        "ABCDEFGI",     // 혼동 문자 I 포함
+        "ABCDEFGO",     // 혼동 문자 O 포함
+        "abcdefgh",     // 소문자 불허
+    })
+    void 형식에_맞지_않으면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new RoomCode(invalidValue))
+            .isInstanceOf(InvalidRoomCodeException.class);
+    }
+
+    @Test
+    void null_값이면_예외() {
+        assertThatThrownBy(() -> new RoomCode(null))
+            .isInstanceOf(InvalidRoomCodeException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomCodeTest.java
@@ -1,5 +1,6 @@
 package com.sssok.domain.room;
 
+import com.sssok.domain.room.exception.InvalidRoomCodeException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/backend/src/test/java/com/sssok/domain/room/RoomExpirationTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomExpirationTest.java
@@ -1,0 +1,44 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomExpirationException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RoomExpirationTest {
+
+    @Test
+    void 기본_만료_시각은_생성_시점으로부터_24시간_뒤다() {
+        Instant now = Instant.parse("2026-08-13T00:00:00Z");
+
+        RoomExpiration expiration = RoomExpiration.defaultFrom(now);
+
+        assertThat(expiration.expiresAt()).isEqualTo(now.plus(Duration.ofHours(24)));
+    }
+
+    @Test
+    void 만료_시각_이전이면_만료가_아니다() {
+        Instant now = Instant.parse("2026-08-13T00:00:00Z");
+        RoomExpiration expiration = RoomExpiration.defaultFrom(now);
+
+        assertThat(expiration.isExpired(now.plus(Duration.ofHours(23)))).isFalse();
+    }
+
+    @Test
+    void 만료_시각과_같거나_지나면_만료다() {
+        Instant now = Instant.parse("2026-08-13T00:00:00Z");
+        RoomExpiration expiration = RoomExpiration.defaultFrom(now);
+
+        assertThat(expiration.isExpired(now.plus(Duration.ofHours(24)))).isTrue();
+        assertThat(expiration.isExpired(now.plus(Duration.ofHours(25)))).isTrue();
+    }
+
+    @Test
+    void 만료_시각이_null이면_예외() {
+        assertThatThrownBy(() -> new RoomExpiration(null))
+            .isInstanceOf(InvalidRoomExpirationException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomNameTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomNameTest.java
@@ -1,0 +1,43 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.InvalidRoomNameException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RoomNameTest {
+
+    @Test
+    void 정상적인_이름은_생성된다() {
+        RoomName name = new RoomName("우테코 회식");
+
+        assertThat(name.value()).isEqualTo("우테코 회식");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void 빈_문자열이거나_공백뿐이면_예외(String invalidValue) {
+        assertThatThrownBy(() -> new RoomName(invalidValue))
+            .isInstanceOf(InvalidRoomNameException.class);
+    }
+
+    @Test
+    void 최대_길이를_넘으면_예외() {
+        String tooLong = "가".repeat(31);
+
+        assertThatThrownBy(() -> new RoomName(tooLong))
+            .isInstanceOf(InvalidRoomNameException.class);
+    }
+
+    @Test
+    void 최대_길이까지는_허용된다() {
+        String exactly30 = "가".repeat(30);
+
+        assertThat(new RoomName(exactly30).value()).hasSize(30);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomPermissionPolicyTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomPermissionPolicyTest.java
@@ -1,0 +1,45 @@
+package com.sssok.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RoomPermissionPolicyTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T00:00:00Z");
+    private static final Long HOST = 1L;
+    private static final Long GUEST = 2L;
+
+    private final RoomPermissionPolicy policy = new RoomPermissionPolicy();
+
+    private Room createRoom() {
+        return Room.create(RoomCode.generate(new SecureRandom()), new RoomName("우테코 회식"), HOST, NOW);
+    }
+
+    @Test
+    void 설정_변경은_방장만_가능하다() {
+        Room room = createRoom();
+
+        assertThat(policy.canChangeSettings(room, HOST)).isTrue();
+        assertThat(policy.canChangeSettings(room, GUEST)).isFalse();
+    }
+
+    @Test
+    void 방_삭제는_방장만_가능하다() {
+        Room room = createRoom();
+
+        assertThat(policy.canDeleteRoom(room, HOST)).isTrue();
+        assertThat(policy.canDeleteRoom(room, GUEST)).isFalse();
+    }
+
+    @Test
+    void 업로드_권한은_Room의_규칙을_그대로_따른다() {
+        Room room = createRoom();
+        room.updateSettings(HOST, room.getName(), room.getExpiration(), UploadPolicy.HOST_ONLY);
+
+        assertThat(policy.canUploadTo(room, HOST, NOW)).isTrue();
+        assertThat(policy.canUploadTo(room, GUEST, NOW)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomStatusTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomStatusTest.java
@@ -1,0 +1,80 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.room.roomstatus.*;
+import org.junit.jupiter.api.Test;
+
+class RoomStatusTest {
+
+    @Test
+    void 초기_상태는_ACTIVE다() {
+        assertThat(RoomStatus.initial()).isSameAs(ActiveRoomStatus.INSTANCE);
+    }
+
+    @Test
+    void 같은_이름으로_찾은_상태는_항상_같은_인스턴스다_싱글톤() {
+        assertThat(RoomStatus.from("ACTIVE")).isSameAs(ActiveRoomStatus.INSTANCE);
+        assertThat(RoomStatus.from("ACTIVE")).isSameAs(RoomStatus.from("ACTIVE"));
+        assertThat(RoomStatus.from("EXPIRED")).isSameAs(ExpiredRoomStatus.INSTANCE);
+        assertThat(RoomStatus.from("DELETED")).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThat(RoomStatus.from("PURGED")).isSameAs(PurgedRoomStatus.INSTANCE);
+    }
+
+    @Test
+    void 알수없는_이름이면_예외() {
+        assertThatThrownBy(() -> RoomStatus.from("UNKNOWN"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void ACTIVE는_EXPIRED와_DELETED로만_전이할_수_있다() {
+        RoomStatus active = ActiveRoomStatus.INSTANCE;
+
+        assertThat(active.toExpired()).isSameAs(ExpiredRoomStatus.INSTANCE);
+        assertThat(active.toDeleted()).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThatThrownBy(active::toPurged).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void EXPIRED는_DELETED로만_전이할_수_있다() {
+        RoomStatus expired = ExpiredRoomStatus.INSTANCE;
+
+        assertThat(expired.toDeleted()).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThatThrownBy(expired::toExpired).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(expired::toPurged).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void DELETED는_PURGED로만_전이할_수_있다() {
+        RoomStatus deleted = DeletedRoomStatus.INSTANCE;
+
+        assertThat(deleted.toPurged()).isSameAs(PurgedRoomStatus.INSTANCE);
+        assertThatThrownBy(deleted::toExpired).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(deleted::toDeleted).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void PURGED는_종단_상태라_더_전이할_수_없다() {
+        RoomStatus purged = PurgedRoomStatus.INSTANCE;
+
+        assertThatThrownBy(purged::toExpired).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(purged::toDeleted).isInstanceOf(IllegalRoomStatusTransitionException.class);
+        assertThatThrownBy(purged::toPurged).isInstanceOf(IllegalRoomStatusTransitionException.class);
+    }
+
+    @Test
+    void ACTIVE만_입장_및_업로드가_가능하다() {
+        assertThat(ActiveRoomStatus.INSTANCE.canEnter()).isTrue();
+        assertThat(ExpiredRoomStatus.INSTANCE.canEnter()).isFalse();
+        assertThat(DeletedRoomStatus.INSTANCE.canEnter()).isFalse();
+        assertThat(PurgedRoomStatus.INSTANCE.canEnter()).isFalse();
+
+        assertThat(ActiveRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isTrue();
+        assertThat(ExpiredRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isFalse();
+        assertThat(DeletedRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isFalse();
+        assertThat(PurgedRoomStatus.INSTANCE.canUpload(UploadPolicy.ANYONE, false)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/RoomTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/RoomTest.java
@@ -1,0 +1,185 @@
+package com.sssok.domain.room;
+
+import com.sssok.domain.room.exception.RoomHostRequiredException;
+import com.sssok.domain.room.exception.IllegalRoomStatusTransitionException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+
+import com.sssok.domain.room.roomstatus.ActiveRoomStatus;
+import com.sssok.domain.room.roomstatus.DeletedRoomStatus;
+import com.sssok.domain.room.roomstatus.ExpiredRoomStatus;
+import com.sssok.domain.room.roomstatus.PurgedRoomStatus;
+import org.junit.jupiter.api.Test;
+
+class RoomTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-13T00:00:00Z");
+    private static final Long HOST = 1L;
+    private static final Long GUEST = 2L;
+
+    private Room createRoom() {
+        RoomCode code = RoomCode.generate(new SecureRandom());
+        return Room.create(code, new RoomName("우테코 회식"), HOST, NOW);
+    }
+
+    @Test
+    void 생성_직후엔_ACTIVE_상태이고_만료_시간은_24시간_뒤이며_업로드_권한은_ANYONE이다() {
+        Room room = createRoom();
+
+        assertThat(room.getStatus()).isSameAs(ActiveRoomStatus.INSTANCE);
+        assertThat(room.getExpiration().expiresAt()).isEqualTo(NOW.plus(Duration.ofHours(24)));
+        assertThat(room.getUploadPolicy()).isEqualTo(UploadPolicy.ANYONE);
+    }
+
+    @Test
+    void 방장_여부를_판별할_수_있다() {
+        Room room = createRoom();
+
+        assertThat(room.isHost(HOST)).isTrue();
+        assertThat(room.isHost(GUEST)).isFalse();
+    }
+
+    @Test
+    void ACTIVE_상태이고_만료_전이면_입장할_수_있다() {
+        Room room = createRoom();
+
+        assertThat(room.canEnter(NOW.plus(Duration.ofHours(1)))).isTrue();
+    }
+
+    @Test
+    void 만료_시각이_지나면_상태_전이와_무관하게_입장할_수_없다() {
+        Room room = createRoom();
+
+        // 배치가 아직 expire()를 호출하지 않아 상태는 여전히 ACTIVE 이지만,
+        // 실제 만료 시각은 지난 상황을 가정한다.
+        boolean canEnterAfterExpiry = room.canEnter(NOW.plus(Duration.ofHours(25)));
+
+        assertThat(room.getStatus()).isSameAs(ActiveRoomStatus.INSTANCE);
+        assertThat(canEnterAfterExpiry).isFalse();
+    }
+
+    @Test
+    void ANYONE_방은_방장도_게스트도_업로드할_수_있다() {
+        Room room = createRoom();
+        Instant soon = NOW.plus(Duration.ofMinutes(1));
+
+        assertThat(room.canUpload(HOST, soon)).isTrue();
+        assertThat(room.canUpload(GUEST, soon)).isTrue();
+    }
+
+    @Test
+    void HOST_ONLY_방은_방장만_업로드할_수_있다() {
+        Room room = createRoom();
+        Instant soon = NOW.plus(Duration.ofMinutes(1));
+        room.updateSettings(HOST, room.getName(), room.getExpiration(), UploadPolicy.HOST_ONLY);
+
+        assertThat(room.canUpload(HOST, soon)).isTrue();
+        assertThat(room.canUpload(GUEST, soon)).isFalse();
+    }
+
+    @Test
+    void 만료된_방은_업로드_권한과_무관하게_업로드할_수_없다() {
+        Room room = createRoom();
+        Instant afterExpiry = NOW.plus(Duration.ofHours(25));
+
+        assertThat(room.canUpload(HOST, afterExpiry)).isFalse();
+    }
+
+    @Test
+    void 방장만_설정을_변경할_수_있다() {
+        Room room = createRoom();
+        RoomName newName = new RoomName("2차 회식");
+
+        room.updateSettings(HOST, newName, room.getExpiration(), UploadPolicy.HOST_ONLY);
+
+        assertThat(room.getName()).isEqualTo(newName);
+        assertThat(room.getUploadPolicy()).isEqualTo(UploadPolicy.HOST_ONLY);
+    }
+
+    @Test
+    void 방장이_아니면_설정을_변경할_수_없다() {
+        Room room = createRoom();
+
+        assertThatThrownBy(() ->
+            room.updateSettings(GUEST, room.getName(), room.getExpiration(), UploadPolicy.HOST_ONLY)
+        ).isInstanceOf(RoomHostRequiredException.class);
+    }
+
+    @Test
+    void 방장은_설정_변경으로_만료_시간을_늘릴_수_있다() {
+        Room room = createRoom();
+        RoomExpiration extended = new RoomExpiration(NOW.plus(Duration.ofHours(48)));
+
+        room.updateSettings(HOST, room.getName(), extended, room.getUploadPolicy());
+
+        assertThat(room.getExpiration()).isEqualTo(extended);
+    }
+
+    @Test
+    void 방장만_방을_삭제할_수_있다() {
+        Room room = createRoom();
+
+        assertThatThrownBy(() -> room.delete(GUEST, NOW))
+            .isInstanceOf(RoomHostRequiredException.class);
+    }
+
+    @Test
+    void 방을_삭제하면_즉시_입장할_수_없고_DELETED_상태가_된다() {
+        Room room = createRoom();
+
+        room.delete(HOST, NOW.plus(Duration.ofMinutes(10)));
+
+        assertThat(room.getStatus()).isSameAs(DeletedRoomStatus.INSTANCE);
+        assertThat(room.canEnter(NOW.plus(Duration.ofMinutes(11)))).isFalse();
+    }
+
+    @Test
+    void 삭제_후_30일이_지나지_않으면_퍼지_대상이_아니다() {
+        Room room = createRoom();
+        Instant deletedAt = NOW;
+        room.delete(HOST, deletedAt);
+
+        assertThat(room.isPurgeable(deletedAt.plus(Duration.ofDays(29)))).isFalse();
+    }
+
+    @Test
+    void 삭제_후_30일이_지나면_퍼지_대상이다() {
+        Room room = createRoom();
+        Instant deletedAt = NOW;
+        room.delete(HOST, deletedAt);
+
+        assertThat(room.isPurgeable(deletedAt.plus(Duration.ofDays(30)))).isTrue();
+    }
+
+    @Test
+    void 삭제되지_않은_방은_퍼지_대상이_아니다() {
+        Room room = createRoom();
+
+        assertThat(room.isPurgeable(NOW.plus(Duration.ofDays(365)))).isFalse();
+    }
+
+    @Test
+    void expire_호출하면_EXPIRED_상태로_전이한다() {
+        Room room = createRoom();
+
+        room.expire();
+
+        assertThat(room.getStatus()).isSameAs(ExpiredRoomStatus.INSTANCE);
+    }
+
+    @Test
+    void purge는_DELETED_상태에서만_가능하다() {
+        Room room = createRoom();
+
+        assertThatThrownBy(room::purge).isInstanceOf(IllegalRoomStatusTransitionException.class);
+
+        room.delete(HOST, NOW);
+        room.purge();
+
+        assertThat(room.getStatus()).isSameAs(PurgedRoomStatus.INSTANCE);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/room/UploadPolicyTest.java
+++ b/backend/src/test/java/com/sssok/domain/room/UploadPolicyTest.java
@@ -1,0 +1,20 @@
+package com.sssok.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UploadPolicyTest {
+
+    @Test
+    void ANYONE은_누구나_업로드할_수_있다() {
+        assertThat(UploadPolicy.ANYONE.allows(true)).isTrue();
+        assertThat(UploadPolicy.ANYONE.allows(false)).isTrue();
+    }
+
+    @Test
+    void HOST_ONLY는_방장만_업로드할_수_있다() {
+        assertThat(UploadPolicy.HOST_ONLY.allows(true)).isTrue();
+        assertThat(UploadPolicy.HOST_ONLY.allows(false)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/sssok/infrastructure/room/RoomPermissionPortAdapterTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/room/RoomPermissionPortAdapterTest.java
@@ -1,0 +1,150 @@
+package com.sssok.infrastructure.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.room.exception.RoomNotFoundException;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoomPermissionPortAdapterTest {
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long HOST_ID = 100L;
+    private static final Long GUEST_ID = 200L;
+    private static final Long MISSING_ROOM_ID = 999L;
+
+    private FakeRoomRepository roomRepository;
+    private RoomPermissionPortAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        roomRepository = new FakeRoomRepository();
+        adapter = new RoomPermissionPortAdapter(roomRepository);
+    }
+
+    private Room roomWith(UploadPolicy uploadPolicy, Instant expiresAt) {
+        return Room.reconstruct(
+            ROOM_ID,
+            new RoomCode("A3F9K2M7"),
+            new RoomName("우테코 데모데이"),
+            RoomStatus.initial(),
+            new RoomExpiration(expiresAt),
+            uploadPolicy,
+            HOST_ID,
+            Instant.now().minusSeconds(60),
+            null
+        );
+    }
+
+    private void givenRoom(Room room) {
+        roomRepository.save(room);
+    }
+
+    private Instant farFuture() {
+        return Instant.now().plusSeconds(3600);
+    }
+
+    private Instant past() {
+        return Instant.now().minusSeconds(1);
+    }
+
+    @Test
+    void 방장이면_isHost_가_참이다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.isHost(ROOM_ID, HOST_ID)).isTrue();
+        assertThat(adapter.isHost(ROOM_ID, GUEST_ID)).isFalse();
+    }
+
+    @Test
+    void ANYONE_방에서는_누구나_업로드할_수_있다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.canUpload(ROOM_ID, GUEST_ID)).isTrue();
+    }
+
+    @Test
+    void HOST_ONLY_방에서는_방장만_업로드할_수_있다() {
+        givenRoom(roomWith(UploadPolicy.HOST_ONLY, farFuture()));
+
+        assertThat(adapter.canUpload(ROOM_ID, HOST_ID)).isTrue();
+        assertThat(adapter.canUpload(ROOM_ID, GUEST_ID)).isFalse();
+    }
+
+    @Test
+    void 만료된_방에는_방장도_업로드할_수_없다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, past()));
+
+        assertThat(adapter.canUpload(ROOM_ID, HOST_ID)).isFalse();
+    }
+
+    @Test
+    void 살아있는_방은_사용_가능하다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.isRoomUsable(ROOM_ID)).isTrue();
+    }
+
+    @Test
+    void 만료된_방은_사용할_수_없다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, past()));
+
+        assertThat(adapter.isRoomUsable(ROOM_ID)).isFalse();
+    }
+
+    @Test
+    void 방_코드를_조회할_수_있다() {
+        givenRoom(roomWith(UploadPolicy.ANYONE, farFuture()));
+
+        assertThat(adapter.getRoomCode(ROOM_ID)).isEqualTo("A3F9K2M7");
+    }
+
+    @Test
+    void 없는_방은_모든_판별이_거짓이다() {
+        assertThat(adapter.isHost(MISSING_ROOM_ID, HOST_ID)).isFalse();
+        assertThat(adapter.canUpload(MISSING_ROOM_ID, HOST_ID)).isFalse();
+        assertThat(adapter.isRoomUsable(MISSING_ROOM_ID)).isFalse();
+    }
+
+    @Test
+    void 없는_방의_코드를_조회하면_예외() {
+        assertThatThrownBy(() -> adapter.getRoomCode(MISSING_ROOM_ID))
+            .isInstanceOf(RoomNotFoundException.class);
+    }
+
+    // DB 없이 검증하기 위한 최소 구현
+    private static class FakeRoomRepository implements RoomRepository {
+
+        private final Map<Long, Room> rooms = new HashMap<>();
+
+        @Override
+        public Room save(Room room) {
+            rooms.put(room.getId(), room);
+            return room;
+        }
+
+        @Override
+        public Optional<Room> findByCode(RoomCode code) {
+            return rooms.values().stream()
+                .filter(room -> room.getCode().equals(code))
+                .findFirst();
+        }
+
+        @Override
+        public Optional<Room> findById(Long id) {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -39,9 +40,12 @@ class RoomApiTest {
 
     @Test
     void 방을_생성하고_코드로_조회한다() throws Exception {
-        MvcResult createResult = mockMvc.perform(post("/rooms"))
+        MvcResult createResult = mockMvc.perform(post("/rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"우테코 회식\"}"))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.code").value(matchesPattern("[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{8}")))
+            .andExpect(jsonPath("$.data.name").value("우테코 회식"))
             .andExpect(jsonPath("$.data.status").value("ACTIVE"))
             .andReturn();
 
@@ -51,7 +55,17 @@ class RoomApiTest {
         mockMvc.perform(get("/rooms/{code}", code))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.code").value(code))
+            .andExpect(jsonPath("$.data.name").value("우테코 회식"))
             .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void 이름_없이_생성하면_400() throws Exception {
+        mockMvc.perform(post("/rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_ROOM_NAME"));
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -1,0 +1,70 @@
+package com.sssok.presentation.api.room;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+// Room 생성 -> 코드로 조회까지 컨트롤러/서비스/리포지토리/Flyway 마이그레이션이
+// 실제 PostgreSQL 위에서 전부 맞물려 도는지 확인하는 관통 테스트 (Walking Skeleton).
+// Flyway가 만든 스키마와 엔티티 매핑이 실제로 맞는지까지 검증한다 (운영과 동일한 검증 모드).
+@SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+@AutoConfigureMockMvc
+@Testcontainers
+class RoomApiTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 방을_생성하고_코드로_조회한다() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/rooms"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.code").value(matchesPattern("[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{8}")))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+            .andReturn();
+
+        JsonNode created = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String code = created.get("data").get("code").asText();
+
+        mockMvc.perform(get("/rooms/{code}", code))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.code").value(code))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void 존재하지_않는_코드로_조회하면_404() throws Exception {
+        mockMvc.perform(get("/rooms/{code}", "23456789"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("ROOM_NOT_FOUND"));
+    }
+
+    @Test
+    void 형식이_잘못된_코드로_조회하면_400() throws Exception {
+        mockMvc.perform(get("/rooms/{code}", "invalid-code"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_ROOM_CODE"));
+    }
+}

--- a/backend/src/test/java/com/sssok/spike/R2PresignedUploadSpikeTest.java
+++ b/backend/src/test/java/com/sssok/spike/R2PresignedUploadSpikeTest.java
@@ -1,0 +1,224 @@
+package com.sssok.spike;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+/**
+ * 이슈 #16 스파이크. presigned PUT 방식으로 이미지 파일이 Cloudflare R2에 실제로 올라가는지 확인한다.
+ * 버리는 코드이므로 프로덕션 구조(FileStoragePort/R2FileStorageAdapter)에 맞추지 않았다.
+ *
+ * 설정은 OS 환경변수를 먼저 보고, 없으면 backend/.env 를 직접 읽는다.
+ * 자격증명이 없으면 테스트는 조용히 skip 된다.
+ */
+@EnabledIf("credentialsAvailable")
+class R2PresignedUploadSpikeTest {
+
+    private static final Map<String, String> CONFIG = loadConfig();
+
+    private static final String ENDPOINT = CONFIG.get("R2_ENDPOINT");
+    private static final String ACCESS_KEY = CONFIG.get("R2_ACCESS_KEY");
+    private static final String SECRET_KEY = CONFIG.get("R2_SECRET_KEY");
+    private static final String BUCKET = CONFIG.getOrDefault("R2_BUCKET", "sssok-dev");
+
+    private static final String CONTENT_TYPE = "image/png";
+    private static final int WIDTH = 320;
+    private static final int HEIGHT = 180;
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+    static boolean credentialsAvailable() {
+        return ACCESS_KEY != null && !ACCESS_KEY.isBlank();
+    }
+
+    // 발급 -> 이미지 PUT 업로드 -> presigned GET 으로 되읽어 이미지로 디코딩까지 확인.
+    @Test
+    void presignedPutUploadsImageToR2() throws Exception {
+        byte[] original = pngBytes();
+        String key = "spike/" + Instant.now().toEpochMilli() + ".png";
+
+        try (S3Presigner presigner = presigner()) {
+            URI uploadUrl = presignPut(presigner, key, CONTENT_TYPE);
+
+            HttpResponse<String> uploaded = put(uploadUrl, CONTENT_TYPE, original);
+            assertThat(uploaded.statusCode()).isEqualTo(200);
+
+            HttpResponse<byte[]> downloaded = HTTP.send(
+                    HttpRequest.newBuilder(presignGet(presigner, key)).GET().build(),
+                    HttpResponse.BodyHandlers.ofByteArray());
+
+            assertThat(downloaded.statusCode()).isEqualTo(200);
+            // R2가 업로드 시 지정한 Content-Type 을 그대로 보관하는지.
+            assertThat(downloaded.headers().firstValue("content-type")).hasValue(CONTENT_TYPE);
+            // 바이너리가 한 바이트도 변형되지 않았는지.
+            assertThat(downloaded.body()).isEqualTo(original);
+
+            // 받은 바이트가 실제로 이미지로 열리는지 (깨진 파일이 아닌지).
+            BufferedImage roundTripped = ImageIO.read(new ByteArrayInputStream(downloaded.body()));
+            assertThat(roundTripped).isNotNull();
+            assertThat(roundTripped.getWidth()).isEqualTo(WIDTH);
+            assertThat(roundTripped.getHeight()).isEqualTo(HEIGHT);
+
+            Path saved = Path.of("build", "spike-downloaded.png");
+            Files.createDirectories(saved.getParent());
+            Files.write(saved, downloaded.body());
+
+            System.out.println("[spike] 업로드 키     = " + key);
+            System.out.println("[spike] 크기          = " + original.length + " bytes, "
+                    + roundTripped.getWidth() + "x" + roundTripped.getHeight());
+            System.out.println("[spike] 내려받은 파일 = " + saved.toAbsolutePath());
+        }
+    }
+
+    // 서명에 포함한 Content-Type 과 실제 PUT 헤더가 다르면 R2가 서명을 거부한다.
+    // 프론트에 업로드 URL을 내려줄 때 Content-Type을 같이 약속해야 하는 이유.
+    @Test
+    void contentTypeMismatchIsRejected() throws Exception {
+        String key = "spike/mismatch-" + Instant.now().toEpochMilli() + ".png";
+
+        try (S3Presigner presigner = presigner()) {
+            URI uploadUrl = presignPut(presigner, key, CONTENT_TYPE);
+
+            HttpResponse<String> response = put(uploadUrl, "application/octet-stream", pngBytes());
+
+            assertThat(response.statusCode()).isEqualTo(403);
+        }
+    }
+
+    // 외부 파일에 의존하지 않도록 테스트가 직접 PNG를 그린다.
+    private static byte[] pngBytes() {
+        System.setProperty("java.awt.headless", "true");
+
+        BufferedImage image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(new Color(0x2E6FF6));
+        graphics.fillRect(0, 0, WIDTH, HEIGHT);
+        graphics.setColor(Color.WHITE);
+        graphics.setFont(new Font("SansSerif", Font.BOLD, 32));
+        graphics.drawString("sssOK #16", 40, 100);
+        graphics.dispose();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(image, "png", out);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return out.toByteArray();
+    }
+
+    // 셸 export 없이도 돌아가도록 .env 를 직접 읽는다. OS 환경변수가 있으면 그쪽이 우선.
+    private static Map<String, String> loadConfig() {
+        Map<String, String> config = new HashMap<>();
+
+        Path envFile = Path.of(".env");
+        if (Files.exists(envFile)) {
+            try {
+                for (String line : Files.readAllLines(envFile)) {
+                    String trimmed = line.trim();
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                        continue;
+                    }
+                    int separator = trimmed.indexOf('=');
+                    if (separator > 0) {
+                        config.put(trimmed.substring(0, separator).trim(),
+                                trimmed.substring(separator + 1).trim());
+                    }
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        for (String key : List.of("R2_ENDPOINT", "R2_ACCESS_KEY", "R2_SECRET_KEY", "R2_BUCKET")) {
+            String value = System.getenv(key);
+            if (value != null && !value.isBlank()) {
+                config.put(key, value);
+            }
+        }
+        return config;
+    }
+
+    private S3Presigner presigner() {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(ENDPOINT))
+                // R2는 리전 개념이 없어 'auto' 고정. 실제 리전 값을 넣으면 서명이 깨진다.
+                .region(Region.of("auto"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                // 가상 호스트 방식(bucket.<account>.r2.cloudflarestorage.com) 대신 path-style 사용.
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+
+    private URI presignPut(S3Presigner presigner, String key, String contentType) {
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        return URI.create(presigner.presignPutObject(PutObjectPresignRequest.builder()
+                        .signatureDuration(TTL)
+                        .putObjectRequest(request)
+                        .build())
+                .url()
+                .toString());
+    }
+
+    private URI presignGet(S3Presigner presigner, String key) {
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .build();
+
+        return URI.create(presigner.presignGetObject(GetObjectPresignRequest.builder()
+                        .signatureDuration(TTL)
+                        .getObjectRequest(request)
+                        .build())
+                .url()
+                .toString());
+    }
+
+    private HttpResponse<String> put(URI url, String contentType, byte[] body) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(url)
+                .header("Content-Type", contentType)
+                .PUT(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        return HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/docs/backend/R2_PRESIGNED_UPLOAD.md
+++ b/docs/backend/R2_PRESIGNED_UPLOAD.md
@@ -1,0 +1,157 @@
+# R2 Presigned 업로드 제약사항
+
+이슈 #16 스파이크에서 Cloudflare R2에 presigned PUT으로 이미지를 실제 업로드해보고 확인한 내용이다.
+업로드 API(`IssueUploadUrlsService`, `R2FileStorageAdapter`)를 구현할 때 여기 적힌 제약을 그대로 가져가면 된다.
+
+검증 코드는 `backend/src/test/java/com/sssok/spike/R2PresignedUploadSpikeTest.java` 에 있으며,
+**업로드 API를 구현하면 삭제한다.**
+
+스파이크 과정에서 임시 컨트롤러(`POST /spike/upload-urls`)를 만들어
+클라이언트 → 서버(URL 발급) → 클라이언트 → R2(직접 업로드) 흐름 전체를 curl로도 확인했다.
+인증이 없는 엔드포인트라 확인 후 삭제했고, 아래 헤더 규칙은 그때 얻은 결과다.
+
+---
+
+## 검증한 것
+
+| 항목 | 결과 |
+|---|---|
+| presigned PUT URL 발급 | 성공 |
+| 발급 URL로 PUT 업로드 | **200**, PNG 3151 bytes |
+| 업로드된 파일 확인 | presigned GET으로 되받아 **바이트 완전 일치** |
+| 파일 무결성 | `ImageIO.read()` 디코딩 성공, 320x180 유지 |
+| Content-Type 보존 | GET 응답에 `image/png` 그대로 반환 |
+| Content-Type 불일치 | **403** (서명 거부) |
+
+---
+
+## 1. 서명 방식
+
+AWS SDK v2의 `S3Presigner`를 그대로 쓴다. 별도 의존성은 필요 없고 `software.amazon.awssdk:s3` 안에 들어 있다.
+
+```java
+S3Presigner.builder()
+        .endpointOverride(URI.create(endpoint))
+        .region(Region.of("auto"))
+        .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)))
+        .serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
+                .build())
+        .build();
+```
+
+**region은 `auto` 고정.** R2에는 리전 개념이 없다. `ap-northeast-2` 같은 실제 리전 값을 넣으면 서명 스코프가 어긋나 요청이 거부된다.
+
+**path-style을 켜야 한다.** SDK 기본값인 virtual-hosted 방식(`<bucket>.<account>.r2.cloudflarestorage.com`) 대신
+`pathStyleAccessEnabled(true)`를 지정한다. 그러면 URL이 `<endpoint>/<bucket>/<key>` 형태로 생성된다.
+
+**endpoint에 버킷명을 붙이지 않는다.** `https://<account-id>.r2.cloudflarestorage.com` 까지만이다.
+버킷은 `PutObjectRequest.bucket()` 으로 따로 넘긴다.
+
+---
+
+## 2. 헤더 규칙 — 가장 중요한 제약
+
+발급 시점에 `contentType()`을 지정하면 **Content-Type이 서명 대상에 포함된다.** 생성된 URL에 이렇게 드러난다.
+
+```
+X-Amz-SignedHeaders=content-type%3Bhost
+```
+
+즉 **업로드하는 쪽이 보내는 `Content-Type` 헤더가 발급 시점의 값과 정확히 같아야 한다.**
+`image/png`로 서명한 URL에 세 가지 경우로 PUT을 보내 직접 확인했다.
+
+| PUT 요청의 Content-Type | 결과 |
+|---|---|
+| `image/png` (서명값과 동일) | **200** |
+| `application/octet-stream` (다른 값) | **403** |
+| 헤더 자체를 생략 | **403** |
+
+**헤더를 빼는 것도 실패한다.** 서명에 포함된 헤더는 반드시 존재하면서 값도 같아야 한다.
+클라이언트가 "잘 모르겠으면 안 보내면 되겠지"로 처리하면 업로드가 전부 깨진다.
+
+### API 설계에 주는 영향
+
+업로드 URL 발급 응답에 **Content-Type을 함께 내려줘야 한다.** 프론트가 파일 확장자로 추측하게 두면
+서버가 서명한 값과 어긋나 업로드가 깨진다.
+
+```
+POST /rooms/{code}/files/upload-urls
+  요청: [{ fileName, contentType, size }, ...]
+  응답: [{ uploadUrl, storageKey, contentType }, ...]
+                                  ^^^^^^^^^^^ 프론트는 이 값을 그대로 PUT 헤더에 사용
+```
+
+발급 요청에서 받은 `contentType`을 서버가 검증(허용 목록 대조)한 뒤, **검증에 쓴 그 값으로 서명하고
+그대로 응답에 돌려주는** 흐름이 안전하다. 서버가 임의로 바꾸면 프론트와 어긋난다.
+
+---
+
+## 3. 만료 시간
+
+`signatureDuration`이 URL 쿼리의 `X-Amz-Expires`에 초 단위로 박힌다. 발급 후에는 바꿀 수 없다.
+
+`application.yml`의 `upload.presigned-url-ttl: 10m` 값을 그대로 넘기면 된다.
+
+---
+
+## 4. R2가 보존해주는 것
+
+업로드 시 지정한 Content-Type을 R2가 오브젝트 메타데이터로 저장하고, 이후 GET 응답에 그대로 실어준다.
+브라우저에서 이미지를 바로 렌더링하려면 이 값이 정확해야 하므로, 발급 시점의 Content-Type 검증이
+다운로드 동작까지 좌우한다.
+
+바이너리는 변형되지 않는다. 올린 3151 bytes와 내려받은 3151 bytes가 완전히 일치했다.
+
+---
+
+## 5. SDK 버전
+
+`build.gradle`의 `software.amazon.awssdk:s3:2.25.0` **을 임의로 올리지 않는다.**
+
+SDK 2.30 이상에서 flexible checksum이 기본 활성화되면서 S3 호환 스토리지의 presigned PUT이
+깨진다고 알려져 있다. 다만 **이 스파이크에서 직접 확인하지는 않았다.** 버전을 올릴 일이 생기면
+`R2PresignedUploadSpikeTest`를 먼저 돌려서 여전히 통과하는지 확인한 뒤 올린다.
+
+---
+
+## 확인하지 않은 것
+
+업로드 API를 구현하기 전에 별도로 확인이 필요한 항목이다.
+
+- **브라우저 CORS** — 스파이크는 Java `HttpClient`로 서버에서 PUT을 보냈다. 실제 서비스는 브라우저가
+  R2로 직접 업로드하므로 **R2 버킷에 CORS 설정이 필요하다.** 이걸 안 하면 프론트 연동 시점에 막힌다.
+  가장 먼저 확인할 항목.
+- **대용량 파일 / multipart** — `upload.video-max-size: 1GB` 인데 스파이크는 3KB짜리 이미지만 올렸다.
+  단일 PUT으로 1GB를 보내는 게 현실적인지, multipart presigned가 필요한지 미확인.
+- **업로드 완료 검증** — `CompleteUploadService`에서 실제 업로드 여부와 크기를 확인하려면
+  HeadObject가 필요하다. 이 경우 presigner가 아닌 `S3Client`가 있어야 하고, 동기 HTTP 클라이언트
+  의존성이 추가로 필요할 수 있다.
+- **키 충돌** — 스파이크는 `Instant.now().toEpochMilli()`로 키를 만들었다. 실제로는 `StorageKey`에
+  충돌하지 않는 규칙(UUID 등)이 필요하다.
+
+---
+
+## 재현 방법
+
+`backend/.env`에 R2 값 3개를 채운다. (`.env`는 gitignore 대상이며, 값은 Cloudflare 대시보드 >
+R2 > Manage API tokens 에서 **Object Read & Write** 권한으로 발급한다.)
+
+```
+R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+R2_ACCESS_KEY=
+R2_SECRET_KEY=
+R2_BUCKET=sssok-dev
+```
+
+```bash
+cd backend
+./gradlew cleanTest test --tests '*R2PresignedUploadSpikeTest*'
+```
+
+테스트는 `.env`를 직접 읽으므로 셸에 export 하지 않아도 된다. 자격증명이 없으면 조용히 skip된다.
+
+**`cleanTest`를 빼면 안 된다.** 환경변수와 `.env`는 Gradle의 입력으로 추적되지 않아,
+`:test UP-TO-DATE`로 건너뛰면서 실행되지 않았는데도 BUILD SUCCESSFUL이 뜬다.
+결과는 `build/test-results/test/*.xml`의 `skipped="0"`으로 확인한다.


### PR DESCRIPTION
## 배포 대상
이번 주 스프린트에서 main에 병합된 내용을 deploy 브랜치에 반영합니다.

- #27 Walking Skeleton: 방 생성/조회 API (POST/GET /rooms)
- #28 Room·Folder 도메인 모델링 (상태 패턴, RoomPermissionPolicy/Port)
- #30 Member·StoredFile 도메인 모델링 (업로드 상태 머신, 미디어 최적화 전략, 파일 삭제 권한 정책, RoomPermissionPort 어댑터)
- #22 Swagger(springdoc) 세팅
- #23 R2 presigned 업로드 스파이크

## 배포 방식
병합 시 backend deploy 워크플로우가 트리거됩니다: 이미지 빌드 → GHCR 푸시 → self-hosted 러너에서 배포 → 헬스체크(실패 시 자동 롤백).