### PR TITLE
feat: 익명 인증 기반 방 생성 API 연동

### DIFF
--- a/frontend/src/app/routes.test.tsx
+++ b/frontend/src/app/routes.test.tsx
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 
 import { ROUTES } from "@/shared/config";
@@ -8,8 +10,17 @@ const ROOM_CODE = "7K93QX2S";
 
 const renderAt = (path: string) => {
   const router = createMemoryRouter(routes, { initialEntries: [path] });
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
 
-  render(<RouterProvider router={router} />);
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
 
   return router;
 };
@@ -31,6 +42,18 @@ describe("라우트", () => {
     renderAt(ROUTES.gallery(ROOM_CODE));
 
     expect(screen.getByText(/갤러리 화면/)).toBeInTheDocument();
+  });
+
+  it("방 생성에 성공하면 생성된 방의 갤러리로 이동한다", async () => {
+    const user = userEvent.setup();
+    const router = renderAt(ROUTES.createRoom);
+
+    await user.type(screen.getByRole("textbox", { name: "내 이름" }), "민수");
+    await user.type(screen.getByRole("textbox", { name: "방 이름" }), "제주 여행");
+    await user.click(screen.getByRole("button", { name: "방 만들기" }));
+
+    expect(await screen.findByText(/갤러리 화면/)).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(ROUTES.gallery("7K93QX2S"));
   });
 
   it("알 수 없는 주소는 홈으로 보낸다", () => {

--- a/frontend/src/entities/session/api/createAnonymous.ts
+++ b/frontend/src/entities/session/api/createAnonymous.ts
@@ -1,0 +1,12 @@
+import { apiClient } from "@/shared/api";
+import type { AnonymousSession, CreateAnonymousRequest } from "../model/types";
+
+export const createAnonymous = (request: CreateAnonymousRequest) => {
+  return apiClient<AnonymousSession>("/auth/anonymous", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+};

--- a/frontend/src/entities/session/index.ts
+++ b/frontend/src/entities/session/index.ts
@@ -1,0 +1,3 @@
+export { createAnonymous } from "./api/createAnonymous";
+export { getRoomSession, removeRoomSession, saveRoomSession } from "./lib/roomSessionStorage";
+export type { AnonymousSession, CreateAnonymousRequest } from "./model/types";

--- a/frontend/src/entities/session/lib/roomSessionStorage.test.ts
+++ b/frontend/src/entities/session/lib/roomSessionStorage.test.ts
@@ -1,0 +1,29 @@
+import type { AnonymousSession } from "../model/types";
+import { getRoomSession, removeRoomSession, saveRoomSession } from "./roomSessionStorage";
+
+const session: AnonymousSession = {
+  accessToken: "mock-access-token",
+  userId: 10234,
+  nickname: "민수",
+  expiresAt: "2026-09-17T05:30:00Z",
+};
+
+describe("roomSessionStorage", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("방 코드별 세션을 저장하고 조회한다", () => {
+    saveRoomSession("7K93QX2S", session);
+
+    expect(getRoomSession("7K93QX2S")).toEqual(session);
+  });
+
+  it("방 코드에 해당하는 세션을 제거한다", () => {
+    saveRoomSession("7K93QX2S", session);
+
+    removeRoomSession("7K93QX2S");
+
+    expect(getRoomSession("7K93QX2S")).toBeNull();
+  });
+});

--- a/frontend/src/entities/session/lib/roomSessionStorage.ts
+++ b/frontend/src/entities/session/lib/roomSessionStorage.ts
@@ -1,0 +1,17 @@
+import type { AnonymousSession } from "../model/types";
+
+const getRoomSessionKey = (roomCode: string) => `room-session:${roomCode}`;
+
+export const saveRoomSession = (roomCode: string, session: AnonymousSession) => {
+  localStorage.setItem(getRoomSessionKey(roomCode), JSON.stringify(session));
+};
+
+export const getRoomSession = (roomCode: string): AnonymousSession | null => {
+  const session = localStorage.getItem(getRoomSessionKey(roomCode));
+
+  return session ? (JSON.parse(session) as AnonymousSession) : null;
+};
+
+export const removeRoomSession = (roomCode: string) => {
+  localStorage.removeItem(getRoomSessionKey(roomCode));
+};

--- a/frontend/src/entities/session/model/types.ts
+++ b/frontend/src/entities/session/model/types.ts
@@ -1,0 +1,10 @@
+export interface CreateAnonymousRequest {
+  nickname: string;
+}
+
+export interface AnonymousSession {
+  accessToken: string;
+  userId: number;
+  nickname: string;
+  expiresAt: string;
+}

--- a/frontend/src/features/create-room/api/createRoom.ts
+++ b/frontend/src/features/create-room/api/createRoom.ts
@@ -1,0 +1,13 @@
+import { apiClient } from "@/shared/api";
+import type { CreateRoomRequest, CreateRoomResponse } from "./types";
+
+export const createRoom = (request: CreateRoomRequest, token: string) => {
+  return apiClient<CreateRoomResponse>("/rooms", {
+    method: "POST",
+    token,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+};

--- a/frontend/src/features/create-room/api/types.ts
+++ b/frontend/src/features/create-room/api/types.ts
@@ -1,0 +1,16 @@
+export interface CreateRoomRequest {
+  name: string;
+  uploadPolicy: "everyone" | "host";
+  expiryHours: 24 | 72;
+}
+
+export interface CreateRoomResponse {
+  roomId: number;
+  code: string;
+  name: string;
+  hostId: number;
+  hostName: string;
+  createdAt: string;
+  expiresAt: string;
+  uploadPolicy: "everyone" | "host";
+}

--- a/frontend/src/features/create-room/index.ts
+++ b/frontend/src/features/create-room/index.ts
@@ -1,2 +1,3 @@
 export { CreateRoomForm } from "./ui/form/CreateRoomForm";
 export type { CreateRoomFormValues } from "./model/createRoomForm";
+export { useCreateRoomMutation } from "./model/useCreateRoomMutation";

--- a/frontend/src/features/create-room/model/createRoomForm.ts
+++ b/frontend/src/features/create-room/model/createRoomForm.ts
@@ -1,8 +1,8 @@
 export interface CreateRoomFormValues {
   nickname: string;
   name: string;
-  uploadPolicy: string;
-  expiryHours: string;
+  uploadPolicy: "everyone" | "host";
+  expiryHours: "24" | "72";
 }
 
 export const INITIAL_CREATE_ROOM_FORM: CreateRoomFormValues = {

--- a/frontend/src/features/create-room/model/useCreateRoomForm.test.ts
+++ b/frontend/src/features/create-room/model/useCreateRoomForm.test.ts
@@ -1,0 +1,30 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { INITIAL_CREATE_ROOM_FORM } from "./createRoomForm";
+import { useCreateRoomForm } from "./useCreateRoomForm";
+
+describe("useCreateRoomForm", () => {
+  it("초기 폼 상태를 반환한다", () => {
+    const { result } = renderHook(() => useCreateRoomForm());
+
+    expect(result.current.formValues).toEqual(INITIAL_CREATE_ROOM_FORM);
+    expect(result.current.isValid).toBe(false);
+  });
+
+  it("필드 값을 변경하고 필수 입력 여부를 검증한다", () => {
+    const { result } = renderHook(() => useCreateRoomForm());
+
+    act(() => {
+      result.current.updateField("nickname")("민수");
+      result.current.updateField("name")("제주 여행");
+    });
+
+    expect(result.current.formValues).toEqual(
+      expect.objectContaining({
+        nickname: "민수",
+        name: "제주 여행",
+      }),
+    );
+    expect(result.current.isValid).toBe(true);
+  });
+});

--- a/frontend/src/features/create-room/model/useCreateRoomForm.ts
+++ b/frontend/src/features/create-room/model/useCreateRoomForm.ts
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+import { INITIAL_CREATE_ROOM_FORM, type CreateRoomFormValues } from "./createRoomForm";
+
+export const useCreateRoomForm = () => {
+  const [formValues, setFormValues] = useState<CreateRoomFormValues>(INITIAL_CREATE_ROOM_FORM);
+
+  const updateField = (name: keyof CreateRoomFormValues) => (value: string) => {
+    setFormValues((previous) => ({ ...previous, [name]: value }));
+  };
+
+  const isValid = Boolean(formValues.nickname.trim() && formValues.name.trim());
+
+  return {
+    formValues,
+    updateField,
+    isValid,
+  };
+};

--- a/frontend/src/features/create-room/model/useCreateRoomMutation.test.tsx
+++ b/frontend/src/features/create-room/model/useCreateRoomMutation.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+
+import { server } from "@/mocks/server";
+import { ApiError } from "@/shared/api";
+import { useCreateRoomMutation } from "./useCreateRoomMutation";
+import { CreateRoomFormValues } from "./createRoomForm";
+
+const formValues = {
+  nickname: "민수",
+  name: "제주 여행",
+  uploadPolicy: "host",
+  expiryHours: "72",
+} satisfies CreateRoomFormValues;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
+
+  return function QueryClientTestWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+};
+
+describe("useCreateRoomMutation", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("익명 인증 후 발급받은 token으로 방을 생성한다", async () => {
+    const { result } = renderHook(() => useCreateRoomMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      const room = await result.current.mutateAsync(formValues);
+
+      expect(room).toEqual(
+        expect.objectContaining({
+          code: "7K93QX2S",
+          name: "제주 여행",
+          uploadPolicy: "host",
+        }),
+      );
+      expect(localStorage.getItem(`room-session:${room.code}`)).toBe(
+        JSON.stringify({
+          accessToken: "mock-access-token",
+          userId: 10234,
+          nickname: "민수",
+          expiresAt: "2026-09-17T05:30:00Z",
+        }),
+      );
+    });
+  });
+
+  it("익명 인증이 실패하면 ApiError를 반환한다", async () => {
+    server.use(
+      http.post("/auth/anonymous", () => {
+        return HttpResponse.json(
+          {
+            code: "ANONYMOUS_AUTH_FAILED",
+            message: "익명 인증에 실패했습니다.",
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    const { result } = renderHook(() => useCreateRoomMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(formValues)).rejects.toEqual(
+        expect.objectContaining<Partial<ApiError>>({
+          status: 500,
+          code: "ANONYMOUS_AUTH_FAILED",
+          message: "익명 인증에 실패했습니다.",
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/features/create-room/model/useCreateRoomMutation.ts
+++ b/frontend/src/features/create-room/model/useCreateRoomMutation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { createAnonymous, saveRoomSession } from "@/entities/session";
+import { createRoom } from "../api/createRoom";
+import type { CreateRoomResponse } from "../api/types";
+import type { CreateRoomFormValues } from "./createRoomForm";
+
+export const useCreateRoomMutation = () =>
+  useMutation({
+    mutationFn: async (values: CreateRoomFormValues): Promise<CreateRoomResponse> => {
+      const session = await createAnonymous({
+        nickname: values.nickname,
+      });
+
+      const room = await createRoom(
+        {
+          name: values.name,
+          uploadPolicy: values.uploadPolicy,
+          expiryHours: values.expiryHours === "72" ? 72 : 24,
+        },
+        session.accessToken,
+      );
+
+      saveRoomSession(room.code, session);
+
+      return room;
+    },
+  });

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.styles.ts
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import { spacing } from "@/shared/styles/tokens";
+import { colors, spacing, typography } from "@/shared/styles/tokens";
 
 export const Form = styled.form`
   display: flex;
@@ -13,4 +13,11 @@ export const Form = styled.form`
 export const SubmitArea = styled.div`
   width: 100%;
   margin-top: auto;
+`;
+
+export const SubmitError = styled.p`
+  margin-bottom: ${spacing[8]};
+  color: ${colors.danger};
+
+  ${typography.label5}
 `;

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.test.tsx
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.test.tsx
@@ -1,29 +1,101 @@
-import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { delay, http, HttpResponse } from "msw";
+import type { ComponentProps, ReactNode } from "react";
 
+import { server } from "@/mocks/server";
 import { CreateRoomForm } from "./CreateRoomForm";
 
-describe("CreateRoomForm", () => {
-  it("입력값을 하나의 객체로 전달한다", async () => {
-    const user = userEvent.setup();
-    const handleSubmit = jest.fn();
+const renderForm = (props: ComponentProps<typeof CreateRoomForm> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
 
-    render(<CreateRoomForm onSubmit={handleSubmit} />);
+  const QueryClientTestWrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return render(<CreateRoomForm {...props} />, { wrapper: QueryClientTestWrapper });
+};
+
+const fillRequiredFields = async () => {
+  const user = userEvent.setup();
+
+  await user.type(screen.getByRole("textbox", { name: "내 이름" }), "민수");
+  await user.type(screen.getByRole("textbox", { name: "방 이름" }), "제주 여행");
+
+  return user;
+};
+
+describe("CreateRoomForm", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("입력값으로 방을 생성하고 성공 결과를 전달한다", async () => {
+    const handleSuccess = jest.fn();
+    renderForm({ onSuccess: handleSuccess });
 
     const submitButton = screen.getByRole("button", { name: "방 만들기" });
     expect(submitButton).toBeDisabled();
 
-    await user.type(screen.getByRole("textbox", { name: "내 이름" }), "민수");
-    await user.type(screen.getByRole("textbox", { name: "방 이름" }), "제주 여행");
+    const user = await fillRequiredFields();
     await user.click(screen.getByRole("radio", { name: "방장만" }));
     await user.click(screen.getByRole("radio", { name: "3일" }));
     await user.click(submitButton);
 
-    expect(handleSubmit).toHaveBeenCalledWith({
-      nickname: "민수",
-      name: "제주 여행",
-      uploadPolicy: "host",
-      expiryHours: "72",
+    await waitFor(() => {
+      expect(handleSuccess).toHaveBeenCalled();
+      expect(handleSuccess.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          code: "7K93QX2S",
+          name: "제주 여행",
+          uploadPolicy: "host",
+        }),
+      );
     });
+  });
+
+  it("요청 중에는 중복 제출을 막는다", async () => {
+    server.use(
+      http.post("/auth/anonymous", async ({ request }) => {
+        const body = (await request.json()) as { nickname: string };
+        await delay(50);
+
+        return HttpResponse.json({
+          accessToken: "mock-access-token",
+          userId: 10234,
+          nickname: body.nickname,
+          expiresAt: "2026-09-17T05:30:00Z",
+        });
+      }),
+    );
+    renderForm();
+
+    const user = await fillRequiredFields();
+    await user.click(screen.getByRole("button", { name: "방 만들기" }));
+
+    expect(screen.getByRole("button", { name: "방 만드는 중..." })).toBeDisabled();
+    expect(await screen.findByRole("button", { name: "방 만들기" })).toBeEnabled();
+  });
+
+  it("방 생성 실패 메시지를 표시한다", async () => {
+    server.use(
+      http.post("/auth/anonymous", () => {
+        return HttpResponse.json(
+          { code: "INVALID_NICKNAME", message: "닉네임을 입력해주세요" },
+          { status: 400 },
+        );
+      }),
+    );
+    renderForm();
+
+    const user = await fillRequiredFields();
+    await user.click(screen.getByRole("button", { name: "방 만들기" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("닉네임을 입력해주세요");
   });
 });

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.tsx
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import type { FormEvent } from "react";
 
 import { ApiError } from "@/shared/api";
 import { Button } from "@/shared/ui/button";
@@ -6,7 +6,7 @@ import { Input } from "@/shared/ui/input";
 import { RadioGroup } from "@/shared/ui/radio-group";
 import { Stack } from "@/shared/ui/stack";
 import type { CreateRoomResponse } from "../../api/types";
-import { INITIAL_CREATE_ROOM_FORM, type CreateRoomFormValues } from "../../model/createRoomForm";
+import { useCreateRoomForm } from "../../model/useCreateRoomForm";
 import { useCreateRoomMutation } from "../../model/useCreateRoomMutation";
 import { Form, SubmitArea, SubmitError } from "./CreateRoomForm.styles";
 
@@ -15,19 +15,14 @@ interface CreateRoomFormProps {
 }
 
 export const CreateRoomForm = ({ onSuccess }: CreateRoomFormProps) => {
-  const [formValues, setFormValues] = useState<CreateRoomFormValues>(INITIAL_CREATE_ROOM_FORM);
+  const { formValues, updateField, isValid } = useCreateRoomForm();
   const { mutate, isPending, error } = useCreateRoomMutation();
-
-  const updateField = (name: keyof CreateRoomFormValues) => (value: string) => {
-    setFormValues((previous) => ({ ...previous, [name]: value }));
-  };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     mutate(formValues, { onSuccess });
   };
 
-  const isValid = Boolean(formValues.nickname.trim() && formValues.name.trim());
   const errorMessage =
     error instanceof ApiError ? error.message : error ? "방을 만들지 못했습니다." : undefined;
 

--- a/frontend/src/features/create-room/ui/form/CreateRoomForm.tsx
+++ b/frontend/src/features/create-room/ui/form/CreateRoomForm.tsx
@@ -1,18 +1,22 @@
 import { useState, type FormEvent } from "react";
 
+import { ApiError } from "@/shared/api";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { RadioGroup } from "@/shared/ui/radio-group";
-import { INITIAL_CREATE_ROOM_FORM, type CreateRoomFormValues } from "../../model/createRoomForm";
-import { Form, SubmitArea } from "./CreateRoomForm.styles";
 import { Stack } from "@/shared/ui/stack";
+import type { CreateRoomResponse } from "../../api/types";
+import { INITIAL_CREATE_ROOM_FORM, type CreateRoomFormValues } from "../../model/createRoomForm";
+import { useCreateRoomMutation } from "../../model/useCreateRoomMutation";
+import { Form, SubmitArea, SubmitError } from "./CreateRoomForm.styles";
 
 interface CreateRoomFormProps {
-  onSubmit?: (values: CreateRoomFormValues) => void;
+  onSuccess?: (room: CreateRoomResponse) => void;
 }
 
-export const CreateRoomForm = ({ onSubmit }: CreateRoomFormProps) => {
+export const CreateRoomForm = ({ onSuccess }: CreateRoomFormProps) => {
   const [formValues, setFormValues] = useState<CreateRoomFormValues>(INITIAL_CREATE_ROOM_FORM);
+  const { mutate, isPending, error } = useCreateRoomMutation();
 
   const updateField = (name: keyof CreateRoomFormValues) => (value: string) => {
     setFormValues((previous) => ({ ...previous, [name]: value }));
@@ -20,10 +24,12 @@ export const CreateRoomForm = ({ onSubmit }: CreateRoomFormProps) => {
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    onSubmit?.(formValues);
+    mutate(formValues, { onSuccess });
   };
 
   const isValid = Boolean(formValues.nickname.trim() && formValues.name.trim());
+  const errorMessage =
+    error instanceof ApiError ? error.message : error ? "방을 만들지 못했습니다." : undefined;
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -70,8 +76,9 @@ export const CreateRoomForm = ({ onSubmit }: CreateRoomFormProps) => {
       </Stack>
 
       <SubmitArea>
-        <Button size="lg" type="submit" disabled={!isValid}>
-          방 만들기
+        {errorMessage && <SubmitError role="alert">{errorMessage}</SubmitError>}
+        <Button size="lg" type="submit" disabled={!isValid || isPending}>
+          {isPending ? "방 만드는 중..." : "방 만들기"}
         </Button>
       </SubmitArea>
     </Form>

--- a/frontend/src/mocks/handlers/room.ts
+++ b/frontend/src/mocks/handlers/room.ts
@@ -2,6 +2,10 @@ import { http, HttpResponse } from "msw";
 
 export const roomHandlers = [
   http.post("/rooms", async ({ request }) => {
+    if (request.headers.get("Authorization") !== "Bearer mock-access-token") {
+      return HttpResponse.json({ message: "인증이 필요합니다." }, { status: 401 });
+    }
+
     const { name, uploadPolicy } = (await request.json()) as {
       name: string;
       uploadPolicy: "everyone" | "host";

--- a/frontend/src/pages/create-room/ui/CreateRoomPage.tsx
+++ b/frontend/src/pages/create-room/ui/CreateRoomPage.tsx
@@ -1,12 +1,17 @@
+import { useNavigate } from "react-router-dom";
+
 import { CreateRoomForm } from "@/features/create-room";
+import { ROUTES } from "@/shared/config";
 import { CreateRoomHeader } from "./header/CreateRoomHeader";
 import { Page } from "./CreateRoomPage.styles";
 
 export const CreateRoomPage = () => {
+  const navigate = useNavigate();
+
   return (
     <Page>
       <CreateRoomHeader />
-      <CreateRoomForm />
+      <CreateRoomForm onSuccess={(room) => navigate(ROUTES.gallery(room.code))} />
     </Page>
   );
 };

--- a/frontend/src/shared/api/ApiError.ts
+++ b/frontend/src/shared/api/ApiError.ts
@@ -1,0 +1,10 @@
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}

--- a/frontend/src/shared/api/apiClient.test.ts
+++ b/frontend/src/shared/api/apiClient.test.ts
@@ -1,0 +1,52 @@
+import { http, HttpResponse } from "msw";
+
+import { server } from "@/mocks/server";
+import { ApiError } from "./ApiError";
+import { apiClient } from "./apiClient";
+
+describe("apiClient", () => {
+  it("응답 JSON을 반환한다", async () => {
+    server.use(
+      http.get("/api-test", () => {
+        return HttpResponse.json({ name: "제주 여행" });
+      }),
+    );
+
+    await expect(apiClient("/api-test")).resolves.toEqual({ name: "제주 여행" });
+  });
+
+  it("전달받은 token을 Authorization 헤더에 추가한다", async () => {
+    server.use(
+      http.get("/api-test", ({ request }) => {
+        return HttpResponse.json({ authorization: request.headers.get("Authorization") });
+      }),
+    );
+
+    await expect(apiClient("/api-test", { token: "test-token" })).resolves.toEqual({
+      authorization: "Bearer test-token",
+    });
+  });
+
+  it("실패 응답을 ApiError로 변환한다", async () => {
+    server.use(
+      http.get("/api-test", () => {
+        return HttpResponse.json(
+          {
+            code: "ROOM_CREATE_FAILED",
+            message: "방을 만들 수 없습니다.",
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expect(apiClient("/api-test")).rejects.toEqual(
+      expect.objectContaining<Partial<ApiError>>({
+        name: "ApiError",
+        status: 500,
+        code: "ROOM_CREATE_FAILED",
+        message: "방을 만들 수 없습니다.",
+      }),
+    );
+  });
+});

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -1,0 +1,52 @@
+import { ApiError } from "./ApiError";
+
+interface ApiClientOptions extends RequestInit {
+  token?: string;
+}
+
+interface ErrorResponse {
+  code?: string;
+  message?: string;
+}
+
+const getErrorResponse = async (response: Response): Promise<ErrorResponse> => {
+  try {
+    return (await response.json()) as ErrorResponse;
+  } catch {
+    return {};
+  }
+};
+
+export const apiClient = async <T>(
+  url: string,
+  { token, headers, ...options }: ApiClientOptions = {},
+): Promise<T> => {
+  const requestHeaders = new Headers(headers);
+
+  if (token) {
+    requestHeaders.set("Authorization", `Bearer ${token}`);
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers: requestHeaders,
+    });
+  } catch {
+    throw new ApiError(0, "NETWORK_ERROR", "네트워크 연결을 확인해주세요.");
+  }
+
+  if (!response.ok) {
+    const error = await getErrorResponse(response);
+
+    throw new ApiError(
+      response.status,
+      error.code ?? "UNKNOWN_ERROR",
+      error.message ?? "API 요청에 실패했습니다.",
+    );
+  }
+
+  return response.json() as Promise<T>;
+};

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,0 +1,2 @@
+export { ApiError } from "./ApiError";
+export { apiClient } from "./apiClient";

--- a/frontend/src/shared/ui/input/Input.test.tsx
+++ b/frontend/src/shared/ui/input/Input.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
@@ -10,13 +10,7 @@ const handleValueChange = jest.fn();
 describe("Input", () => {
   it("입력값과 글자 수를 렌더링한다", () => {
     render(
-      <Input
-        label="이름"
-        value="윤돌"
-        maxLength={10}
-        onValueChange={handleValueChange}
-        readOnly
-      />,
+      <Input label="이름" value="윤돌" maxLength={10} onValueChange={handleValueChange} readOnly />,
     );
 
     expect(screen.getByRole("textbox", { name: "이름" })).toHaveValue("윤돌");
@@ -44,13 +38,7 @@ describe("Input", () => {
 
   it("에러가 없어도 글자 수 영역을 표시한다", () => {
     render(
-      <Input
-        label="이름"
-        value=""
-        maxLength={10}
-        onValueChange={handleValueChange}
-        readOnly
-      />,
+      <Input label="이름" value="" maxLength={10} onValueChange={handleValueChange} readOnly />,
     );
 
     expect(screen.getByRole("textbox", { name: "이름" })).toHaveAttribute("aria-invalid", "false");
@@ -85,5 +73,17 @@ describe("Input", () => {
 
     expect(handleChange).toHaveBeenLastCalledWith("윤돌");
     expect(input).toHaveValue("윤돌");
+  });
+
+  it("한글 입력값을 maxLength에 맞게 제한한다", () => {
+    const handleChange = jest.fn();
+
+    render(<Input label="이름" value="" maxLength={12} onValueChange={handleChange} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "이름" }), {
+      target: { value: "가나다라마바사아자차카타파" },
+    });
+
+    expect(handleChange).toHaveBeenCalledWith("가나다라마바사아자차카타");
   });
 });

--- a/frontend/src/shared/ui/input/Input.tsx
+++ b/frontend/src/shared/ui/input/Input.tsx
@@ -4,8 +4,10 @@ import { Row } from "../row";
 import { Stack } from "../stack";
 import { Count, ErrorMessage, Label, StyledInput } from "./Input.styles";
 
-export interface InputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "value" | "onChange"
+> {
   label: string;
   errorMessage?: string;
   value: string;
@@ -34,7 +36,7 @@ export const Input = ({
         id={inputId}
         value={value}
         maxLength={maxLength}
-        onChange={(event) => onValueChange(event.target.value)}
+        onChange={(event) => onValueChange(event.target.value.slice(0, maxLength))}
         aria-invalid={Boolean(errorMessage)}
         $hasError={Boolean(errorMessage)}
       />


### PR DESCRIPTION
## 작업 내용
- 익명 인증 후 발급받은 토큰으로 방을 생성하는 API 흐름을 구현합니다.
- TanStack Query Mutation을 통해 요청 상태를 관리합니다.
- 방 생성 성공 시 생성된 방의 갤러리 화면으로 이동합니다.

## 관련 이슈
Closes #64 

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] 공통 `apiClient` 및 `ApiError` 구현
- [x] 서버의 `code`, `message` 오류 응답 처리
- [x] `entities/session`에 익명 인증 API 구현
- [x] 방 코드별 세션 로컬 저장·조회·삭제 기능 구현
- [x] `features/create-room`에 방 생성 API 구현
- [x] 익명 인증과 방 생성을 순차 실행하는 Mutation 구현
- [x] 폼 상태와 유효성 검사 로직을 전용 훅으로 분리
- [x] Form 내부에서 로딩 및 오류 상태 관리
- [x] 방 생성 성공 시 갤러리 화면으로 이동
- [x] 한글 입력 시 `maxLength`를 초과하는 문제 수정
- [x] MSW 방 생성 요청의 인증 토큰 검증 추가

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
-
