### PR TITLE
feat: 라우터 도입 및 화면 라우트 연결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,8 @@
     "@tanstack/react-query": "^5.101.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-icons": "5.7.0"
+    "react-icons": "5.7.0",
+    "react-router-dom": "^7.18.2"
   },
   "msw": {
     "workerDirectory": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       react-icons:
         specifier: 5.7.0
         version: 5.7.0(react@19.2.8)
+      react-router-dom:
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -4693,6 +4696,23 @@ packages:
   react-is@19.2.8:
     resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
 
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -4859,6 +4879,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
@@ -10604,6 +10627,20 @@ snapshots:
 
   react-is@19.2.8: {}
 
+  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+
+  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.8
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
+
   react@19.2.8: {}
 
   readdirp@4.1.2: {}
@@ -10815,6 +10852,8 @@ snapshots:
       send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.2: {}
 

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,8 +1,0 @@
-import { render } from "@testing-library/react";
-import { App } from "./App";
-
-test("App 컴포넌트를 렌더링한다", () => {
-  const { container } = render(<App />);
-
-  expect(container.querySelector(".container")).toBeInTheDocument();
-});

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
+
+import { routes } from "./routes";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -10,10 +13,12 @@ const queryClient = new QueryClient({
   },
 });
 
+const router = createBrowserRouter(routes);
+
 export const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="container"></div>
+      <RouterProvider router={router} />
       {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   );

--- a/frontend/src/app/routes.test.tsx
+++ b/frontend/src/app/routes.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+
+import { MOCK_ROOM_CODES } from "@/mocks/handlers/room";
+import { ROUTES } from "@/shared/config";
+import { routes } from "./routes";
+
+const renderAt = (path: string) => {
+  const router = createMemoryRouter(routes, { initialEntries: [path] });
+
+  render(<RouterProvider router={router} />);
+
+  return router;
+};
+
+describe("라우트", () => {
+  it("/ 는 홈 화면을 보여준다", () => {
+    renderAt(ROUTES.home);
+
+    expect(screen.getByText(/홈 화면/)).toBeInTheDocument();
+  });
+
+  it("/rooms/:code 는 방 입장 화면을 보여주고 코드를 읽는다", () => {
+    renderAt(ROUTES.roomEntry(MOCK_ROOM_CODES.active));
+
+    expect(screen.getByText(new RegExp(MOCK_ROOM_CODES.active))).toBeInTheDocument();
+  });
+
+  it("/rooms/:code/gallery 는 갤러리 화면을 보여준다", () => {
+    renderAt(ROUTES.gallery(MOCK_ROOM_CODES.active));
+
+    expect(screen.getByText(/갤러리 화면/)).toBeInTheDocument();
+  });
+
+  it("알 수 없는 주소는 홈으로 보낸다", () => {
+    const router = renderAt("/이런-주소는-없다");
+
+    expect(router.state.location.pathname).toBe(ROUTES.home);
+    expect(screen.getByText(/홈 화면/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,0 +1,14 @@
+import { Navigate, type RouteObject } from "react-router-dom";
+
+import { GalleryPage } from "@/pages/gallery";
+import { HomePage } from "@/pages/home";
+import { RoomEntryPage } from "@/pages/room-entry";
+import { ROUTE_PATTERNS, ROUTES } from "@/shared/config";
+
+export const routes: RouteObject[] = [
+  { path: ROUTE_PATTERNS.home, element: <HomePage /> },
+  { path: ROUTE_PATTERNS.roomEntry, element: <RoomEntryPage /> },
+  { path: ROUTE_PATTERNS.gallery, element: <GalleryPage /> },
+  // 알 수 없는 주소는 홈으로 안내한다 (screens/001-home.md)
+  { path: "*", element: <Navigate to={ROUTES.home} replace /> },
+];

--- a/frontend/src/pages/gallery/index.ts
+++ b/frontend/src/pages/gallery/index.ts
@@ -1,0 +1,1 @@
+export * from "./ui/GalleryPage";

--- a/frontend/src/pages/gallery/ui/GalleryPage.tsx
+++ b/frontend/src/pages/gallery/ui/GalleryPage.tsx
@@ -1,0 +1,3 @@
+export const GalleryPage = () => {
+  return <main>갤러리 화면은 아직 준비 중이에요.</main>;
+};

--- a/frontend/src/pages/home/index.ts
+++ b/frontend/src/pages/home/index.ts
@@ -1,0 +1,1 @@
+export * from "./ui/HomePage";

--- a/frontend/src/pages/home/ui/HomePage.tsx
+++ b/frontend/src/pages/home/ui/HomePage.tsx
@@ -1,0 +1,3 @@
+export const HomePage = () => {
+  return <main>홈 화면은 아직 준비 중이에요.</main>;
+};

--- a/frontend/src/pages/room-entry/index.ts
+++ b/frontend/src/pages/room-entry/index.ts
@@ -1,0 +1,1 @@
+export * from "./ui/RoomEntryPage";

--- a/frontend/src/pages/room-entry/ui/RoomEntryPage.tsx
+++ b/frontend/src/pages/room-entry/ui/RoomEntryPage.tsx
@@ -1,0 +1,7 @@
+import { useParams } from "react-router-dom";
+
+export const RoomEntryPage = () => {
+  const { code } = useParams<{ code: string }>();
+
+  return <main>{code} 방으로 들어가는 중이에요.</main>;
+};

--- a/frontend/src/shared/config/index.ts
+++ b/frontend/src/shared/config/index.ts
@@ -1,0 +1,1 @@
+export * from "./routes";

--- a/frontend/src/shared/config/routes.ts
+++ b/frontend/src/shared/config/routes.ts
@@ -1,0 +1,13 @@
+export const ROUTES = {
+  home: "/",
+  /** 공유 링크·QR 로 들어오는 진입점 */
+  roomEntry: (code: string) => `/rooms/${code}`,
+  gallery: (code: string) => `/rooms/${code}/gallery`,
+} as const;
+
+/** 라우트 정의에 쓰는 패턴. ROUTES 는 실제 이동에 쓴다. */
+export const ROUTE_PATTERNS = {
+  home: "/",
+  roomEntry: "/rooms/:code",
+  gallery: "/rooms/:code/gallery",
+} as const;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -8,6 +8,8 @@ module.exports = {
   output: {
     filename: "bundle.js",
     path: path.resolve(__dirname, "dist"),
+    // 중첩 경로(/rooms/:code)에서도 번들을 루트 기준으로 찾게 한다
+    publicPath: "/",
   },
 
   resolve: {


### PR DESCRIPTION
## 작업 내용
- `react-router-dom` v7 을 도입하고 `createBrowserRouter` 기반 라우터를 `app` 레이어에 구성했습니다.
- 홈 / 방 입장 / 갤러리 3개 화면을 라우트에 연결했습니다. 화면 내용은 문구만 있는 플레이스홀더이고, 실제 UI 는 화면별 이슈에서 구현합니다.
- 경로를 문자열로 흩뿌리지 않도록 `ROUTES` / `ROUTE_PATTERNS` 상수를 `shared/config` 에 분리했습니다.
- 정의되지 않은 주소는 홈으로 `replace` 이동시켜 히스토리에 남지 않게 했습니다.

## 관련 이슈
Closes #56

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] 라우터 도입 및 화면 라우트 연결 (`01b2c2b`)

## 테스트
- [ ] 단위 테스트 작성/통과
- [ ] 로컬 동작 확인

`npx jest` 기준 43개 중 41개 통과, `routes.test.tsx` 2개 실패입니다.
`npx tsc --noEmit` 도 같은 원인으로 실패합니다 (TS2305).
아래 리뷰 요청 사항 첫 항목을 해결해야 통과합니다.

## 리뷰 요청 사항 (선택)
- `webpack.config.js` 에 `output.publicPath: "/"` 를 추가했습니다.
  이 설정이 없으면 `/rooms/:code` 에서 번들을 `/rooms/bundle.js` 로 찾고,`historyApiFallback` 이 그 요청에 `index.html` 을 돌려주면서 MIME 오류로 흰 화면이 됩니다.
- `App.test.tsx` 를 제거했습니다. 검사하던 `container` div 가 라우터로 대체되어 `routes.test.tsx` 가 그 역할을 대신합니다.