### PR TITLE
feat: 방 생성 폼 UI 구현

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,5 +1,6 @@
 import { Navigate, type RouteObject } from "react-router-dom";
 
+import { CreateRoomPage } from "@/pages/create-room";
 import { GalleryPage } from "@/pages/gallery";
 import { HomePage } from "@/pages/home";
 import { RoomEntryPage } from "@/pages/room-entry";
@@ -7,6 +8,7 @@ import { ROUTE_PATTERNS, ROUTES } from "@/shared/config";
 
 export const routes: RouteObject[] = [
   { path: ROUTE_PATTERNS.home, element: <HomePage /> },
+  { path: ROUTE_PATTERNS.createRoom, element: <CreateRoomPage /> },
   { path: ROUTE_PATTERNS.roomEntry, element: <RoomEntryPage /> },
   { path: ROUTE_PATTERNS.gallery, element: <GalleryPage /> },
   // 알 수 없는 주소는 홈으로 안내한다 (screens/001-home.md)

--- a/frontend/src/features/create-room/index.ts
+++ b/frontend/src/features/create-room/index.ts
@@ -1,0 +1,2 @@
+export { CreateRoomForm } from "./ui/form/CreateRoomForm";
+export type { CreateRoomFormValues } from "./model/createRoomForm";

--- a/frontend/src/features/create-room/model/createRoomForm.ts
+++ b/frontend/src/features/create-room/model/createRoomForm.ts
@@ -1,0 +1,13 @@
+export interface CreateRoomFormValues {
+  nickname: string;
+  name: string;
+  uploadPolicy: string;
+  expiryHours: string;
+}
+
+export const INITIAL_CREATE_ROOM_FORM: CreateRoomFormValues = {
+  nickname: "",
+  name: "",
+  uploadPolicy: "everyone",
+  expiryHours: "24",
+};

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.styles.ts
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.styles.ts
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+
+import { spacing } from "@/shared/styles/tokens";
+
+export const Form = styled.form`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  width: 100%;
+  padding: ${spacing[16]};
+`;
+
+export const SubmitArea = styled.div`
+  width: 100%;
+  margin-top: auto;
+`;

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.test.tsx
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CreateRoomForm } from "./CreateRoomForm";
+
+describe("CreateRoomForm", () => {
+  it("입력값을 하나의 객체로 전달한다", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = jest.fn();
+
+    render(<CreateRoomForm onSubmit={handleSubmit} />);
+
+    const submitButton = screen.getByRole("button", { name: "방 만들기" });
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByRole("textbox", { name: "내 이름" }), "민수");
+    await user.type(screen.getByRole("textbox", { name: "방 이름" }), "제주 여행");
+    await user.click(screen.getByRole("radio", { name: "방장만" }));
+    await user.click(screen.getByRole("radio", { name: "3일" }));
+    await user.click(submitButton);
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      nickname: "민수",
+      name: "제주 여행",
+      uploadPolicy: "host",
+      expiryHours: "72",
+    });
+  });
+});

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.tsx
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.tsx
@@ -1,0 +1,79 @@
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { RadioGroup } from "@/shared/ui/radio-group";
+import { INITIAL_CREATE_ROOM_FORM, type CreateRoomFormValues } from "../../model/createRoomForm";
+import { Form, SubmitArea } from "./CreateRoomForm.styles";
+import { Stack } from "@/shared/ui/stack";
+
+interface CreateRoomFormProps {
+  onSubmit?: (values: CreateRoomFormValues) => void;
+}
+
+export const CreateRoomForm = ({ onSubmit }: CreateRoomFormProps) => {
+  const [formValues, setFormValues] = useState<CreateRoomFormValues>(INITIAL_CREATE_ROOM_FORM);
+
+  const updateField = (name: keyof CreateRoomFormValues) => (value: string) => {
+    setFormValues((previous) => ({ ...previous, [name]: value }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit?.(formValues);
+  };
+
+  const isValid = Boolean(formValues.nickname.trim() && formValues.name.trim());
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Input
+        label="내 이름"
+        name="nickname"
+        value={formValues.nickname}
+        maxLength={12}
+        placeholder="예) 민수"
+        onValueChange={updateField("nickname")}
+      />
+
+      <Input
+        label="방 이름"
+        name="name"
+        value={formValues.name}
+        maxLength={12}
+        placeholder="예) 제주 여행"
+        onValueChange={updateField("name")}
+      />
+
+      <Stack gap={16}>
+        <RadioGroup
+          label="업로드 권한"
+          name="uploadPolicy"
+          value={formValues.uploadPolicy}
+          options={[
+            { label: "누구나", value: "everyone" },
+            { label: "방장만", value: "host" },
+          ]}
+          onValueChange={updateField("uploadPolicy")}
+        />
+
+        <RadioGroup
+          label="방 만료 시간"
+          name="expiryHours"
+          value={formValues.expiryHours}
+          options={[
+            { label: "1일", value: "24" },
+            { label: "3일", value: "72" },
+          ]}
+          onValueChange={updateField("expiryHours")}
+        />
+      </Stack>
+
+      <SubmitArea>
+        <Button size="lg" type="submit" disabled={!isValid}>
+          방 만들기
+        </Button>
+      </SubmitArea>
+    </Form>
+  );
+};

--- a/frontend/src/pages/create-room/index.ts
+++ b/frontend/src/pages/create-room/index.ts
@@ -1,0 +1,1 @@
+export { CreateRoomPage } from "./ui/CreateRoomPage";

--- a/frontend/src/pages/create-room/ui/CreateRoomPage.styles.ts
+++ b/frontend/src/pages/create-room/ui/CreateRoomPage.styles.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const Page = styled.main`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  width: 100%;
+`;

--- a/frontend/src/pages/create-room/ui/CreateRoomPage.tsx
+++ b/frontend/src/pages/create-room/ui/CreateRoomPage.tsx
@@ -1,0 +1,12 @@
+import { CreateRoomForm } from "@/features/create-room";
+import { CreateRoomHeader } from "./header/CreateRoomHeader";
+import { Page } from "./CreateRoomPage.styles";
+
+export const CreateRoomPage = () => {
+  return (
+    <Page>
+      <CreateRoomHeader />
+      <CreateRoomForm />
+    </Page>
+  );
+};

--- a/frontend/src/pages/create-room/ui/header/CreateRoomHeader.styles.ts
+++ b/frontend/src/pages/create-room/ui/header/CreateRoomHeader.styles.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+
+import { colors, spacing, typography } from "@/shared/styles/tokens";
+
+export const Header = styled.header`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 56px;
+  padding: 0 ${spacing[12]} 0 ${spacing[8]};
+`;
+
+export const Title = styled.h1`
+  color: ${colors.textStrong};
+
+  ${typography.heading3}
+`;

--- a/frontend/src/pages/create-room/ui/header/CreateRoomHeader.tsx
+++ b/frontend/src/pages/create-room/ui/header/CreateRoomHeader.tsx
@@ -1,0 +1,18 @@
+import { HiArrowLeft } from "react-icons/hi2";
+import { useNavigate } from "react-router-dom";
+
+import { IconButton } from "@/shared/ui/icon-button";
+import { Header, Title } from "./CreateRoomHeader.styles";
+
+export const CreateRoomHeader = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Header>
+      <IconButton aria-label="이전 화면" onClick={() => navigate(-1)}>
+        <HiArrowLeft />
+      </IconButton>
+      <Title>방 만들기</Title>
+    </Header>
+  );
+};

--- a/frontend/src/shared/config/routes.ts
+++ b/frontend/src/shared/config/routes.ts
@@ -1,5 +1,7 @@
 export const ROUTES = {
   home: "/",
+  createRoom: "/rooms/create",
+  joinRoom: "/rooms/join",
   /** 공유 링크·QR 로 들어오는 진입점 */
   roomEntry: (code: string) => `/rooms/${code}`,
   gallery: (code: string) => `/rooms/${code}/gallery`,

--- a/frontend/src/shared/config/routes.ts
+++ b/frontend/src/shared/config/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
 /** 라우트 정의에 쓰는 패턴. ROUTES 는 실제 이동에 쓴다. */
 export const ROUTE_PATTERNS = {
   home: "/",
+  createRoom: "/rooms/create",
   roomEntry: "/rooms/:code",
   gallery: "/rooms/:code/gallery",
 } as const;

--- a/frontend/src/shared/styles/GlobalStyles.tsx
+++ b/frontend/src/shared/styles/GlobalStyles.tsx
@@ -1,6 +1,6 @@
 import { Global, css } from "@emotion/react";
 import "./fonts/fonts.css";
-import { colors, spacing } from "./tokens";
+import { colors } from "./tokens";
 
 export const GlobalStyles = () => (
   <Global
@@ -120,7 +120,6 @@ export const GlobalStyles = () => (
         display: flex;
         flex-direction: column;
         overflow-x: hidden;
-        padding: ${spacing[16]};
 
         @media (min-width: 768px) {
           max-width: 1180px;

--- a/frontend/src/shared/ui/input/Input.stories.tsx
+++ b/frontend/src/shared/ui/input/Input.stories.tsx
@@ -5,14 +5,14 @@ import { Input } from "./Input";
 import type { InputProps } from "./Input";
 
 const InteractiveInput = (props: InputProps) => {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(props.value);
 
   return (
     <Input
       {...props}
       value={value}
       readOnly={false}
-      onChange={(event) => setValue(event.target.value.slice(0, props.maxLength))}
+      onValueChange={setValue}
     />
   );
 };
@@ -25,6 +25,7 @@ const meta = {
     value: "",
     maxLength: 10,
     placeholder: "이름을 입력해주세요.",
+    onValueChange: () => undefined,
     readOnly: true,
   },
 } satisfies Meta<typeof Input>;

--- a/frontend/src/shared/ui/input/Input.test.tsx
+++ b/frontend/src/shared/ui/input/Input.test.tsx
@@ -1,13 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 
 import { colors } from "@/shared/styles/tokens";
 import { Input } from "./Input";
-import { useState } from "react";
+
+const handleValueChange = jest.fn();
 
 describe("Input", () => {
   it("입력값과 글자 수를 렌더링한다", () => {
-    render(<Input label="이름" value="윤돌" maxLength={10} readOnly />);
+    render(
+      <Input
+        label="이름"
+        value="윤돌"
+        maxLength={10}
+        onValueChange={handleValueChange}
+        readOnly
+      />,
+    );
 
     expect(screen.getByRole("textbox", { name: "이름" })).toHaveValue("윤돌");
     expect(screen.getByText("2/10")).toBeInTheDocument();
@@ -15,7 +25,14 @@ describe("Input", () => {
 
   it("에러 메시지와 에러 상태를 표시한다", () => {
     render(
-      <Input label="이름" value="" maxLength={10} errorMessage="이름을 입력해주세요." readOnly />,
+      <Input
+        label="이름"
+        value=""
+        maxLength={10}
+        errorMessage="이름을 입력해주세요."
+        onValueChange={handleValueChange}
+        readOnly
+      />,
     );
 
     const input = screen.getByRole("textbox", { name: "이름" });
@@ -26,7 +43,15 @@ describe("Input", () => {
   });
 
   it("에러가 없어도 글자 수 영역을 표시한다", () => {
-    render(<Input label="이름" value="" maxLength={10} readOnly />);
+    render(
+      <Input
+        label="이름"
+        value=""
+        maxLength={10}
+        onValueChange={handleValueChange}
+        readOnly
+      />,
+    );
 
     expect(screen.getByRole("textbox", { name: "이름" })).toHaveAttribute("aria-invalid", "false");
     expect(screen.getByText("0/10")).toBeInTheDocument();
@@ -45,9 +70,9 @@ describe("Input", () => {
           value={value}
           maxLength={10}
           placeholder="이름을 입력해주세요."
-          onChange={(event) => {
-            setValue(event.target.value);
-            handleChange(event);
+          onValueChange={(nextValue) => {
+            setValue(nextValue);
+            handleChange(nextValue);
           }}
         />
       );
@@ -58,7 +83,7 @@ describe("Input", () => {
     const input = screen.getByPlaceholderText("이름을 입력해주세요.");
     await user.type(input, "윤돌");
 
-    expect(handleChange).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenLastCalledWith("윤돌");
     expect(input).toHaveValue("윤돌");
   });
 });

--- a/frontend/src/shared/ui/input/Input.tsx
+++ b/frontend/src/shared/ui/input/Input.tsx
@@ -4,14 +4,24 @@ import { Row } from "../row";
 import { Stack } from "../stack";
 import { Count, ErrorMessage, Label, StyledInput } from "./Input.styles";
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
   label: string;
   errorMessage?: string;
   value: string;
   maxLength: number;
+  onValueChange: (value: string) => void;
 }
 
-export const Input = ({ label, errorMessage = "", value, maxLength, id, ...props }: InputProps) => {
+export const Input = ({
+  label,
+  errorMessage = "",
+  value,
+  maxLength,
+  onValueChange,
+  id,
+  ...props
+}: InputProps) => {
   const generatedId = useId();
   const inputId = id ?? generatedId;
 
@@ -24,6 +34,7 @@ export const Input = ({ label, errorMessage = "", value, maxLength, id, ...props
         id={inputId}
         value={value}
         maxLength={maxLength}
+        onChange={(event) => onValueChange(event.target.value)}
         aria-invalid={Boolean(errorMessage)}
         $hasError={Boolean(errorMessage)}
       />

--- a/frontend/src/shared/ui/radio-group/RadioGroup.stories.tsx
+++ b/frontend/src/shared/ui/radio-group/RadioGroup.stories.tsx
@@ -7,7 +7,7 @@ import type { RadioGroupProps } from "./RadioGroup";
 const InteractiveRadioGroup = (props: RadioGroupProps) => {
   const [value, setValue] = useState(props.value);
 
-  return <RadioGroup {...props} value={value} onChange={setValue} />;
+  return <RadioGroup {...props} value={value} onValueChange={setValue} />;
 };
 
 const meta = {
@@ -21,7 +21,7 @@ const meta = {
       { label: "누구나", value: "everyone" },
       { label: "방장만", value: "host" },
     ],
-    onChange: () => undefined,
+    onValueChange: () => undefined,
   },
   render: (args) => <InteractiveRadioGroup {...args} />,
 } satisfies Meta<typeof RadioGroup>;

--- a/frontend/src/shared/ui/radio-group/RadioGroup.test.tsx
+++ b/frontend/src/shared/ui/radio-group/RadioGroup.test.tsx
@@ -16,7 +16,7 @@ describe("RadioGroup", () => {
         name="uploadPermission"
         value="everyone"
         options={options}
-        onChange={jest.fn()}
+        onValueChange={jest.fn()}
       />,
     );
 
@@ -35,7 +35,7 @@ describe("RadioGroup", () => {
         name="uploadPermission"
         value="everyone"
         options={options}
-        onChange={handleChange}
+        onValueChange={handleChange}
       />,
     );
 

--- a/frontend/src/shared/ui/radio-group/RadioGroup.tsx
+++ b/frontend/src/shared/ui/radio-group/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { useId, type ChangeEvent } from "react";
+import { useId } from "react";
 
 import { Stack } from "../stack";
 import { Option, OptionLabel, RadioGroupContainer, RadioGroupLabel } from "./RadioGroup.styles";
@@ -13,7 +13,7 @@ export interface RadioGroupProps {
   name: string;
   value: string;
   options: RadioOption[];
-  onChange: (value: string) => void;
+  onValueChange: (value: string) => void;
   disabled?: boolean;
 }
 
@@ -22,14 +22,10 @@ export const RadioGroup = ({
   name,
   value,
   options,
-  onChange,
+  onValueChange,
   disabled = false,
 }: RadioGroupProps) => {
   const labelId = useId();
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange(event.target.value);
-  };
 
   return (
     <Stack gap={8}>
@@ -47,7 +43,7 @@ export const RadioGroup = ({
               name={name}
               value={option.value}
               checked={value === option.value}
-              onChange={handleChange}
+              onChange={() => onValueChange(option.value)}
               disabled={disabled}
             />
             <Option>{option.label}</Option>

--- a/frontend/src/widgets/onboarding/ui/CreateRoomNavButton.tsx
+++ b/frontend/src/widgets/onboarding/ui/CreateRoomNavButton.tsx
@@ -1,12 +1,13 @@
 import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/shared/ui/button";
+import { ROUTES } from "@/shared/config";
 
 export const CreateRoomNavButton = () => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate("/rooms/create");
+    navigate(ROUTES.createRoom);
   };
 
   return (

--- a/frontend/src/widgets/onboarding/ui/JoinRoomNavButton.tsx
+++ b/frontend/src/widgets/onboarding/ui/JoinRoomNavButton.tsx
@@ -1,12 +1,13 @@
 import { useNavigate } from "react-router-dom";
 
+import { ROUTES } from "@/shared/config";
 import { Button } from "@/shared/ui/button";
 
 export const JoinRoomNavButton = () => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate("/rooms/join");
+    navigate(ROUTES.joinRoom);
   };
 
   return (

--- a/frontend/src/widgets/onboarding/ui/OnboardingSection.styles.ts
+++ b/frontend/src/widgets/onboarding/ui/OnboardingSection.styles.ts
@@ -7,6 +7,7 @@ export const Section = styled.section`
   flex: 1;
   flex-direction: column;
   width: 100%;
+  padding: ${spacing[16]};
 `;
 
 export const IntroArea = styled.div`


### PR DESCRIPTION
## 작업 내용
- 방 생성에 필요한 폼과 페이지 UI를 구현합니다.
- 폼 입력값을 하나의 객체 상태로 관리합니다.
- 방 생성 페이지 라우트를 추가합니다.

## 관련 이슈
Closes #61 

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] Input과 RadioGroup의 값 변경 인터페이스를 `onValueChange`로 통일
- [x] 사용자 이름 및 방 이름 입력 UI 구현
- [x] 업로드 권한 및 방 만료 시간 선택 UI 구현
- [x] 필수 입력값에 따른 제출 버튼 활성화 처리
- [x] 방 생성 페이지 헤더 및 이전 화면 이동 기능 구현
- [x] 방 생성 페이지 라우트 추가
- [x] 온보딩 이동 경로 상수화
- [x] 전역 컨테이너와 페이지별 콘텐츠 여백 책임 분리

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
-
