### PR TITLE
feat: 익명 인증 및 연결 코드(Link Code) API 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,6 @@ jobs:
       run:
         working-directory: backend
 
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_DB: sssok
-          POSTGRES_USER: sssok
-          POSTGRES_PASSWORD: sssok
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U sssok -d sssok"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
@@ -53,10 +38,6 @@ jobs:
       - name: 빌드 및 테스트
         run: ./gradlew build
         env:
-          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/sssok
-          SPRING_DATASOURCE_USERNAME: sssok
-          SPRING_DATASOURCE_PASSWORD: sssok
-          SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
           # CI 테스트 전용 키. 운영 시크릿과 무관하며 실제 배포에는 쓰이지 않는다.
           JWT_SECRET: 5SWYqRqL3JIuYo1c/ecWhbU6RTRd2nWPQfeaDjGJSd0=
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           SPRING_DATASOURCE_USERNAME: sssok
           SPRING_DATASOURCE_PASSWORD: sssok
           SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
+          # CI 테스트 전용 키. 운영 시크릿과 무관하며 실제 배포에는 쓰이지 않는다.
+          JWT_SECRET: 5SWYqRqL3JIuYo1c/ecWhbU6RTRd2nWPQfeaDjGJSd0=
 
       - name: 테스트 리포트 업로드
         if: always()

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -60,7 +60,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    // 통합 테스트용 실제 PostgreSQL (H2 금지 — JSONB 등 PostgreSQL 전용 기능 검증 불가)
+    // Repository+Service 통합 테스트용 (기본 CRUD는 H2로 빠르게 검증)
+    testImplementation 'com.h2database:h2'
+
+    // API 인수 테스트 / PostgreSQL 전용 기능(JSONB 등) 검증용 실제 PostgreSQL
+    // 자세히: docs/backend/TEST_CONVENTION.md
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'

--- a/backend/src/main/java/com/sssok/SssOkApplication.java
+++ b/backend/src/main/java/com/sssok/SssOkApplication.java
@@ -2,8 +2,10 @@ package com.sssok;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SssOkApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/sssok/application/auth/AnonymousAuthService.java
+++ b/backend/src/main/java/com/sssok/application/auth/AnonymousAuthService.java
@@ -1,0 +1,26 @@
+package com.sssok.application.auth;
+
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.application.port.out.TokenProvider.IssuedToken;
+import com.sssok.domain.member.Member;
+import com.sssok.domain.member.Nickname;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 익명 회원 생성 및 토큰 발급. 호출할 때마다 새 회원(새 userId)이 생긴다.
+@Service
+@RequiredArgsConstructor
+public class AnonymousAuthService {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    public AuthResult authenticate(String nickname) {
+        Instant now = Instant.now();
+        Member member = memberRepository.save(Member.register(new Nickname(nickname), now));
+        IssuedToken token = tokenProvider.issue(member.getId(), now);
+        return new AuthResult(token.value(), member.getId(), member.getDisplayName().value(), token.expiresAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/auth/AuthResult.java
+++ b/backend/src/main/java/com/sssok/application/auth/AuthResult.java
@@ -1,0 +1,6 @@
+package com.sssok.application.auth;
+
+import java.time.Instant;
+
+public record AuthResult(String accessToken, Long userId, String nickname, Instant expiresAt) {
+}

--- a/backend/src/main/java/com/sssok/application/auth/IssueLinkCodeService.java
+++ b/backend/src/main/java/com/sssok/application/auth/IssueLinkCodeService.java
@@ -1,0 +1,31 @@
+package com.sssok.application.auth;
+
+import com.sssok.application.port.out.LinkCodeRepository;
+import com.sssok.domain.auth.LinkCode;
+import com.sssok.domain.auth.LinkCodeValue;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.random.RandomGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 인증된 회원의 연결 코드를 발급한다. 동시에 유효한 코드는 최대 1개만 허용한다.
+@Service
+@RequiredArgsConstructor
+public class IssueLinkCodeService {
+
+    private final LinkCodeRepository linkCodeRepository;
+    private final RandomGenerator randomGenerator = new SecureRandom();
+
+    // 이전 코드 삭제 + 새 코드 저장이 하나의 원자적 단위로 묶여야 해서 명시적으로 트랜잭션을 연다.
+    @Transactional
+    public LinkCodeResult issue(Long memberId) {
+        Instant now = Instant.now();
+        linkCodeRepository.deleteAllByMemberId(memberId);
+
+        LinkCodeValue code = LinkCodeValue.generate(randomGenerator);
+        LinkCode linkCode = linkCodeRepository.save(LinkCode.issue(memberId, code, now));
+        return new LinkCodeResult(linkCode.getCode().value(), linkCode.getExpiresAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/auth/LinkCodeResult.java
+++ b/backend/src/main/java/com/sssok/application/auth/LinkCodeResult.java
@@ -1,0 +1,6 @@
+package com.sssok.application.auth;
+
+import java.time.Instant;
+
+public record LinkCodeResult(String linkCode, Instant expiresAt) {
+}

--- a/backend/src/main/java/com/sssok/application/auth/LinkLoginService.java
+++ b/backend/src/main/java/com/sssok/application/auth/LinkLoginService.java
@@ -23,7 +23,8 @@ public class LinkLoginService {
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
 
-    @Transactional
+    // LinkCodeExpiredException을 던질 때도 그 직전의 청소용 삭제는 커밋돼야 하므로 롤백 대상에서 뺌
+    @Transactional(noRollbackFor = LinkCodeExpiredException.class)
     public AuthResult login(String rawCode) {
         Instant now = Instant.now();
         LinkCodeValue code = new LinkCodeValue(rawCode);
@@ -31,6 +32,7 @@ public class LinkLoginService {
         LinkCode linkCode = linkCodeRepository.findByCode(code)
             .orElseThrow(LinkCodeNotFoundException::new);
         if (linkCode.isExpired(now)) {
+            linkCodeRepository.deleteByCode(code);
             throw new LinkCodeExpiredException();
         }
 

--- a/backend/src/main/java/com/sssok/application/auth/LinkLoginService.java
+++ b/backend/src/main/java/com/sssok/application/auth/LinkLoginService.java
@@ -33,7 +33,12 @@ public class LinkLoginService {
         if (linkCode.isExpired(now)) {
             throw new LinkCodeExpiredException();
         }
-        linkCodeRepository.deleteByCode(code);
+
+        // 삭제가 실제로 이 행을 지웠는지로 소비 성공 여부를 판별
+        boolean consumed = linkCodeRepository.deleteByCode(code);
+        if (!consumed) {
+            throw new LinkCodeNotFoundException();
+        }
 
         Member member = memberRepository.findById(linkCode.getMemberId()).orElseThrow();
         IssuedToken token = tokenProvider.issue(member.getId(), now);

--- a/backend/src/main/java/com/sssok/application/auth/LinkLoginService.java
+++ b/backend/src/main/java/com/sssok/application/auth/LinkLoginService.java
@@ -1,0 +1,42 @@
+package com.sssok.application.auth;
+
+import com.sssok.application.auth.exception.LinkCodeExpiredException;
+import com.sssok.application.auth.exception.LinkCodeNotFoundException;
+import com.sssok.application.port.out.LinkCodeRepository;
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.application.port.out.TokenProvider.IssuedToken;
+import com.sssok.domain.auth.LinkCode;
+import com.sssok.domain.auth.LinkCodeValue;
+import com.sssok.domain.member.Member;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 연결 코드로 원래 계정의 새 토큰을 발급받는다. 코드는 1회 사용 후 즉시 폐기한다.
+@Service
+@RequiredArgsConstructor
+public class LinkLoginService {
+
+    private final LinkCodeRepository linkCodeRepository;
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public AuthResult login(String rawCode) {
+        Instant now = Instant.now();
+        LinkCodeValue code = new LinkCodeValue(rawCode);
+
+        LinkCode linkCode = linkCodeRepository.findByCode(code)
+            .orElseThrow(LinkCodeNotFoundException::new);
+        if (linkCode.isExpired(now)) {
+            throw new LinkCodeExpiredException();
+        }
+        linkCodeRepository.deleteByCode(code);
+
+        Member member = memberRepository.findById(linkCode.getMemberId()).orElseThrow();
+        IssuedToken token = tokenProvider.issue(member.getId(), now);
+        return new AuthResult(token.value(), member.getId(), member.getDisplayName().value(), token.expiresAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/auth/exception/LinkCodeExpiredException.java
+++ b/backend/src/main/java/com/sssok/application/auth/exception/LinkCodeExpiredException.java
@@ -1,0 +1,8 @@
+package com.sssok.application.auth.exception;
+
+public class LinkCodeExpiredException extends RuntimeException {
+
+    public LinkCodeExpiredException() {
+        super("만료된 코드입니다");
+    }
+}

--- a/backend/src/main/java/com/sssok/application/auth/exception/LinkCodeNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/auth/exception/LinkCodeNotFoundException.java
@@ -1,0 +1,8 @@
+package com.sssok.application.auth.exception;
+
+public class LinkCodeNotFoundException extends RuntimeException {
+
+    public LinkCodeNotFoundException() {
+        super("유효하지 않은 코드입니다");
+    }
+}

--- a/backend/src/main/java/com/sssok/application/auth/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/sssok/application/auth/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.sssok.application.auth.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/port/out/LinkCodeRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/LinkCodeRepository.java
@@ -1,0 +1,12 @@
+package com.sssok.application.port.out;
+
+import com.sssok.domain.auth.LinkCode;
+
+// 연결 코드 영속화 출력
+public interface LinkCodeRepository {
+
+    LinkCode save(LinkCode linkCode);
+
+    // 한 회원은 동시에 최대 1개의 유효한 코드만 가진다 — 새로 발급하기 전에 이전 코드를 무효화한다.
+    void deleteAllByMemberId(Long memberId);
+}

--- a/backend/src/main/java/com/sssok/application/port/out/LinkCodeRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/LinkCodeRepository.java
@@ -14,6 +14,7 @@ public interface LinkCodeRepository {
 
     Optional<LinkCode> findByCode(LinkCodeValue code);
 
-    // 1회용 코드 소비 — 로그인에 성공하면 즉시 폐기한다.
-    void deleteByCode(LinkCodeValue code);
+    // 1회용 코드 소비 — 실제로 이 호출이 행을 지웠으면(=소비에 성공했으면) true.
+    // 동시에 같은 코드로 여러 요청이 들어와도 단 하나만 true를 받는다.
+    boolean deleteByCode(LinkCodeValue code);
 }

--- a/backend/src/main/java/com/sssok/application/port/out/LinkCodeRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/LinkCodeRepository.java
@@ -1,6 +1,8 @@
 package com.sssok.application.port.out;
 
 import com.sssok.domain.auth.LinkCode;
+import com.sssok.domain.auth.LinkCodeValue;
+import java.util.Optional;
 
 // 연결 코드 영속화 출력
 public interface LinkCodeRepository {
@@ -9,4 +11,9 @@ public interface LinkCodeRepository {
 
     // 한 회원은 동시에 최대 1개의 유효한 코드만 가진다 — 새로 발급하기 전에 이전 코드를 무효화한다.
     void deleteAllByMemberId(Long memberId);
+
+    Optional<LinkCode> findByCode(LinkCodeValue code);
+
+    // 1회용 코드 소비 — 로그인에 성공하면 즉시 폐기한다.
+    void deleteByCode(LinkCodeValue code);
 }

--- a/backend/src/main/java/com/sssok/application/port/out/MemberRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.sssok.application.port.out;
+
+import com.sssok.domain.member.Member;
+import java.util.Optional;
+
+// 회원 영속화 출력
+public interface MemberRepository {
+
+    Member save(Member member);
+
+    Optional<Member> findById(Long id);
+}

--- a/backend/src/main/java/com/sssok/application/port/out/TokenProvider.java
+++ b/backend/src/main/java/com/sssok/application/port/out/TokenProvider.java
@@ -7,6 +7,9 @@ public interface TokenProvider {
 
     IssuedToken issue(Long memberId, Instant now);
 
+    // 토큰이 없거나 형식이 잘못됐거나 만료·서명 검증에 실패하면 UnauthorizedException을 던진다.
+    Long parse(String token);
+
     record IssuedToken(String value, Instant expiresAt) {
     }
 }

--- a/backend/src/main/java/com/sssok/application/port/out/TokenProvider.java
+++ b/backend/src/main/java/com/sssok/application/port/out/TokenProvider.java
@@ -1,0 +1,12 @@
+package com.sssok.application.port.out;
+
+import java.time.Instant;
+
+// 인증 토큰 발급 출력
+public interface TokenProvider {
+
+    IssuedToken issue(Long memberId, Instant now);
+
+    record IssuedToken(String value, Instant expiresAt) {
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/auth/LinkCode.java
+++ b/backend/src/main/java/com/sssok/domain/auth/LinkCode.java
@@ -29,4 +29,8 @@ public class LinkCode {
     public static LinkCode reconstruct(Long id, Long memberId, LinkCodeValue code, Instant expiresAt) {
         return new LinkCode(id, memberId, code, expiresAt);
     }
+
+    public boolean isExpired(Instant now) {
+        return now.isAfter(expiresAt);
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/auth/LinkCode.java
+++ b/backend/src/main/java/com/sssok/domain/auth/LinkCode.java
@@ -1,0 +1,32 @@
+package com.sssok.domain.auth;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.Getter;
+
+// 다른 기기로 이어받기 위한 1회용 코드. memberId(원래 기기의 계정)를 새 기기가 이어받을 수 있게 한다.
+@Getter
+public class LinkCode {
+
+    private static final Duration TTL = Duration.ofMinutes(5);
+
+    private final Long id;
+    private final Long memberId;
+    private final LinkCodeValue code;
+    private final Instant expiresAt;
+
+    private LinkCode(Long id, Long memberId, LinkCodeValue code, Instant expiresAt) {
+        this.id = id;
+        this.memberId = memberId;
+        this.code = code;
+        this.expiresAt = expiresAt;
+    }
+
+    public static LinkCode issue(Long memberId, LinkCodeValue code, Instant now) {
+        return new LinkCode(null, memberId, code, now.plus(TTL));
+    }
+
+    public static LinkCode reconstruct(Long id, Long memberId, LinkCodeValue code, Instant expiresAt) {
+        return new LinkCode(id, memberId, code, expiresAt);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/auth/LinkCode.java
+++ b/backend/src/main/java/com/sssok/domain/auth/LinkCode.java
@@ -30,7 +30,8 @@ public class LinkCode {
         return new LinkCode(id, memberId, code, expiresAt);
     }
 
+    // 만료 시각과 정확히 같은 순간도 만료로 취급한다 (RoomExpiration.isExpired와 동일한 경계 규칙).
     public boolean isExpired(Instant now) {
-        return now.isAfter(expiresAt);
+        return !now.isBefore(expiresAt);
     }
 }

--- a/backend/src/main/java/com/sssok/domain/auth/LinkCodeValue.java
+++ b/backend/src/main/java/com/sssok/domain/auth/LinkCodeValue.java
@@ -1,0 +1,23 @@
+package com.sssok.domain.auth;
+
+import com.sssok.domain.auth.exception.InvalidLinkCodeException;
+import java.util.random.RandomGenerator;
+
+// 다른 기기로 이어받을 때 입력하는 1회용 코드. 사람이 직접 타이핑하는 흐름을 지원하기 위해
+// 6자리 숫자로 고정한다(짧은 유효시간 + 발급 시 이전 코드 무효화로 노출 위험을 상쇄한다).
+public record LinkCodeValue(String value) {
+
+    private static final int LENGTH = 6;
+    private static final int UPPER_BOUND = 1_000_000;
+
+    public LinkCodeValue {
+        if (value == null || !value.matches("\\d{" + LENGTH + "}")) {
+            throw new InvalidLinkCodeException(value);
+        }
+    }
+
+    public static LinkCodeValue generate(RandomGenerator random) {
+        int number = random.nextInt(UPPER_BOUND);
+        return new LinkCodeValue("%06d".formatted(number));
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/auth/exception/InvalidLinkCodeException.java
+++ b/backend/src/main/java/com/sssok/domain/auth/exception/InvalidLinkCodeException.java
@@ -1,0 +1,8 @@
+package com.sssok.domain.auth.exception;
+
+public class InvalidLinkCodeException extends RuntimeException {
+
+    public InvalidLinkCodeException(String value) {
+        super("코드 형식이 올바르지 않습니다: " + value);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/member/Member.java
+++ b/backend/src/main/java/com/sssok/domain/member/Member.java
@@ -3,27 +3,27 @@ package com.sssok.domain.member;
 import java.time.Instant;
 import lombok.Getter;
 
+// 전역 회원(계정) 애그리거트. 로그인이 없는 서비스라 닉네임만으로 생성되며,
+// 특정 방에 속하지 않는다 — 이 id(userId)가 방장·업로더 판정의 유일한 기준이 된다.
 @Getter
 public class Member {
 
     private final Long id;
-    private final Long roomId;
     private final Nickname displayName;
-    private final Instant joinedAt;
+    private final Instant createdAt;
 
-    private Member(Long id, Long roomId, Nickname displayName, Instant joinedAt) {
+    private Member(Long id, Nickname displayName, Instant createdAt) {
         this.id = id;
-        this.roomId = roomId;
         this.displayName = displayName;
-        this.joinedAt = joinedAt;
+        this.createdAt = createdAt;
     }
 
-    public static Member join(Long roomId, Nickname displayName, Instant now) {
-        return new Member(null, roomId, displayName, now);
+    public static Member register(Nickname displayName, Instant now) {
+        return new Member(null, displayName, now);
     }
 
-    public static Member reconstruct(Long id, Long roomId, Nickname displayName, Instant joinedAt) {
-        return new Member(id, roomId, displayName, joinedAt);
+    public static Member reconstruct(Long id, Nickname displayName, Instant createdAt) {
+        return new Member(id, displayName, createdAt);
     }
 
     public boolean isSame(Long memberId) {

--- a/backend/src/main/java/com/sssok/infrastructure/config/JwtProperties.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/JwtProperties.java
@@ -1,0 +1,8 @@
+package com.sssok.infrastructure.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(String secret, Duration accessTokenTtl) {
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/OpenApiConfig.java
@@ -1,13 +1,21 @@
 package com.sssok.infrastructure.config;
 
+import com.sssok.presentation.auth.AuthMember;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.Arrays;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
+
+    public static final String BEARER_AUTH = "bearerAuth";
 
     @Bean
     public OpenAPI openApi() {
@@ -18,6 +26,25 @@ public class OpenApiConfig {
                 .version("v0.0.1")
                 .contact(new Contact()
                     .name("sssOK Backend")
-                    .url("https://github.com/woowacourse-teams/2026-sssOK")));
+                    .url("https://github.com/woowacourse-teams/2026-sssOK")))
+            .components(new Components()
+                .addSecuritySchemes(BEARER_AUTH, new SecurityScheme()
+                    .name(BEARER_AUTH)
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")));
+    }
+
+    // 컨트롤러 메서드 파라미터에 @AuthMember가 붙어 있으면 자동으로 잠금 표시를 붙임
+    @Bean
+    public OperationCustomizer authMemberSecurityCustomizer() {
+        return (operation, handlerMethod) -> {
+            boolean requiresAuth = Arrays.stream(handlerMethod.getMethodParameters())
+                .anyMatch(parameter -> parameter.hasParameterAnnotation(AuthMember.class));
+            if (requiresAuth) {
+                operation.addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH));
+            }
+            return operation;
+        };
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
@@ -5,16 +5,29 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
+    // 실제 API 베이스 URL: https://api.ssssok.com/api/v1
+    // 헬스체크(HealthController, /health)는 배포 healthcheck가 그대로 참조하므로 접두사에서 제외한다
+    // — presentation.api "하위 패키지"에 있는 컨트롤러에만 붙도록 해서 자동으로 걸러진다.
+    private static final String API_PREFIX = "/api/v1";
+    private static final String API_SUB_PACKAGE_PREFIX = "com.sssok.presentation.api.";
+
     private final AuthMemberArgumentResolver authMemberArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authMemberArgumentResolver);
+    }
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix(API_PREFIX,
+            controllerType -> controllerType.getPackageName().startsWith(API_SUB_PACKAGE_PREFIX));
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.sssok.infrastructure.config;
+
+import com.sssok.presentation.auth.AuthMemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authMemberArgumentResolver);
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaEntity.java
@@ -1,0 +1,39 @@
+package com.sssok.infrastructure.persistence.auth;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "link_code")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LinkCodeJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "code", nullable = false, unique = true, length = 6)
+    private String code;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    public LinkCodeJpaEntity(Long id, Long memberId, String code, Instant expiresAt) {
+        this.id = id;
+        this.memberId = memberId;
+        this.code = code;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaRepository.java
@@ -1,8 +1,13 @@
 package com.sssok.infrastructure.persistence.auth;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LinkCodeJpaRepository extends JpaRepository<LinkCodeJpaEntity, Long> {
 
     void deleteAllByMemberId(Long memberId);
+
+    Optional<LinkCodeJpaEntity> findByCode(String code);
+
+    void deleteByCode(String code);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaRepository.java
@@ -2,6 +2,9 @@ package com.sssok.infrastructure.persistence.auth;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LinkCodeJpaRepository extends JpaRepository<LinkCodeJpaEntity, Long> {
 
@@ -9,5 +12,7 @@ public interface LinkCodeJpaRepository extends JpaRepository<LinkCodeJpaEntity, 
 
     Optional<LinkCodeJpaEntity> findByCode(String code);
 
-    void deleteByCode(String code);
+    @Modifying
+    @Query("DELETE FROM LinkCodeJpaEntity e WHERE e.code = :code")
+    int deleteByCode(@Param("code") String code);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaRepository.java
@@ -1,0 +1,8 @@
+package com.sssok.infrastructure.persistence.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LinkCodeJpaRepository extends JpaRepository<LinkCodeJpaEntity, Long> {
+
+    void deleteAllByMemberId(Long memberId);
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeRepositoryAdapter.java
@@ -30,8 +30,8 @@ public class LinkCodeRepositoryAdapter implements LinkCodeRepository {
     }
 
     @Override
-    public void deleteByCode(LinkCodeValue code) {
-        jpaRepository.deleteByCode(code.value());
+    public boolean deleteByCode(LinkCodeValue code) {
+        return jpaRepository.deleteByCode(code.value()) > 0;
     }
 
     private LinkCodeJpaEntity toEntity(LinkCode linkCode) {

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.sssok.infrastructure.persistence.auth;
+
+import com.sssok.application.port.out.LinkCodeRepository;
+import com.sssok.domain.auth.LinkCode;
+import com.sssok.domain.auth.LinkCodeValue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkCodeRepositoryAdapter implements LinkCodeRepository {
+
+    private final LinkCodeJpaRepository jpaRepository;
+
+    @Override
+    public LinkCode save(LinkCode linkCode) {
+        LinkCodeJpaEntity saved = jpaRepository.save(toEntity(linkCode));
+        return toDomain(saved);
+    }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        jpaRepository.deleteAllByMemberId(memberId);
+    }
+
+    private LinkCodeJpaEntity toEntity(LinkCode linkCode) {
+        return new LinkCodeJpaEntity(
+            linkCode.getId(),
+            linkCode.getMemberId(),
+            linkCode.getCode().value(),
+            linkCode.getExpiresAt()
+        );
+    }
+
+    private LinkCode toDomain(LinkCodeJpaEntity entity) {
+        return LinkCode.reconstruct(
+            entity.getId(),
+            entity.getMemberId(),
+            new LinkCodeValue(entity.getCode()),
+            entity.getExpiresAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.sssok.infrastructure.persistence.auth;
 import com.sssok.application.port.out.LinkCodeRepository;
 import com.sssok.domain.auth.LinkCode;
 import com.sssok.domain.auth.LinkCodeValue;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,16 @@ public class LinkCodeRepositoryAdapter implements LinkCodeRepository {
     @Override
     public void deleteAllByMemberId(Long memberId) {
         jpaRepository.deleteAllByMemberId(memberId);
+    }
+
+    @Override
+    public Optional<LinkCode> findByCode(LinkCodeValue code) {
+        return jpaRepository.findByCode(code.value()).map(this::toDomain);
+    }
+
+    @Override
+    public void deleteByCode(LinkCodeValue code) {
+        jpaRepository.deleteByCode(code.value());
     }
 
     private LinkCodeJpaEntity toEntity(LinkCode linkCode) {

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaEntity.java
@@ -1,0 +1,35 @@
+package com.sssok.infrastructure.persistence.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nickname", nullable = false, length = 12)
+    private String nickname;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public MemberJpaEntity(Long id, String nickname, Instant createdAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaRepository.java
@@ -1,0 +1,6 @@
+package com.sssok.infrastructure.persistence.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Long> {
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberRepositoryAdapter.java
@@ -1,0 +1,42 @@
+package com.sssok.infrastructure.persistence.member;
+
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.domain.member.Member;
+import com.sssok.domain.member.Nickname;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRepositoryAdapter implements MemberRepository {
+
+    private final MemberJpaRepository jpaRepository;
+
+    @Override
+    public Member save(Member member) {
+        MemberJpaEntity saved = jpaRepository.save(toEntity(member));
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<Member> findById(Long id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
+    private MemberJpaEntity toEntity(Member member) {
+        return new MemberJpaEntity(
+            member.getId(),
+            member.getDisplayName().value(),
+            member.getCreatedAt()
+        );
+    }
+
+    private Member toDomain(MemberJpaEntity entity) {
+        return Member.reconstruct(
+            entity.getId(),
+            new Nickname(entity.getNickname()),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/sssok/infrastructure/security/JwtTokenProvider.java
@@ -1,0 +1,35 @@
+package com.sssok.infrastructure.security;
+
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.infrastructure.config.JwtProperties;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider implements TokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    @Override
+    public IssuedToken issue(Long memberId, Instant now) {
+        Instant expiresAt = now.plus(jwtProperties.accessTokenTtl());
+        String token = Jwts.builder()
+            .subject(String.valueOf(memberId))
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiresAt))
+            .signWith(secretKey())
+            .compact();
+        return new IssuedToken(token, expiresAt);
+    }
+
+    private SecretKey secretKey() {
+        return Keys.hmacShaKeyFor(Base64.getDecoder().decode(jwtProperties.secret()));
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/sssok/infrastructure/security/JwtTokenProvider.java
@@ -1,7 +1,9 @@
 package com.sssok.infrastructure.security;
 
+import com.sssok.application.auth.exception.UnauthorizedException;
 import com.sssok.application.port.out.TokenProvider;
 import com.sssok.infrastructure.config.JwtProperties;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.time.Instant;
@@ -27,6 +29,21 @@ public class JwtTokenProvider implements TokenProvider {
             .signWith(secretKey())
             .compact();
         return new IssuedToken(token, expiresAt);
+    }
+
+    @Override
+    public Long parse(String token) {
+        try {
+            String subject = Jwts.parser()
+                .verifyWith(secretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+            return Long.valueOf(subject);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new UnauthorizedException("다시 접속해주세요");
+        }
     }
 
     private SecretKey secretKey() {

--- a/backend/src/main/java/com/sssok/presentation/api/auth/AnonymousAuthRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/AnonymousAuthRequest.java
@@ -1,0 +1,5 @@
+package com.sssok.presentation.api.auth;
+
+// 형식 검증(길이 등)은 Nickname 값 객체가 담당한다.
+public record AnonymousAuthRequest(String nickname) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/auth/AuthController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/AuthController.java
@@ -2,7 +2,10 @@ package com.sssok.presentation.api.auth;
 
 import com.sssok.application.auth.AnonymousAuthService;
 import com.sssok.application.auth.AuthResult;
+import com.sssok.application.auth.IssueLinkCodeService;
+import com.sssok.application.auth.LinkCodeResult;
 import com.sssok.presentation.api.common.ApiResponse;
+import com.sssok.presentation.auth.AuthMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,11 +20,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AnonymousAuthService anonymousAuthService;
+    private final IssueLinkCodeService issueLinkCodeService;
 
     @PostMapping("/anonymous")
     public ResponseEntity<ApiResponse<AuthResponse>> createAnonymous(@RequestBody AnonymousAuthRequest request) {
         AuthResult result = anonymousAuthService.authenticate(request.nickname());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(AuthResponse.from(result)));
+    }
+
+    @PostMapping("/link-code")
+    public ResponseEntity<ApiResponse<LinkCodeResponse>> createLinkCode(@AuthMember Long memberId) {
+        LinkCodeResult result = issueLinkCodeService.issue(memberId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.of(LinkCodeResponse.from(result)));
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/auth/AuthController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/AuthController.java
@@ -4,6 +4,7 @@ import com.sssok.application.auth.AnonymousAuthService;
 import com.sssok.application.auth.AuthResult;
 import com.sssok.application.auth.IssueLinkCodeService;
 import com.sssok.application.auth.LinkCodeResult;
+import com.sssok.application.auth.LinkLoginService;
 import com.sssok.presentation.api.common.ApiResponse;
 import com.sssok.presentation.auth.AuthMember;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class AuthController {
 
     private final AnonymousAuthService anonymousAuthService;
     private final IssueLinkCodeService issueLinkCodeService;
+    private final LinkLoginService linkLoginService;
 
     @PostMapping("/anonymous")
     public ResponseEntity<ApiResponse<AuthResponse>> createAnonymous(@RequestBody AnonymousAuthRequest request) {
@@ -34,5 +36,11 @@ public class AuthController {
         LinkCodeResult result = issueLinkCodeService.issue(memberId);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(LinkCodeResponse.from(result)));
+    }
+
+    @PostMapping("/link")
+    public ApiResponse<AuthResponse> login(@RequestBody LinkLoginRequest request) {
+        AuthResult result = linkLoginService.login(request.linkCode());
+        return ApiResponse.of(AuthResponse.from(result));
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/auth/AuthController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/AuthController.java
@@ -1,0 +1,27 @@
+package com.sssok.presentation.api.auth;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.auth.AuthResult;
+import com.sssok.presentation.api.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AnonymousAuthService anonymousAuthService;
+
+    @PostMapping("/anonymous")
+    public ResponseEntity<ApiResponse<AuthResponse>> createAnonymous(@RequestBody AnonymousAuthRequest request) {
+        AuthResult result = anonymousAuthService.authenticate(request.nickname());
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.of(AuthResponse.from(result)));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/auth/AuthResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/AuthResponse.java
@@ -1,0 +1,11 @@
+package com.sssok.presentation.api.auth;
+
+import com.sssok.application.auth.AuthResult;
+import java.time.Instant;
+
+public record AuthResponse(String accessToken, Long userId, String nickname, Instant expiresAt) {
+
+    public static AuthResponse from(AuthResult result) {
+        return new AuthResponse(result.accessToken(), result.userId(), result.nickname(), result.expiresAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/auth/LinkCodeResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/LinkCodeResponse.java
@@ -1,0 +1,11 @@
+package com.sssok.presentation.api.auth;
+
+import com.sssok.application.auth.LinkCodeResult;
+import java.time.Instant;
+
+public record LinkCodeResponse(String linkCode, Instant expiresAt) {
+
+    public static LinkCodeResponse from(LinkCodeResult result) {
+        return new LinkCodeResponse(result.linkCode(), result.expiresAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/auth/LinkLoginRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/auth/LinkLoginRequest.java
@@ -1,0 +1,5 @@
+package com.sssok.presentation.api.auth;
+
+// 형식 검증(6자리 숫자 여부)은 LinkCodeValue 값 객체가 담당한다.
+public record LinkLoginRequest(String linkCode) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sssok.presentation.api.common;
 
+import com.sssok.domain.member.exception.InvalidNicknameException;
 import com.sssok.domain.room.exception.InvalidRoomNameException;
 import com.sssok.application.room.exception.RoomNotFoundException;
 import com.sssok.domain.room.exception.InvalidRoomCodeException;
@@ -11,6 +12,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidNicknameException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidNickname(InvalidNicknameException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("INVALID_NICKNAME", "닉네임을 입력해주세요"));
+    }
 
     @ExceptionHandler(RoomNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleRoomNotFound(RoomNotFoundException e) {

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -9,11 +9,13 @@ import com.sssok.domain.room.exception.InvalidRoomNameException;
 import com.sssok.application.room.exception.RoomNotFoundException;
 import com.sssok.domain.room.exception.InvalidRoomCodeException;
 import com.sssok.domain.room.exception.RoomHostRequiredException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -69,5 +71,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleRoomHostRequired(RoomHostRequiredException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(new ErrorResponse("ROOM_HOST_REQUIRED", e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception e) {
+        log.error("처리되지 않은 예외가 발생했습니다", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new ErrorResponse("INTERNAL_SERVER_ERROR", "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요"));
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sssok.presentation.api.common;
 
+import com.sssok.application.auth.exception.UnauthorizedException;
 import com.sssok.domain.member.exception.InvalidNicknameException;
 import com.sssok.domain.room.exception.InvalidRoomNameException;
 import com.sssok.application.room.exception.RoomNotFoundException;
@@ -17,6 +18,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidNickname(InvalidNicknameException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse("INVALID_NICKNAME", "닉네임을 입력해주세요"));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorized(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(new ErrorResponse("UNAUTHORIZED", e.getMessage()));
     }
 
     @ExceptionHandler(RoomNotFoundException.class)

--- a/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.sssok.presentation.api.common;
 
+import com.sssok.application.auth.exception.LinkCodeExpiredException;
+import com.sssok.application.auth.exception.LinkCodeNotFoundException;
 import com.sssok.application.auth.exception.UnauthorizedException;
+import com.sssok.domain.auth.exception.InvalidLinkCodeException;
 import com.sssok.domain.member.exception.InvalidNicknameException;
 import com.sssok.domain.room.exception.InvalidRoomNameException;
 import com.sssok.application.room.exception.RoomNotFoundException;
@@ -24,6 +27,24 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleUnauthorized(UnauthorizedException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(new ErrorResponse("UNAUTHORIZED", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidLinkCodeException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidLinkCode(InvalidLinkCodeException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("INVALID_LINK_CODE", "코드가 올바르지 않습니다"));
+    }
+
+    @ExceptionHandler(LinkCodeNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleLinkCodeNotFound(LinkCodeNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse("LINK_CODE_NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(LinkCodeExpiredException.class)
+    public ResponseEntity<ErrorResponse> handleLinkCodeExpired(LinkCodeExpiredException e) {
+        return ResponseEntity.status(HttpStatus.GONE)
+            .body(new ErrorResponse("LINK_CODE_EXPIRED", e.getMessage()));
     }
 
     @ExceptionHandler(RoomNotFoundException.class)

--- a/backend/src/main/java/com/sssok/presentation/auth/AuthMember.java
+++ b/backend/src/main/java/com/sssok/presentation/auth/AuthMember.java
@@ -1,0 +1,12 @@
+package com.sssok.presentation.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// Authorization: Bearer {accessToken} 에서 뽑아낸 memberId를 컨트롤러 파라미터로 주입받는다.
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+}

--- a/backend/src/main/java/com/sssok/presentation/auth/AuthMemberArgumentResolver.java
+++ b/backend/src/main/java/com/sssok/presentation/auth/AuthMemberArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.sssok.presentation.auth;
+
+import com.sssok.application.auth.exception.UnauthorizedException;
+import com.sssok.application.port.out.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMember.class)
+            && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = extractToken(request.getHeader("Authorization"));
+        return tokenProvider.parse(token);
+    }
+
+    private String extractToken(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new UnauthorizedException("다시 접속해주세요");
+        }
+        return authorizationHeader.substring(BEARER_PREFIX.length());
+    }
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -25,7 +25,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  guest-token-ttl: 24h
+  access-token-ttl: 30d
 
 storage:
   r2:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -23,10 +23,6 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
 
-jwt:
-  secret: ${JWT_SECRET}
-  access-token-ttl: 30d
-
 storage:
   r2:
     endpoint: ${R2_ENDPOINT}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -32,6 +32,11 @@ spring:
       pool:
         size: 2
 
+jwt:
+  # 시크릿 자체는 실제 값을 커밋하지 않는다 — 로컬은 application-local.yml(gitignored), CI/운영은 환경변수로 공급한다.
+  secret: ${JWT_SECRET}
+  access-token-ttl: ${JWT_ACCESS_TOKEN_TTL:30d}
+
 room:
   code-length: 8
   default-ttl: 24h

--- a/backend/src/main/resources/db/migration/V3__create_member.sql
+++ b/backend/src/main/resources/db/migration/V3__create_member.sql
@@ -1,0 +1,7 @@
+-- #38 익명 인증: 닉네임 기반 전역 회원(계정) 테이블.
+-- 특정 방에 속하지 않는다 — id(userId)가 방장·업로더 판정의 유일한 기준이 된다.
+CREATE TABLE member (
+    id         BIGSERIAL PRIMARY KEY,
+    nickname   VARCHAR(12) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);

--- a/backend/src/main/resources/db/migration/V4__create_link_code.sql
+++ b/backend/src/main/resources/db/migration/V4__create_link_code.sql
@@ -1,0 +1,8 @@
+-- #38 연결 코드 발급: 다른 기기로 이어받기 위한 1회용 코드.
+-- code는 유일해야 하므로 UNIQUE로 둔다 (6자리 숫자 100만 가지 * 5분 TTL 규모에서는 재사용 가능성이 낮다).
+CREATE TABLE link_code (
+    id         BIGSERIAL PRIMARY KEY,
+    member_id  BIGINT NOT NULL,
+    code       VARCHAR(6) NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL
+);

--- a/backend/src/test/java/com/sssok/SssOkApplicationTests.java
+++ b/backend/src/test/java/com/sssok/SssOkApplicationTests.java
@@ -1,13 +1,14 @@
 package com.sssok;
 
+import com.sssok.support.PostgresContainerSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+// PostgresContainerSupport(싱글톤 컨테이너)를 상속하므로 다른 API 인수 테스트와 컨테이너를 공유한다.
 @SpringBootTest
-class SssOkApplicationTests {
+class SssOkApplicationTests extends PostgresContainerSupport {
 
     @Test
     void contextLoads() {
     }
-
 }

--- a/backend/src/test/java/com/sssok/application/auth/AnonymousAuthServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/AnonymousAuthServiceTest.java
@@ -1,0 +1,49 @@
+package com.sssok.application.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sssok.application.port.out.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+// Service가 실제 Repository 빈을 통해 회원을 저장하고 토큰을 발급하는지 확인하는 통합 테스트.
+// 기본 CRUD만 검증하므로 PostgreSQL 전용 기능이 필요 없어 H2로 빠르게 돈다 (Flyway는 끄고
+// Hibernate가 엔티티로부터 스키마를 직접 생성한다 — 실제 운영 스키마 검증은 API 인수 테스트가 담당).
+@SpringBootTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:auth-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false"
+})
+class AnonymousAuthServiceTest {
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void 닉네임으로_인증하면_회원이_저장되고_토큰이_발급된다() {
+        AuthResult result = anonymousAuthService.authenticate("로지");
+
+        assertThat(result.userId()).isNotNull();
+        assertThat(result.nickname()).isEqualTo("로지");
+        assertThat(result.accessToken()).isNotBlank();
+        assertThat(result.expiresAt()).isNotNull();
+        assertThat(memberRepository.findById(result.userId())).isPresent();
+    }
+
+    @Test
+    void 호출할_때마다_다른_회원이_생성된다() {
+        AuthResult first = anonymousAuthService.authenticate("로지");
+        AuthResult second = anonymousAuthService.authenticate("로지");
+
+        assertThat(first.userId()).isNotEqualTo(second.userId());
+    }
+}

--- a/backend/src/test/java/com/sssok/application/auth/AnonymousAuthServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/AnonymousAuthServiceTest.java
@@ -6,20 +6,13 @@ import com.sssok.application.port.out.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 
 // Service가 실제 Repository 빈을 통해 회원을 저장하고 토큰을 발급하는지 확인하는 통합 테스트.
-// 기본 CRUD만 검증하므로 PostgreSQL 전용 기능이 필요 없어 H2로 빠르게 돈다 (Flyway는 끄고
-// Hibernate가 엔티티로부터 스키마를 직접 생성한다 — 실제 운영 스키마 검증은 API 인수 테스트가 담당).
+// 기본 CRUD만 검증하므로 PostgreSQL 전용 기능이 필요 없어 H2로 빠르게 돈다.
+// H2 설정은 application-test.yml(test 프로파일)에 모아뒀다 (docs/backend/TEST_CONVENTION.md 참고).
 @SpringBootTest
-@TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:h2:mem:auth-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
-    "spring.datasource.driver-class-name=org.h2.Driver",
-    "spring.datasource.username=sa",
-    "spring.datasource.password=",
-    "spring.jpa.hibernate.ddl-auto=create-drop",
-    "spring.flyway.enabled=false"
-})
+@ActiveProfiles("test")
 class AnonymousAuthServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/sssok/application/auth/IssueLinkCodeServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/IssueLinkCodeServiceTest.java
@@ -1,0 +1,47 @@
+package com.sssok.application.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sssok.infrastructure.persistence.auth.LinkCodeJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+// Service가 실제 Repository 빈을 통해 연결 코드를 저장/무효화하는지 확인하는 통합 테스트.
+// 기본 CRUD만 검증하므로 H2로 빠르게 돈다 (docs/backend/TEST_CONVENTION.md 참고).
+@SpringBootTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:link-code-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false"
+})
+class IssueLinkCodeServiceTest {
+
+    @Autowired
+    IssueLinkCodeService issueLinkCodeService;
+
+    @Autowired
+    LinkCodeJpaRepository linkCodeJpaRepository;
+
+    @Test
+    void 코드를_발급하면_6자리_숫자와_만료시각을_받는다() {
+        LinkCodeResult result = issueLinkCodeService.issue(10L);
+
+        assertThat(result.linkCode()).matches("\\d{6}");
+        assertThat(result.expiresAt()).isNotNull();
+    }
+
+    @Test
+    void 같은_회원이_다시_발급하면_이전_코드는_무효화된다() {
+        issueLinkCodeService.issue(10L);
+        issueLinkCodeService.issue(10L);
+
+        assertThat(linkCodeJpaRepository.findAll())
+            .filteredOn(entity -> entity.getMemberId().equals(10L))
+            .hasSize(1);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/auth/IssueLinkCodeServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/IssueLinkCodeServiceTest.java
@@ -6,19 +6,13 @@ import com.sssok.infrastructure.persistence.auth.LinkCodeJpaRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 
 // Service가 실제 Repository 빈을 통해 연결 코드를 저장/무효화하는지 확인하는 통합 테스트.
-// 기본 CRUD만 검증하므로 H2로 빠르게 돈다 (docs/backend/TEST_CONVENTION.md 참고).
+// 기본 CRUD만 검증하므로 H2로 빠르게 돈다.
+// H2 설정은 application-test.yml(test 프로파일)에 모아뒀다 (docs/backend/TEST_CONVENTION.md 참고).
 @SpringBootTest
-@TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:h2:mem:link-code-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
-    "spring.datasource.driver-class-name=org.h2.Driver",
-    "spring.datasource.username=sa",
-    "spring.datasource.password=",
-    "spring.jpa.hibernate.ddl-auto=create-drop",
-    "spring.flyway.enabled=false"
-})
+@ActiveProfiles("test")
 class IssueLinkCodeServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/sssok/application/auth/LinkLoginServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/LinkLoginServiceTest.java
@@ -90,6 +90,21 @@ class LinkLoginServiceTest {
     }
 
     @Test
+    void 만료된_코드는_로그인_시도_시점에_청소된다() {
+        AuthResult registered = anonymousAuthService.authenticate("로지");
+        LinkCodeValue code = LinkCodeValue.generate(RandomGenerator.of("Random"));
+        LinkCode expired = LinkCode.issue(registered.userId(), code, Instant.now().minus(10, ChronoUnit.MINUTES));
+        linkCodeRepository.save(expired);
+
+        assertThatThrownBy(() -> linkLoginService.login(code.value()))
+            .isInstanceOf(LinkCodeExpiredException.class);
+
+        // 방치돼있던 행이 지워졌는지 확인 — 같은 코드로 다시 시도하면 이제는 404(찾을 수 없음)여야 한다.
+        assertThatThrownBy(() -> linkLoginService.login(code.value()))
+            .isInstanceOf(LinkCodeNotFoundException.class);
+    }
+
+    @Test
     void 동시에_같은_코드로_로그인하면_하나만_성공한다() throws InterruptedException {
         AuthResult registered = anonymousAuthService.authenticate("로지");
         LinkCodeResult issued = issueLinkCodeService.issue(registered.userId());

--- a/backend/src/test/java/com/sssok/application/auth/LinkLoginServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/LinkLoginServiceTest.java
@@ -11,23 +11,24 @@ import com.sssok.domain.auth.LinkCodeValue;
 import com.sssok.domain.auth.exception.InvalidLinkCodeException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.random.RandomGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 
 // LinkLoginService가 실제 Repository 빈을 통해 코드를 조회·소비하고 토큰을 발급하는지 확인하는 통합 테스트.
-// 기본 CRUD만 검증하므로 H2로 빠르게 돈다 (docs/backend/TEST_CONVENTION.md 참고).
+// 기본 CRUD만 검증하므로 H2로 빠르게 돈다.
+// H2 설정은 application-test.yml(test 프로파일)에 모아뒀다 (docs/backend/TEST_CONVENTION.md 참고).
 @SpringBootTest
-@TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:h2:mem:link-login-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
-    "spring.datasource.driver-class-name=org.h2.Driver",
-    "spring.datasource.username=sa",
-    "spring.datasource.password=",
-    "spring.jpa.hibernate.ddl-auto=create-drop",
-    "spring.flyway.enabled=false"
-})
+@ActiveProfiles("test")
 class LinkLoginServiceTest {
 
     @Autowired
@@ -86,5 +87,43 @@ class LinkLoginServiceTest {
 
         assertThatThrownBy(() -> linkLoginService.login(code.value()))
             .isInstanceOf(LinkCodeExpiredException.class);
+    }
+
+    @Test
+    void 동시에_같은_코드로_로그인하면_하나만_성공한다() throws InterruptedException {
+        AuthResult registered = anonymousAuthService.authenticate("로지");
+        LinkCodeResult issued = issueLinkCodeService.issue(registered.userId());
+
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        List<Future<AuthResult>> futures = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                readyLatch.countDown();
+                startLatch.await();
+                return linkLoginService.login(issued.linkCode());
+            }));
+        }
+        readyLatch.await();
+        startLatch.countDown();
+
+        int successCount = 0;
+        int notFoundCount = 0;
+        for (Future<AuthResult> future : futures) {
+            try {
+                future.get();
+                successCount++;
+            } catch (ExecutionException e) {
+                assertThat(e.getCause()).isInstanceOf(LinkCodeNotFoundException.class);
+                notFoundCount++;
+            }
+        }
+        executor.shutdown();
+
+        assertThat(successCount).isEqualTo(1);
+        assertThat(notFoundCount).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/com/sssok/application/auth/LinkLoginServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/auth/LinkLoginServiceTest.java
@@ -1,0 +1,90 @@
+package com.sssok.application.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.auth.exception.LinkCodeExpiredException;
+import com.sssok.application.auth.exception.LinkCodeNotFoundException;
+import com.sssok.application.port.out.LinkCodeRepository;
+import com.sssok.domain.auth.LinkCode;
+import com.sssok.domain.auth.LinkCodeValue;
+import com.sssok.domain.auth.exception.InvalidLinkCodeException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.random.RandomGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+// LinkLoginService가 실제 Repository 빈을 통해 코드를 조회·소비하고 토큰을 발급하는지 확인하는 통합 테스트.
+// 기본 CRUD만 검증하므로 H2로 빠르게 돈다 (docs/backend/TEST_CONVENTION.md 참고).
+@SpringBootTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:link-login-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false"
+})
+class LinkLoginServiceTest {
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    IssueLinkCodeService issueLinkCodeService;
+
+    @Autowired
+    LinkLoginService linkLoginService;
+
+    @Autowired
+    LinkCodeRepository linkCodeRepository;
+
+    @Test
+    void 유효한_코드로_로그인하면_같은_회원의_새_토큰을_받는다() {
+        AuthResult registered = anonymousAuthService.authenticate("로지");
+        LinkCodeResult issued = issueLinkCodeService.issue(registered.userId());
+
+        AuthResult loggedIn = linkLoginService.login(issued.linkCode());
+
+        assertThat(loggedIn.userId()).isEqualTo(registered.userId());
+        assertThat(loggedIn.nickname()).isEqualTo("로지");
+        assertThat(loggedIn.accessToken()).isNotBlank();
+    }
+
+    @Test
+    void 로그인에_성공하면_코드는_즉시_폐기된다() {
+        AuthResult registered = anonymousAuthService.authenticate("로지");
+        LinkCodeResult issued = issueLinkCodeService.issue(registered.userId());
+
+        linkLoginService.login(issued.linkCode());
+
+        assertThatThrownBy(() -> linkLoginService.login(issued.linkCode()))
+            .isInstanceOf(LinkCodeNotFoundException.class);
+    }
+
+    @Test
+    void 존재하지_않는_코드면_예외() {
+        assertThatThrownBy(() -> linkLoginService.login("999999"))
+            .isInstanceOf(LinkCodeNotFoundException.class);
+    }
+
+    @Test
+    void 형식이_잘못된_코드면_예외() {
+        assertThatThrownBy(() -> linkLoginService.login("abc"))
+            .isInstanceOf(InvalidLinkCodeException.class);
+    }
+
+    @Test
+    void 만료된_코드면_예외() {
+        AuthResult registered = anonymousAuthService.authenticate("로지");
+        LinkCodeValue code = LinkCodeValue.generate(RandomGenerator.of("Random"));
+        LinkCode expired = LinkCode.issue(registered.userId(), code, Instant.now().minus(10, ChronoUnit.MINUTES));
+        linkCodeRepository.save(expired);
+
+        assertThatThrownBy(() -> linkLoginService.login(code.value()))
+            .isInstanceOf(LinkCodeExpiredException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/auth/LinkCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/auth/LinkCodeTest.java
@@ -25,4 +25,18 @@ class LinkCodeTest {
 
         assertThat(linkCode.getId()).isEqualTo(1L);
     }
+
+    @Test
+    void 만료_시각_이전이면_만료가_아니다() {
+        LinkCode linkCode = LinkCode.issue(10L, new LinkCodeValue("483920"), NOW);
+
+        assertThat(linkCode.isExpired(NOW.plusSeconds(1))).isFalse();
+    }
+
+    @Test
+    void 만료_시각이_지나면_만료다() {
+        LinkCode linkCode = LinkCode.issue(10L, new LinkCodeValue("483920"), NOW);
+
+        assertThat(linkCode.isExpired(NOW.plus(6, ChronoUnit.MINUTES))).isTrue();
+    }
 }

--- a/backend/src/test/java/com/sssok/domain/auth/LinkCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/auth/LinkCodeTest.java
@@ -39,4 +39,11 @@ class LinkCodeTest {
 
         assertThat(linkCode.isExpired(NOW.plus(6, ChronoUnit.MINUTES))).isTrue();
     }
+
+    @Test
+    void 만료_시각과_정확히_같은_순간도_만료다() {
+        LinkCode linkCode = LinkCode.issue(10L, new LinkCodeValue("483920"), NOW);
+
+        assertThat(linkCode.isExpired(linkCode.getExpiresAt())).isTrue();
+    }
 }

--- a/backend/src/test/java/com/sssok/domain/auth/LinkCodeTest.java
+++ b/backend/src/test/java/com/sssok/domain/auth/LinkCodeTest.java
@@ -1,0 +1,28 @@
+package com.sssok.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+
+class LinkCodeTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-22T04:10:00Z");
+
+    @Test
+    void 발급하면_5분_뒤_만료시각을_가진다() {
+        LinkCode linkCode = LinkCode.issue(10L, new LinkCodeValue("483920"), NOW);
+
+        assertThat(linkCode.getMemberId()).isEqualTo(10L);
+        assertThat(linkCode.getCode().value()).isEqualTo("483920");
+        assertThat(linkCode.getExpiresAt()).isEqualTo(NOW.plus(5, ChronoUnit.MINUTES));
+    }
+
+    @Test
+    void 저장된_값으로_복원할_수_있다() {
+        LinkCode linkCode = LinkCode.reconstruct(1L, 10L, new LinkCodeValue("483920"), NOW);
+
+        assertThat(linkCode.getId()).isEqualTo(1L);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/auth/LinkCodeValueTest.java
+++ b/backend/src/test/java/com/sssok/domain/auth/LinkCodeValueTest.java
@@ -1,0 +1,35 @@
+package com.sssok.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.domain.auth.exception.InvalidLinkCodeException;
+import java.util.random.RandomGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LinkCodeValueTest {
+
+    @Test
+    void 항상_6자리_숫자로_생성된다() {
+        RandomGenerator fixed = RandomGenerator.of("Random");
+
+        LinkCodeValue code = LinkCodeValue.generate(fixed);
+
+        assertThat(code.value()).matches("\\d{6}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"12345", "1234567", "12345a", "", " "})
+    void 형식이_아니면_예외(String invalid) {
+        assertThatThrownBy(() -> new LinkCodeValue(invalid))
+            .isInstanceOf(InvalidLinkCodeException.class);
+    }
+
+    @Test
+    void null이면_예외() {
+        assertThatThrownBy(() -> new LinkCodeValue(null))
+            .isInstanceOf(InvalidLinkCodeException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/sssok/domain/member/MemberTest.java
@@ -10,33 +10,32 @@ class MemberTest {
     private static final Instant NOW = Instant.parse("2026-08-13T10:00:00Z");
 
     @Test
-    void 최초_입장하면_아직_식별자가_없다() {
-        Member member = Member.join(1L, new Nickname("로지"), NOW);
+    void 등록_직후에는_아직_식별자가_없다() {
+        Member member = Member.register(new Nickname("로지"), NOW);
 
         assertThat(member.getId()).isNull();
-        assertThat(member.getRoomId()).isEqualTo(1L);
         assertThat(member.getDisplayName().value()).isEqualTo("로지");
-        assertThat(member.getJoinedAt()).isEqualTo(NOW);
+        assertThat(member.getCreatedAt()).isEqualTo(NOW);
     }
 
     @Test
     void 저장된_값으로_복원할_수_있다() {
-        Member member = Member.reconstruct(10L, 1L, new Nickname("로지"), NOW);
+        Member member = Member.reconstruct(10L, new Nickname("로지"), NOW);
 
         assertThat(member.getId()).isEqualTo(10L);
     }
 
     @Test
     void 같은_식별자인지_판별할_수_있다() {
-        Member member = Member.reconstruct(10L, 1L, new Nickname("로지"), NOW);
+        Member member = Member.reconstruct(10L, new Nickname("로지"), NOW);
 
         assertThat(member.isSame(10L)).isTrue();
         assertThat(member.isSame(11L)).isFalse();
     }
 
     @Test
-    void 저장되지_않은_참여자는_어떤_식별자와도_같지_않다() {
-        Member member = Member.join(1L, new Nickname("로지"), NOW);
+    void 저장되지_않은_회원은_어떤_식별자와도_같지_않다() {
+        Member member = Member.register(new Nickname("로지"), NOW);
 
         assertThat(member.isSame(10L)).isFalse();
     }

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
@@ -40,7 +40,7 @@ class AuthApiTest {
 
     @Test
     void 닉네임으로_익명_인증하면_토큰과_userId를_발급받는다() throws Exception {
-        mockMvc.perform(post("/auth/anonymous")
+        mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"민수\"}"))
             .andExpect(status().isCreated())
@@ -52,11 +52,11 @@ class AuthApiTest {
 
     @Test
     void 호출할_때마다_다른_회원이_생성된다() throws Exception {
-        MvcResult first = mockMvc.perform(post("/auth/anonymous")
+        MvcResult first = mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"민수\"}"))
             .andReturn();
-        MvcResult second = mockMvc.perform(post("/auth/anonymous")
+        MvcResult second = mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"민수\"}"))
             .andReturn();
@@ -70,7 +70,7 @@ class AuthApiTest {
 
     @Test
     void 닉네임_없이_요청하면_400() throws Exception {
-        mockMvc.perform(post("/auth/anonymous")
+        mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"\"}"))
             .andExpect(status().isBadRequest())
@@ -81,7 +81,7 @@ class AuthApiTest {
     void 발급받은_토큰으로_연결_코드를_발급받는다() throws Exception {
         String accessToken = 익명_인증으로_토큰_발급받기();
 
-        mockMvc.perform(post("/auth/link-code")
+        mockMvc.perform(post("/api/v1/auth/link-code")
                 .header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.linkCode").value(matchesPattern("\\d{6}")))
@@ -92,10 +92,10 @@ class AuthApiTest {
     void 같은_토큰으로_다시_발급받으면_이전_코드가_무효화된다() throws Exception {
         String accessToken = 익명_인증으로_토큰_발급받기();
 
-        MvcResult first = mockMvc.perform(post("/auth/link-code")
+        MvcResult first = mockMvc.perform(post("/api/v1/auth/link-code")
                 .header("Authorization", "Bearer " + accessToken))
             .andReturn();
-        MvcResult second = mockMvc.perform(post("/auth/link-code")
+        MvcResult second = mockMvc.perform(post("/api/v1/auth/link-code")
                 .header("Authorization", "Bearer " + accessToken))
             .andReturn();
 
@@ -108,21 +108,85 @@ class AuthApiTest {
 
     @Test
     void Authorization_헤더_없이_연결_코드를_요청하면_401() throws Exception {
-        mockMvc.perform(post("/auth/link-code"))
+        mockMvc.perform(post("/api/v1/auth/link-code"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 
     @Test
     void 형식이_잘못된_토큰으로_요청하면_401() throws Exception {
-        mockMvc.perform(post("/auth/link-code")
+        mockMvc.perform(post("/api/v1/auth/link-code")
                 .header("Authorization", "Bearer not-a-real-token"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 
+    @Test
+    void 연결_코드로_로그인하면_같은_회원의_새_토큰을_받는다() throws Exception {
+        MvcResult registerResult = mockMvc.perform(post("/api/v1/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"민수\"}"))
+            .andReturn();
+        JsonNode registerBody = objectMapper.readTree(registerResult.getResponse().getContentAsString());
+        String accessToken = registerBody.get("data").get("accessToken").asText();
+        long userId = registerBody.get("data").get("userId").asLong();
+
+        MvcResult linkCodeResult = mockMvc.perform(post("/api/v1/auth/link-code")
+                .header("Authorization", "Bearer " + accessToken))
+            .andReturn();
+        String linkCode = objectMapper.readTree(linkCodeResult.getResponse().getContentAsString())
+            .get("data").get("linkCode").asText();
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"" + linkCode + "\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").value(notNullValue()))
+            .andExpect(jsonPath("$.data.userId").value(userId))
+            .andExpect(jsonPath("$.data.nickname").value("민수"));
+    }
+
+    @Test
+    void 이미_사용한_코드로_다시_로그인하면_404() throws Exception {
+        String accessToken = 익명_인증으로_토큰_발급받기();
+        MvcResult linkCodeResult = mockMvc.perform(post("/api/v1/auth/link-code")
+                .header("Authorization", "Bearer " + accessToken))
+            .andReturn();
+        String linkCode = objectMapper.readTree(linkCodeResult.getResponse().getContentAsString())
+            .get("data").get("linkCode").asText();
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"" + linkCode + "\"}"))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"" + linkCode + "\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("LINK_CODE_NOT_FOUND"));
+    }
+
+    @Test
+    void 존재하지_않는_코드로_로그인하면_404() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"999999\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("LINK_CODE_NOT_FOUND"));
+    }
+
+    @Test
+    void 형식이_잘못된_코드로_로그인하면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"abc\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_LINK_CODE"));
+    }
+
     private String 익명_인증으로_토큰_발급받기() throws Exception {
-        MvcResult result = mockMvc.perform(post("/auth/anonymous")
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"민수\"}"))
             .andReturn();

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
@@ -101,9 +101,23 @@ class AuthApiTest {
 
         JsonNode firstBody = objectMapper.readTree(first.getResponse().getContentAsString());
         JsonNode secondBody = objectMapper.readTree(second.getResponse().getContentAsString());
+        String firstCode = firstBody.get("data").get("linkCode").asText();
+        String secondCode = secondBody.get("data").get("linkCode").asText();
 
-        assertThat(firstBody.get("data").get("linkCode").asText())
-            .isNotEqualTo(secondBody.get("data").get("linkCode").asText());
+        assertThat(firstCode).isNotEqualTo(secondCode);
+
+        // 실제로 이전 코드가 무효화됐는지: 첫 번째 코드로는 로그인이 실패해야 한다.
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"" + firstCode + "\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("LINK_CODE_NOT_FOUND"));
+
+        // 두 번째(최신) 코드로는 로그인이 성공해야 한다.
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"" + secondCode + "\"}"))
+            .andExpect(status().isOk());
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
@@ -20,6 +20,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+// API 인수 테스트 (docs/backend/TEST_CONVENTION.md 참고)
 // 닉네임으로 익명 회원을 생성하고 토큰을 발급받는 흐름이 실제 PostgreSQL 위에서 맞물려 도는지 확인한다.
 @SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
 @AutoConfigureMockMvc

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
@@ -1,6 +1,7 @@
 package com.sssok.presentation.api.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -74,5 +75,58 @@ class AuthApiTest {
                 .content("{\"nickname\":\"\"}"))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("INVALID_NICKNAME"));
+    }
+
+    @Test
+    void 발급받은_토큰으로_연결_코드를_발급받는다() throws Exception {
+        String accessToken = 익명_인증으로_토큰_발급받기();
+
+        mockMvc.perform(post("/auth/link-code")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.linkCode").value(matchesPattern("\\d{6}")))
+            .andExpect(jsonPath("$.data.expiresAt").value(notNullValue()));
+    }
+
+    @Test
+    void 같은_토큰으로_다시_발급받으면_이전_코드가_무효화된다() throws Exception {
+        String accessToken = 익명_인증으로_토큰_발급받기();
+
+        MvcResult first = mockMvc.perform(post("/auth/link-code")
+                .header("Authorization", "Bearer " + accessToken))
+            .andReturn();
+        MvcResult second = mockMvc.perform(post("/auth/link-code")
+                .header("Authorization", "Bearer " + accessToken))
+            .andReturn();
+
+        JsonNode firstBody = objectMapper.readTree(first.getResponse().getContentAsString());
+        JsonNode secondBody = objectMapper.readTree(second.getResponse().getContentAsString());
+
+        assertThat(firstBody.get("data").get("linkCode").asText())
+            .isNotEqualTo(secondBody.get("data").get("linkCode").asText());
+    }
+
+    @Test
+    void Authorization_헤더_없이_연결_코드를_요청하면_401() throws Exception {
+        mockMvc.perform(post("/auth/link-code"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void 형식이_잘못된_토큰으로_요청하면_401() throws Exception {
+        mockMvc.perform(post("/auth/link-code")
+                .header("Authorization", "Bearer not-a-real-token"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    private String 익명_인증으로_토큰_발급받기() throws Exception {
+        MvcResult result = mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"민수\"}"))
+            .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        return body.get("data").get("accessToken").asText();
     }
 }

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
@@ -1,0 +1,77 @@
+package com.sssok.presentation.api.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+// 닉네임으로 익명 회원을 생성하고 토큰을 발급받는 흐름이 실제 PostgreSQL 위에서 맞물려 도는지 확인한다.
+@SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthApiTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 닉네임으로_익명_인증하면_토큰과_userId를_발급받는다() throws Exception {
+        mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"민수\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.accessToken").value(notNullValue()))
+            .andExpect(jsonPath("$.data.userId").value(notNullValue()))
+            .andExpect(jsonPath("$.data.nickname").value("민수"))
+            .andExpect(jsonPath("$.data.expiresAt").value(notNullValue()));
+    }
+
+    @Test
+    void 호출할_때마다_다른_회원이_생성된다() throws Exception {
+        MvcResult first = mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"민수\"}"))
+            .andReturn();
+        MvcResult second = mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"민수\"}"))
+            .andReturn();
+
+        JsonNode firstBody = objectMapper.readTree(first.getResponse().getContentAsString());
+        JsonNode secondBody = objectMapper.readTree(second.getResponse().getContentAsString());
+
+        assertThat(firstBody.get("data").get("userId").asLong())
+            .isNotEqualTo(secondBody.get("data").get("userId").asLong());
+    }
+
+    @Test
+    void 닉네임_없이_요청하면_400() throws Exception {
+        mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_NICKNAME"));
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthApiTest.java
@@ -9,28 +9,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sssok.support.PostgresContainerSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 // API 인수 테스트 (docs/backend/TEST_CONVENTION.md 참고)
 // 닉네임으로 익명 회원을 생성하고 토큰을 발급받는 흐름이 실제 PostgreSQL 위에서 맞물려 도는지 확인한다.
+// PostgresContainerSupport(싱글톤 컨테이너)를 상속하므로 다른 API 인수 테스트와 컨테이너를 공유한다.
 @SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
 @AutoConfigureMockMvc
-@Testcontainers
-class AuthApiTest {
-
-    @Container
-    @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+class AuthApiTest extends PostgresContainerSupport {
 
     @Autowired
     MockMvc mockMvc;

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
@@ -18,6 +18,7 @@ import com.sssok.application.port.out.TokenProvider;
 import com.sssok.domain.auth.exception.InvalidLinkCodeException;
 import com.sssok.domain.member.exception.InvalidNicknameException;
 import java.time.Instant;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -148,5 +149,16 @@ class AuthControllerTest {
                 .content("{\"linkCode\":\"999999\"}"))
             .andExpect(status().isGone())
             .andExpect(jsonPath("$.code").value("LINK_CODE_EXPIRED"));
+    }
+
+    @Test
+    void 매핑되지_않은_예외는_500과_일관된_에러_형식으로_반환된다() throws Exception {
+        given(linkLoginService.login(anyString())).willThrow(new NoSuchElementException());
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"999999\"}"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
     }
 }

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
@@ -10,8 +10,12 @@ import com.sssok.application.auth.AnonymousAuthService;
 import com.sssok.application.auth.AuthResult;
 import com.sssok.application.auth.IssueLinkCodeService;
 import com.sssok.application.auth.LinkCodeResult;
+import com.sssok.application.auth.LinkLoginService;
+import com.sssok.application.auth.exception.LinkCodeExpiredException;
+import com.sssok.application.auth.exception.LinkCodeNotFoundException;
 import com.sssok.application.auth.exception.UnauthorizedException;
 import com.sssok.application.port.out.TokenProvider;
+import com.sssok.domain.auth.exception.InvalidLinkCodeException;
 import com.sssok.domain.member.exception.InvalidNicknameException;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
@@ -35,6 +39,9 @@ class AuthControllerTest {
     @MockitoBean
     IssueLinkCodeService issueLinkCodeService;
 
+    @MockitoBean
+    LinkLoginService linkLoginService;
+
     // AuthMemberArgumentResolver가 의존하는 포트 — Authorization 헤더 파싱 검증에 필요하다.
     @MockitoBean
     TokenProvider tokenProvider;
@@ -44,7 +51,7 @@ class AuthControllerTest {
         given(anonymousAuthService.authenticate(anyString()))
             .willReturn(new AuthResult("token-value", 1L, "민수", Instant.parse("2026-09-17T05:30:00Z")));
 
-        mockMvc.perform(post("/auth/anonymous")
+        mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"민수\"}"))
             .andExpect(status().isCreated())
@@ -59,7 +66,7 @@ class AuthControllerTest {
         given(anonymousAuthService.authenticate(anyString()))
             .willThrow(new InvalidNicknameException("닉네임을 입력해주세요"));
 
-        mockMvc.perform(post("/auth/anonymous")
+        mockMvc.perform(post("/api/v1/auth/anonymous")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"nickname\":\"\"}"))
             .andExpect(status().isBadRequest())
@@ -72,7 +79,7 @@ class AuthControllerTest {
         given(issueLinkCodeService.issue(1L))
             .willReturn(new LinkCodeResult("483920", Instant.parse("2026-08-22T04:15:00Z")));
 
-        mockMvc.perform(post("/auth/link-code")
+        mockMvc.perform(post("/api/v1/auth/link-code")
                 .header("Authorization", "Bearer valid-token"))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.linkCode").value("483920"))
@@ -81,7 +88,7 @@ class AuthControllerTest {
 
     @Test
     void Authorization_헤더가_없으면_401을_반환한다() throws Exception {
-        mockMvc.perform(post("/auth/link-code"))
+        mockMvc.perform(post("/api/v1/auth/link-code"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
@@ -90,9 +97,56 @@ class AuthControllerTest {
     void 토큰_검증에_실패하면_401을_반환한다() throws Exception {
         given(tokenProvider.parse(anyString())).willThrow(new UnauthorizedException("다시 접속해주세요"));
 
-        mockMvc.perform(post("/auth/link-code")
+        mockMvc.perform(post("/api/v1/auth/link-code")
                 .header("Authorization", "Bearer invalid-token"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void 유효한_연결_코드로_로그인하면_200과_토큰_정보를_반환한다() throws Exception {
+        given(linkLoginService.login("483920"))
+            .willReturn(new AuthResult("token-value", 1L, "민수", Instant.parse("2026-09-17T05:30:00Z")));
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"483920\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").value("token-value"))
+            .andExpect(jsonPath("$.data.userId").value(1))
+            .andExpect(jsonPath("$.data.nickname").value("민수"));
+    }
+
+    @Test
+    void 형식이_잘못된_코드면_400을_반환한다() throws Exception {
+        given(linkLoginService.login(anyString())).willThrow(new InvalidLinkCodeException("abc"));
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"abc\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_LINK_CODE"));
+    }
+
+    @Test
+    void 존재하지_않는_코드면_404를_반환한다() throws Exception {
+        given(linkLoginService.login(anyString())).willThrow(new LinkCodeNotFoundException());
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"999999\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("LINK_CODE_NOT_FOUND"));
+    }
+
+    @Test
+    void 만료된_코드면_410을_반환한다() throws Exception {
+        given(linkLoginService.login(anyString())).willThrow(new LinkCodeExpiredException());
+
+        mockMvc.perform(post("/api/v1/auth/link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"linkCode\":\"999999\"}"))
+            .andExpect(status().isGone())
+            .andExpect(jsonPath("$.code").value("LINK_CODE_EXPIRED"));
     }
 }

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
@@ -1,0 +1,57 @@
+package com.sssok.presentation.api.auth;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.auth.AuthResult;
+import com.sssok.domain.member.exception.InvalidNicknameException;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+// AuthController의 요청/응답 매핑과 예외 -> 에러 응답 변환만 검증하는 슬라이스 테스트.
+// Service는 Mock으로 대체하므로 실제 회원 생성·토큰 발급 로직은 이 테스트의 관심사가 아니다.
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    AnonymousAuthService anonymousAuthService;
+
+    @Test
+    void 익명_인증에_성공하면_201과_토큰_정보를_반환한다() throws Exception {
+        given(anonymousAuthService.authenticate(anyString()))
+            .willReturn(new AuthResult("token-value", 1L, "민수", Instant.parse("2026-09-17T05:30:00Z")));
+
+        mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"민수\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.accessToken").value("token-value"))
+            .andExpect(jsonPath("$.data.userId").value(1))
+            .andExpect(jsonPath("$.data.nickname").value("민수"))
+            .andExpect(jsonPath("$.data.expiresAt").value("2026-09-17T05:30:00Z"));
+    }
+
+    @Test
+    void 닉네임이_유효하지_않으면_400과_에러코드를_반환한다() throws Exception {
+        given(anonymousAuthService.authenticate(anyString()))
+            .willThrow(new InvalidNicknameException("닉네임을 입력해주세요"));
+
+        mockMvc.perform(post("/auth/anonymous")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_NICKNAME"));
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/auth/AuthControllerTest.java
@@ -8,6 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.sssok.application.auth.AnonymousAuthService;
 import com.sssok.application.auth.AuthResult;
+import com.sssok.application.auth.IssueLinkCodeService;
+import com.sssok.application.auth.LinkCodeResult;
+import com.sssok.application.auth.exception.UnauthorizedException;
+import com.sssok.application.port.out.TokenProvider;
 import com.sssok.domain.member.exception.InvalidNicknameException;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
@@ -18,7 +22,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 // AuthController의 요청/응답 매핑과 예외 -> 에러 응답 변환만 검증하는 슬라이스 테스트.
-// Service는 Mock으로 대체하므로 실제 회원 생성·토큰 발급 로직은 이 테스트의 관심사가 아니다.
+// Service는 Mock으로 대체하므로 실제 회원 생성·토큰 발급·코드 발급 로직은 이 테스트의 관심사가 아니다.
 @WebMvcTest(AuthController.class)
 class AuthControllerTest {
 
@@ -27,6 +31,13 @@ class AuthControllerTest {
 
     @MockitoBean
     AnonymousAuthService anonymousAuthService;
+
+    @MockitoBean
+    IssueLinkCodeService issueLinkCodeService;
+
+    // AuthMemberArgumentResolver가 의존하는 포트 — Authorization 헤더 파싱 검증에 필요하다.
+    @MockitoBean
+    TokenProvider tokenProvider;
 
     @Test
     void 익명_인증에_성공하면_201과_토큰_정보를_반환한다() throws Exception {
@@ -53,5 +64,35 @@ class AuthControllerTest {
                 .content("{\"nickname\":\"\"}"))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("INVALID_NICKNAME"));
+    }
+
+    @Test
+    void 유효한_토큰으로_연결_코드를_발급받으면_201을_반환한다() throws Exception {
+        given(tokenProvider.parse("valid-token")).willReturn(1L);
+        given(issueLinkCodeService.issue(1L))
+            .willReturn(new LinkCodeResult("483920", Instant.parse("2026-08-22T04:15:00Z")));
+
+        mockMvc.perform(post("/auth/link-code")
+                .header("Authorization", "Bearer valid-token"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.linkCode").value("483920"))
+            .andExpect(jsonPath("$.data.expiresAt").value("2026-08-22T04:15:00Z"));
+    }
+
+    @Test
+    void Authorization_헤더가_없으면_401을_반환한다() throws Exception {
+        mockMvc.perform(post("/auth/link-code"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void 토큰_검증에_실패하면_401을_반환한다() throws Exception {
+        given(tokenProvider.parse(anyString())).willThrow(new UnauthorizedException("다시 접속해주세요"));
+
+        mockMvc.perform(post("/auth/link-code")
+                .header("Authorization", "Bearer invalid-token"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 }

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -8,29 +8,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sssok.support.PostgresContainerSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 // Room 생성 -> 코드로 조회까지 컨트롤러/서비스/리포지토리/Flyway 마이그레이션이
 // 실제 PostgreSQL 위에서 전부 맞물려 도는지 확인하는 관통 테스트 (Walking Skeleton).
 // Flyway가 만든 스키마와 엔티티 매핑이 실제로 맞는지까지 검증한다 (운영과 동일한 검증 모드).
+// PostgresContainerSupport(싱글톤 컨테이너)를 상속하므로 다른 API 인수 테스트와 컨테이너를 공유한다.
 @SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
 @AutoConfigureMockMvc
-@Testcontainers
-class RoomApiTest {
-
-    @Container
-    @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+class RoomApiTest extends PostgresContainerSupport {
 
     @Autowired
     MockMvc mockMvc;

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -40,7 +40,7 @@ class RoomApiTest {
 
     @Test
     void 방을_생성하고_코드로_조회한다() throws Exception {
-        MvcResult createResult = mockMvc.perform(post("/rooms")
+        MvcResult createResult = mockMvc.perform(post("/api/v1/rooms")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"name\":\"우테코 회식\"}"))
             .andExpect(status().isCreated())
@@ -52,7 +52,7 @@ class RoomApiTest {
         JsonNode created = objectMapper.readTree(createResult.getResponse().getContentAsString());
         String code = created.get("data").get("code").asText();
 
-        mockMvc.perform(get("/rooms/{code}", code))
+        mockMvc.perform(get("/api/v1/rooms/{code}", code))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.code").value(code))
             .andExpect(jsonPath("$.data.name").value("우테코 회식"))
@@ -61,7 +61,7 @@ class RoomApiTest {
 
     @Test
     void 이름_없이_생성하면_400() throws Exception {
-        mockMvc.perform(post("/rooms")
+        mockMvc.perform(post("/api/v1/rooms")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"name\":\"\"}"))
             .andExpect(status().isBadRequest())
@@ -70,14 +70,14 @@ class RoomApiTest {
 
     @Test
     void 존재하지_않는_코드로_조회하면_404() throws Exception {
-        mockMvc.perform(get("/rooms/{code}", "23456789"))
+        mockMvc.perform(get("/api/v1/rooms/{code}", "23456789"))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("ROOM_NOT_FOUND"));
     }
 
     @Test
     void 형식이_잘못된_코드로_조회하면_400() throws Exception {
-        mockMvc.perform(get("/rooms/{code}", "invalid-code"))
+        mockMvc.perform(get("/api/v1/rooms/{code}", "invalid-code"))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("INVALID_ROOM_CODE"));
     }

--- a/backend/src/test/java/com/sssok/support/PostgresContainerSupport.java
+++ b/backend/src/test/java/com/sssok/support/PostgresContainerSupport.java
@@ -1,0 +1,26 @@
+package com.sssok.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+// Testcontainers "싱글톤 컨테이너" 패턴
+// @Container(JUnit 확장의 클래스별 생명주기 관리) 대신 static 초기화 블록에서 한 번만 띄우고 stop() 안함
+// JVM(테스트 실행) 하나에 컨테이너 하나만 뜨고, 이 클래스를 상속하는 모든 API 인수 테스트가 같은 컨테이너를 공유
+// 정리는 Testcontainers 자체의 Ryuk 리소스 리퍼가 테스트 실행이 끝나면 자동으로 처리
+public abstract class PostgresContainerSupport {
+
+    static final PostgreSQLContainer<?> POSTGRES;
+
+    static {
+        POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void registerDatasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,7 +1,3 @@
-# Repository+Service 통합 테스트(H2) 전용 프로파일. @ActiveProfiles("test")로 활성화한다.
-# Flyway 마이그레이션은 PostgreSQL 전용 문법(BIGSERIAL, TIMESTAMPTZ 등)을 쓰므로 H2에서 그대로
-# 돌리지 않고, Hibernate가 엔티티로부터 스키마를 직접 생성하게 한다.
-# (실제 마이그레이션-엔티티 정합성 검증은 API 인수 테스트의 ddl-auto=validate가 담당한다.)
 spring:
   datasource:
     url: jdbc:h2:mem:sssok-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+# Repository+Service 통합 테스트(H2) 전용 프로파일. @ActiveProfiles("test")로 활성화한다.
+# Flyway 마이그레이션은 PostgreSQL 전용 문법(BIGSERIAL, TIMESTAMPTZ 등)을 쓰므로 H2에서 그대로
+# 돌리지 않고, Hibernate가 엔티티로부터 스키마를 직접 생성하게 한다.
+# (실제 마이그레이션-엔티티 정합성 검증은 API 인수 테스트의 ddl-auto=validate가 담당한다.)
+spring:
+  datasource:
+    url: jdbc:h2:mem:sssok-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  flyway:
+    enabled: false
+
+# 테스트 전용 키. 운영 시크릿과 무관하며 실제 배포에는 쓰이지 않는다.
+jwt:
+  secret: mvtcAhMGbXlhpJ4JuIvRWJVF+yMUju6PxRCb/FMojgA=

--- a/docs/backend/TEST_CONVENTION.md
+++ b/docs/backend/TEST_CONVENTION.md
@@ -50,12 +50,12 @@ DB나 전체 Spring Context를 띄우지 않아 실행이 빠르다. Service 내
 
 Flyway 마이그레이션은 PostgreSQL 전용 문법(`BIGSERIAL`, `TIMESTAMPTZ` 등)을 쓰므로 H2에서 그대로 실행되지 않는다. Repository+Service 테스트는 Flyway를 끄고 Hibernate가 엔티티로부터 스키마를 직접 생성하도록 한다 (실제 마이그레이션-엔티티 정합성 검증은 API 인수 테스트의 `ddl-auto=validate`가 담당하므로 역할이 겹치지 않는다).
 
+H2 설정(데이터소스, `ddl-auto`, Flyway 끄기, 테스트 전용 `jwt.secret`)은 테스트 클래스마다 반복해서 적지 않고, `backend/src/test/resources/application-test.yml`(`test` 프로파일) 하나에 모아뒀다. 새 Repository+Service 테스트를 추가할 때는 아래처럼 프로파일만 지정하면 된다.
+
 ```java
 @SpringBootTest
-@TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:h2:mem:auth-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
-    "spring.datasource.driver-class-name=org.h2.Driver",
-    "spring.jpa.hibernate.ddl-auto=create-drop",
-    "spring.flyway.enabled=false"
-})
+@ActiveProfiles("test")
+class SomeServiceTest {
+    // ...
+}
 ```

--- a/docs/backend/TEST_CONVENTION.md
+++ b/docs/backend/TEST_CONVENTION.md
@@ -1,0 +1,61 @@
+# 백엔드 테스트 컨벤션
+
+계층마다 검증 목적이 다르므로, 테스트 종류와 DB를 계층별로 다르게 가져간다.
+
+## 요약
+
+| 계층 | 테스트 종류 | DB | 주요 도구 |
+| --- | --- | --- | --- |
+| Repository + Service | 통합 테스트 | 기본 H2, PostgreSQL 전용 기능만 Testcontainers | `@DataJpaTest`/`@SpringBootTest` + JUnit |
+| Controller | 슬라이스 테스트 | 없음(Mock) | `@WebMvcTest` + `MockMvc` |
+| API 인수 테스트 | 통합 테스트 | Testcontainers(PostgreSQL) | `@SpringBootTest` + `MockMvc` |
+
+## 1. Repository + Service — 통합 테스트
+
+Repository와 Service를 계층별로 쪼개 각각 단위 테스트하지 않고, **하나의 통합 테스트**로 같이 검증한다. Service가 Repository를 실제로 호출했을 때의 동작(저장·조회 결과)까지 한 번에 확인하는 게 목적이라, Mock으로 Repository를 대체하지 않는다.
+
+- **기본 CRUD·일반 로직**은 H2로 검증한다. 실행이 빠르고 대부분의 케이스는 어떤 RDB를 쓰든 동작이 같다.
+- **해당 DB에 종속적인 내용**(PostgreSQL 전용 타입·함수, JSONB, 네이티브 쿼리 등)은 H2로 검증할 수 없으므로 Testcontainers로 실제 PostgreSQL을 띄워 검증한다.
+- 하나의 기능 안에서도 두 그룹이 섞일 수 있다 — 일반 CRUD 부분은 H2 테스트로, PostgreSQL 전용 기능을 쓰는 부분만 별도로 Testcontainers 테스트를 추가한다.
+
+예시(이 저장소 기준):
+- `RoomRepository.save`/`findByCode`, `CreateRoomService`/`GetRoomService`의 흐름 검증 → H2
+- 이후 JSONB 컬럼이나 PostgreSQL 전용 인덱스/쿼리를 쓰는 기능이 생기면, 그 부분만 Testcontainers로 별도 검증
+
+## 2. Controller — 슬라이스 테스트
+
+`@WebMvcTest`로 웹 계층만 띄우는 슬라이스 테스트를 작성한다. Service는 `@MockBean`으로 대체하고, `MockMvc`로 다음만 확인한다.
+
+- 요청 매핑(`@PathVariable`, `@RequestBody` 등)이 올바른지
+- 응답 형식(`ApiResponse`, HTTP 상태 코드)이 올바른지
+- 유효성 검증 실패·예외 발생 시 `GlobalExceptionHandler`가 기대한 에러 응답으로 변환하는지
+
+DB나 전체 Spring Context를 띄우지 않아 실행이 빠르다. Service 내부 로직 자체는 이 테스트의 관심사가 아니다(1번에서 이미 검증됨).
+
+## 3. API 인수 테스트 — 통합 테스트
+
+컨트롤러 → 서비스 → 리포지토리 → DB까지 전체 흐름이 실제로 맞물려 동작하는지 확인하는 테스트다. `@SpringBootTest` + `@AutoConfigureMockMvc`로 애플리케이션 컨텍스트를 통째로 띄우고, Testcontainers로 실제 PostgreSQL을 연결한 뒤 `MockMvc`로 실제 HTTP 요청처럼 호출한다.
+
+- Mock을 쓰지 않는다 — 실제 DB, 실제 Flyway 마이그레이션, 실제 JPA 매핑까지 전부 맞물려야 통과한다.
+- `spring.jpa.hibernate.ddl-auto=validate`로 고정해서, Flyway가 만든 스키마와 엔티티 매핑이 실제로 일치하는지도 함께 검증한다.
+- 이미 이 저장소의 `RoomApiTest`, `AuthApiTest`가 이 계층에 해당한다.
+
+## 현재 적용 현황
+
+- **Auth(익명 인증) 기능**은 3단계 구조를 모두 적용했다: `AnonymousAuthServiceTest`(Repository+Service, H2) / `AuthControllerTest`(Controller 슬라이스) / `AuthApiTest`(API 인수 테스트, Testcontainers)
+- **Room·Folder 기능**(`RoomApiTest`)은 아직 API 인수 테스트만 있다 — Room을 다시 손보게 되면 이 구조로 맞춰 나간다
+- H2 의존성(`com.h2database:h2`)은 `backend/build.gradle`에 추가되어 있다
+
+## H2 통합 테스트 작성 시 참고
+
+Flyway 마이그레이션은 PostgreSQL 전용 문법(`BIGSERIAL`, `TIMESTAMPTZ` 등)을 쓰므로 H2에서 그대로 실행되지 않는다. Repository+Service 테스트는 Flyway를 끄고 Hibernate가 엔티티로부터 스키마를 직접 생성하도록 한다 (실제 마이그레이션-엔티티 정합성 검증은 API 인수 테스트의 `ddl-auto=validate`가 담당하므로 역할이 겹치지 않는다).
+
+```java
+@SpringBootTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:auth-service-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false"
+})
+```


### PR DESCRIPTION
> **리뷰 가이드**: 이 PR은 인증/인가 이슈(#38)의 API 3개를 한 번에 담고 있어서 diff가 큽니다. 
전체 diff를 한 번에 보시기보다 커밋 단위로 4단계에 걸쳐 보면 좋을거 같아요!!

> 1. **인증 인프라** : Member 도메인 재정의, JWT 발급, Bearer 인증 메커니즘 (`71d0755`~`cb606c3`, 5개 커밋)
> 2. **익명 인증 API** : `POST /auth/anonymous` + 테스트 컨벤션 문서화 + CI 버그 수정 (`cd4cffe`~`35c41af`, 5개 커밋)
> 3. **연결 코드 발급 API** : LinkCode 도메인 + `POST /auth/link-code` (`4f8aeec`~`2ff6033`, 5개 커밋)
> 4. **baseURL 통일 + 연결 코드 로그인 API** : `POST /auth/link` (`2ac19fc`~`ee9f399`, 6개 커밋)
>
> 시간이 없으시면 3번(핵심 도메인)과 맨 아래 "리뷰 요청 사항"만 먼저 봐주셔도 됩니다.

## 작업 내용
로그인이 없는 서비스라, 닉네임만으로 익명 계정을 만들고 토큰으로 본인을 증명하는 구조를 만들었습니다.
이슈 노션 API v2버전을 기반으로 #38를 만들었고 그 내용대로 구현했습니다. 

명세에 "정해야 할 것"으로 남아있던 부분(토큰 유효기간, 코드 형식, 동시 세션 처리 등)은 이번에 직접 정해서 코드에 반영했습니다.

### 1. API 구현
- `POST /auth/anonymous` — 닉네임으로 익명 회원 생성 + 토큰 발급
- `POST /auth/link-code` — 로그인된 사용자가 다른 기기로 넘길 6자리 연결 코드 발급 (5분 유효, 재발급하면 이전 코드는 바로 무효화됨)
- `POST /auth/link` — 연결 코드로 같은 계정의 새 토큰 발급 (1회용, 쓰는 순간 폐기)

### 2. Spring Security를 안 쓰고 직접 구현과 이유
지금 필요한 인증은 "Authorization 헤더의 토큰에서 memberId 하나 꺼내기"가 전부입니다. 
Spring Security는 로그인 폼, 세션, 역할(Role) 체계, `UserDetailsService` 같은 걸 위한 프레임워크라 이 서비스 규모엔 오히려 무겁다고 판단했습니다. 
그래서 `@AuthMember` 커스텀 어노테이션 + `HandlerMethodArgumentResolver`로 직접 구현해서, 이미 있는 `TokenProvider`(JWT 검증)와 자연스럽게 이어지도록 했다.

### 3. 다중 디바이스 연결 방식 : 연결 코드(Link Code)로 한 이유

방장이 다른 기기로 넘어갈 때 같은 계정을 어떻게 이어받을지 여러 방식을 검토했고, 트레이드오프는 노션에 정리해뒀습니다.

#### 캡퍼빌리티 링크
캡퍼빌리티 링크는 구글 폼 독스 처럼 동시에 여러 사람이 같이 방장역할로 편집하는 경우가 거의 없다고 판단했고,
방장이 그저 다른 디바이스에서 이어받아서 작업을 하는것이 중요해서 과하다고 판단.

#### 페어링 코드
현재 상황에서, SSE, Redis를 도입하고 기능으로 구현할 난이도가 높고, 나중에 발전 시키면 좋을거 같다고 판단했다.

#### 1회용 연결 코드 
이번에 실제로 구현한 건 연결 코드 방식입니다.
원래 기기에서 1회용 코드를 발급받아 새 기기에 입력하면 이어받아지는, 
발급과 사용 시점이 분리된 일방향·비동기 흐름입니다. (카톡 "나에게 보내기"로 전달해두고 나중에 입력해도 된다).

### 4. 테스트 컨벤션

지금까지는 인수 테스트 하나로 전체 흐름만 검증했는데, 이전에 백엔드 회의에서 이야기한 내용을 토대로 문서화했습니다. 
- Repository+Service(통합 테스트, 기본은 H2 · PostgreSQL 전용 기능만 Testcontainers)
- Controller(슬라이스 테스트, MockMvc) 
- API 인수 테스트(통합, Testcontainers) 3단계로 나눴고

이번 인증 기능에 3단계를 전부 실제로 적용해서 앞으로 참고할 예시로 남겨뒀습니다.

### 5. base url WebConfig 에 통일

그리고 API 베이스 경로를 `/api/v1`로 통일했습니다.
`HealthController`는 배포 헬스체크가 그대로 참조하는 엔드포인트라 접두사에서 제외했다 (실서버 띄워서 `/health`, `/api/v1/auth/*` 둘 다 확인함).

## 관련 이슈
Closes #38

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] 닉네임 기반 익명 인증 — Member 도메인을 "방 참여 기록"에서 "방과 무관한 전역 계정"으로 재정의
- [x] JWT 발급/검증 + Authorization: Bearer 인증 메커니즘 (Spring Security 미사용, 직접 구현)
- [x] 연결 코드 발급/로그인 — 다중 디바이스 연결 방식 검토(노션 정리) 후 채택한 방식, 1회용 코드는 로그인 성공 시 즉시 삭제
- [x] API 베이스 경로 `/api/v1` 통일
- [x] 백엔드 테스트 컨벤션 문서화(`docs/backend/TEST_CONVENTION.md`) 및 적용 — Repository+Service(H2) / Controller 슬라이스 / API 인수 테스트 3단계
- [x] CI에서 `jwt.secret`이 안 채워져서 나던 NPE 버그 수정 (로컬에서만 존재하는 gitignore 파일에 의존하고 있었음)

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)

- Member 도메인을 이번에 "방 참여 기록"에서 "전역 계정"으로 바꿨습니다.(`roomId` 제거, `join()` → `register()`). 
#25에서 만든 도메인이라 현미밥이 담당자여서 한 번 봐주면 좋을거 같아요 !

- 연결 코드는 별도 `usedAt` 플래그 없이, 로그인에 성공하면 행 자체를 삭제하는 방식으로 "1회용"을 구현했다. 그래서 "존재하지 않음"과 "이미 사용됨"이 둘 다 같은 404로 응답됩니다.

- LinkCode는 지금 DB(Postgres)에 저장하고 있는데, 나중엔 Redis로 옮기는게 좋을거 같습니다! 
5분짜리 1회용 코드라 TTL 기반 저장소가 훨씬 잘 맞고, 429(브루트포스 방지) 레이트리미팅도 결국 Redis가 필요해서, 
그때 LinkCode도 같이 옮기는 게 좋을거 같습니다!. 지금은 Redis 인프라 자체가 없어서 일단 DB로 진행했습니다!

- **토큰 유효기간(30일) · revocation 없음** — refresh token 없이 access token을 30일로 길게 잡았는데, 토큰을 강제로 무효화할 수단이 전혀 없습니다. 토큰이 탈취되면 만료될 때까지 30일을 막을 방법이 없다는 뜻인데, 방 자체는 24시간짜리라는 걸 감안했을 때 이 정도 트레이드오프가 괜찮은지 판단 부탁드립니다.

- **다중 세션 허용(원래 기기 토큰 무효화 안 함)** — 연결 코드로 새 기기에서 로그인해도 원래 기기의 토큰은 계속 유효합니다. 그래서 지금 흐름은 "이전"보다는 "복제"에 가까운데, 이게 의도한 정책이 맞는지, 아니면 새 기기 로그인 시 원래 토큰을 무효화하는 쪽이 나은지 의견 주시면 좋겠습니다.

- **연결 코드 브루트포스 방지 전무(429 미구현)** — 코드가 6자리 숫자(100만 가지)인데 시도 횟수 제한이 전혀 없습니다. 5분 TTL이 어느 정도 방어는 되지만, 레이트리미팅 없이 지금 상태로 먼저 merge해도 괜찮을지 판단 부탁드립니다.

- **`/api/v1` 접두사를 애플리케이션 코드(WebConfig)에서 처리** — 나중에 리버스 프록시나 API 게이트웨이 레벨에서 경로를 붙이는 방식으로 갈 수도 있어서, 지금처럼 Spring 애플리케이션 안에서 처리하는 게 맞는 방향인지도 봐주시면 좋겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 닉네임으로 익명 회원을 생성하고 액세스 토큰을 발급받을 수 있습니다.
  * 1회용 연결 코드를 발급해 다른 환경에서 간편하게 로그인할 수 있습니다.
  * 연결 코드의 만료, 재사용 방지 및 동시 사용을 지원합니다.
  * 인증이 필요한 API에서 Bearer 토큰 인증을 사용할 수 있습니다.
  * 인증 API가 `/api/v1` 경로로 제공되며, OpenAPI 문서에 인증 방식이 표시됩니다.

* **개선 사항**
  * 잘못되거나 만료된 인증·연결 코드에 대해 일관된 오류 응답을 제공합니다.
  * 회원이 특정 방에 종속되지 않는 전역 계정으로 변경되었습니다.

* **테스트**
  * 인증 및 연결 코드의 주요 성공·실패 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->