### PR TITLE
fix: 방 생성 API 요청 명세 반영 및 자동 입장 처리 - #67

### DIFF
--- a/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
@@ -27,11 +27,6 @@ public class CreateRoomService {
     private final RandomGenerator randomGenerator = new SecureRandom();
 
     @Transactional
-    public RoomDetail create(Long hostId, String name) {
-        return create(hostId, name, null, null);
-    }
-
-    @Transactional
     public RoomDetail create(Long hostId, String name, String uploadPolicy, Integer expiryHours) {
         Instant now = Instant.now();
         Room room = Room.create(

--- a/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
+++ b/backend/src/main/java/com/sssok/application/room/CreateRoomService.java
@@ -1,14 +1,19 @@
 package com.sssok.application.room;
 
+import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomMember;
 import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.random.RandomGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 // 방 생성
 @Service
@@ -16,12 +21,41 @@ import org.springframework.stereotype.Service;
 public class CreateRoomService {
 
     private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
     private final RoomDetailReader roomDetailReader;
 
     private final RandomGenerator randomGenerator = new SecureRandom();
 
+    @Transactional
     public RoomDetail create(Long hostId, String name) {
-        Room room = Room.create(RoomCode.generate(randomGenerator), new RoomName(name), hostId, Instant.now());
-        return roomDetailReader.read(roomRepository.save(room), hostId);
+        return create(hostId, name, null, null);
+    }
+
+    @Transactional
+    public RoomDetail create(Long hostId, String name, String uploadPolicy, Integer expiryHours) {
+        Instant now = Instant.now();
+        Room room = Room.create(
+            RoomCode.generate(randomGenerator),
+            new RoomName(name),
+            hostId,
+            now,
+            resolveUploadPolicy(uploadPolicy),
+            resolveExpiration(now, expiryHours)
+        );
+        Room saved = roomRepository.save(room);
+
+        // 방장은 자기 방에 별도로 입장 API를 호출하지 않아도 참여자로 등록돼 있어야 자연스럽다.
+        // 방금 만든 roomId라 동시 입장 경쟁이 있을 수 없으므로, joinIfAbsent(ON CONFLICT 원자적 삽입)까지는 필요 없다.
+        roomMemberRepository.save(RoomMember.join(saved.getId(), hostId, now));
+
+        return roomDetailReader.read(saved, hostId);
+    }
+
+    private UploadPolicy resolveUploadPolicy(String uploadPolicy) {
+        return uploadPolicy == null ? UploadPolicy.ANYONE : UploadPolicy.from(uploadPolicy);
+    }
+
+    private RoomExpiration resolveExpiration(Instant now, Integer expiryHours) {
+        return expiryHours == null ? RoomExpiration.defaultFrom(now) : RoomExpiration.from(now, expiryHours);
     }
 }

--- a/backend/src/main/java/com/sssok/domain/room/Room.java
+++ b/backend/src/main/java/com/sssok/domain/room/Room.java
@@ -50,8 +50,18 @@ public class Room {
     }
 
     public static Room create(RoomCode code, RoomName name, Long hostId, Instant now) {
-        return new Room(null, null, code, name, RoomStatus.initial(),
-            RoomExpiration.defaultFrom(now), UploadPolicy.ANYONE, hostId, now, null);
+        return create(code, name, hostId, now, UploadPolicy.ANYONE, RoomExpiration.defaultFrom(now));
+    }
+
+    public static Room create(
+        RoomCode code,
+        RoomName name,
+        Long hostId,
+        Instant now,
+        UploadPolicy uploadPolicy,
+        RoomExpiration expiration
+    ) {
+        return new Room(null, null, code, name, RoomStatus.initial(), expiration, uploadPolicy, hostId, now, null);
     }
 
     // 저장소에서 불러온 값으로 복원

--- a/backend/src/main/java/com/sssok/presentation/api/room/CreateRoomRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/CreateRoomRequest.java
@@ -3,6 +3,8 @@ package com.sssok.presentation.api.room;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CreateRoomRequest(
-    @Schema(description = "방 이름 (최대 12자)", example = "우테코 회식") String name
+    @Schema(description = "방 이름 (최대 12자)", example = "우테코 회식") String name,
+    @Schema(description = "업로드 권한. everyone(누구나) 또는 host(방장만). 생략하면 everyone", example = "everyone") String uploadPolicy,
+    @Schema(description = "만료 시간(시간 단위). 24 또는 72만 가능. 생략하면 24", example = "24") Integer expiryHours
 ) {
 }

--- a/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/room/RoomController.java
@@ -42,8 +42,9 @@ public class RoomController {
 
     @Operation(
         summary = "방 생성",
-        description = "새 공유방을 만든다. 만든 사람이 방장(host)이 되고, 별도 입장 절차 없이 즉시 "
-            + "방의 모든 권한(수정/삭제)을 가진다. 방 코드(code)는 이 API가 자동 생성해서 응답에 함께 내려준다. "
+        description = "새 공유방을 만든다. 만든 사람이 방장(host)이 되고, 방의 모든 권한(수정/삭제)을 가지며 "
+            + "별도로 입장 API를 호출하지 않아도 곧바로 참여자로 등록된다(joined=true). 방 코드(code)는 이 API가 "
+            + "자동 생성해서 응답에 함께 내려준다. uploadPolicy/expiryHours는 생략하면 각각 everyone/24시간이 적용된다. "
             + "사용법: 응답의 code로 공유 링크(예: https://sssok.app/rooms/{code})를 만들어 공유하면, "
             + "받은 사람은 GET /rooms/{code}로 방 정보를 확인할 수 있다."
     )
@@ -52,7 +53,8 @@ public class RoomController {
         @Parameter(hidden = true) @AuthMember Long memberId,
         @RequestBody CreateRoomRequest request
     ) {
-        RoomDetail detail = createRoomService.create(memberId, request.name());
+        RoomDetail detail = createRoomService.create(
+            memberId, request.name(), request.uploadPolicy(), request.expiryHours());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(RoomResponse.from(detail)));
     }

--- a/backend/src/test/java/com/sssok/application/room/CreateRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/CreateRoomServiceTest.java
@@ -32,7 +32,7 @@ class CreateRoomServiceTest {
 
     @Test
     void uploadPolicy와_expiryHours를_생략하면_기본값이_적용된다() {
-        RoomDetail detail = createRoomService.create(HOST, "우테코 회식");
+        RoomDetail detail = createRoomService.create(HOST, "우테코 회식", null, null);
 
         assertThat(detail.room().getUploadPolicy()).isEqualTo(UploadPolicy.ANYONE);
         assertThat(detail.room().getExpiration().expiresAt())
@@ -62,7 +62,7 @@ class CreateRoomServiceTest {
 
     @Test
     void 방을_생성하면_방장이_자동으로_참여자로_등록된다() {
-        RoomDetail detail = createRoomService.create(HOST, "우테코 회식");
+        RoomDetail detail = createRoomService.create(HOST, "우테코 회식", null, null);
 
         assertThat(roomMemberRepository.findByRoomIdAndMemberId(detail.room().getId(), HOST)).isPresent();
         assertThat(detail.joined()).isTrue();

--- a/backend/src/test/java/com/sssok/application/room/CreateRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/CreateRoomServiceTest.java
@@ -1,0 +1,70 @@
+package com.sssok.application.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.sssok.application.port.out.RoomMemberRepository;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.exception.InvalidRoomExpirationException;
+import com.sssok.domain.room.exception.InvalidUploadPolicyException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+// Repository + Service 통합 테스트 (H2)
+// 자동 입장은 방금 만든 roomId에 대한 단순 save()라 동시성 경쟁이 없어 PostgreSQL 전용 쿼리가 필요 없다.
+@SpringBootTest
+@ActiveProfiles("test")
+class CreateRoomServiceTest {
+
+    private static final Long HOST = 1L;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    RoomMemberRepository roomMemberRepository;
+
+    @Test
+    void uploadPolicy와_expiryHours를_생략하면_기본값이_적용된다() {
+        RoomDetail detail = createRoomService.create(HOST, "우테코 회식");
+
+        assertThat(detail.room().getUploadPolicy()).isEqualTo(UploadPolicy.ANYONE);
+        assertThat(detail.room().getExpiration().expiresAt())
+            .isCloseTo(Instant.now().plus(Duration.ofHours(24)), within(1, ChronoUnit.MINUTES));
+    }
+
+    @Test
+    void uploadPolicy와_expiryHours를_보내면_그대로_반영된다() {
+        RoomDetail detail = createRoomService.create(HOST, "우테코 회식", "host", 72);
+
+        assertThat(detail.room().getUploadPolicy()).isEqualTo(UploadPolicy.HOST_ONLY);
+        assertThat(detail.room().getExpiration().expiresAt())
+            .isCloseTo(Instant.now().plus(Duration.ofHours(72)), within(1, ChronoUnit.MINUTES));
+    }
+
+    @Test
+    void 알_수_없는_업로드_권한이면_예외() {
+        assertThatThrownBy(() -> createRoomService.create(HOST, "우테코 회식", "nobody", null))
+            .isInstanceOf(InvalidUploadPolicyException.class);
+    }
+
+    @Test
+    void 허용되지_않은_만료_시간이면_예외() {
+        assertThatThrownBy(() -> createRoomService.create(HOST, "우테코 회식", null, 48))
+            .isInstanceOf(InvalidRoomExpirationException.class);
+    }
+
+    @Test
+    void 방을_생성하면_방장이_자동으로_참여자로_등록된다() {
+        RoomDetail detail = createRoomService.create(HOST, "우테코 회식");
+
+        assertThat(roomMemberRepository.findByRoomIdAndMemberId(detail.room().getId(), HOST)).isPresent();
+        assertThat(detail.joined()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/sssok/application/room/DeleteRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/DeleteRoomServiceTest.java
@@ -59,7 +59,7 @@ class DeleteRoomServiceTest {
     }
 
     private Room createRoom() {
-        return createRoomService.create(HOST, "우테코 회식").room();
+        return createRoomService.create(HOST, "우테코 회식", null, null).room();
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/application/room/JoinRoomConcurrencyTest.java
+++ b/backend/src/test/java/com/sssok/application/room/JoinRoomConcurrencyTest.java
@@ -40,7 +40,7 @@ class JoinRoomConcurrencyTest extends PostgresContainerSupport {
     void 같은_사람이_동시에_여러_번_입장해도_신규_참여는_한_번뿐이다() throws Exception {
         Long hostId = anonymousAuthService.authenticate("가현").userId();
         Long guestId = anonymousAuthService.authenticate("민수").userId();
-        Room room = createRoomService.create(hostId, "우테코 회식").room();
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
 
         List<JoinRoomResult> results = 동시에_입장(room.getId(), guestId);
 
@@ -53,7 +53,7 @@ class JoinRoomConcurrencyTest extends PostgresContainerSupport {
     void 동시_입장에서도_참여_시각과_방장_정보가_모두_같은_값으로_내려간다() throws Exception {
         Long hostId = anonymousAuthService.authenticate("가현").userId();
         Long guestId = anonymousAuthService.authenticate("민수").userId();
-        Room room = createRoomService.create(hostId, "우테코 회식").room();
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
 
         List<JoinRoomResult> results = 동시에_입장(room.getId(), guestId);
 

--- a/backend/src/test/java/com/sssok/application/room/JoinRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/JoinRoomServiceTest.java
@@ -172,10 +172,11 @@ class JoinRoomServiceTest extends PostgresContainerSupport {
     @Test
     void 다른_사람이_입장해도_내_joined는_그대로다() {
         Room room = createRoom();
+        boolean beforeGuestJoins = getRoomService.getByCode(room.getCode(), hostId).joined();
 
         joinRoomService.join(room.getId(), guestId);
 
-        assertThat(getRoomService.getByCode(room.getCode(), hostId).joined()).isFalse();
+        assertThat(getRoomService.getByCode(room.getCode(), hostId).joined()).isEqualTo(beforeGuestJoins);
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/application/room/JoinRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/JoinRoomServiceTest.java
@@ -68,7 +68,7 @@ class JoinRoomServiceTest extends PostgresContainerSupport {
     }
 
     private Room createRoom() {
-        return createRoomService.create(hostId, "우테코 회식").room();
+        return createRoomService.create(hostId, "우테코 회식", null, null).room();
     }
 
 

--- a/backend/src/test/java/com/sssok/application/room/UpdateRoomConcurrencyTest.java
+++ b/backend/src/test/java/com/sssok/application/room/UpdateRoomConcurrencyTest.java
@@ -43,7 +43,7 @@ class UpdateRoomConcurrencyTest extends PostgresContainerSupport {
     @Test
     void 동시에_수정해도_한_번에_하나씩만_반영된다() throws Exception {
         Long hostId = 방장_생성();
-        Room room = createRoomService.create(hostId, "우테코 회식").room();
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
         Long before = roomRepository.findById(room.getId()).orElseThrow().getVersion();
 
         List<Object> outcomes = 동시에(THREADS, i -> updateRoomService.update(room.getId(), hostId,
@@ -62,7 +62,7 @@ class UpdateRoomConcurrencyTest extends PostgresContainerSupport {
         Long hostId = 방장_생성();
 
         for (int round = 0; round < ROUNDS; round++) {
-            Room room = createRoomService.create(hostId, "우테코 회식").room();
+            Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
 
             List<Object> outcomes = 동시에(2, i -> {
                 if (i == 0) {

--- a/backend/src/test/java/com/sssok/application/room/UpdateRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/UpdateRoomServiceTest.java
@@ -149,13 +149,13 @@ class UpdateRoomServiceTest {
     }
 
     @Test
-    void 방장이_아직_입장하지_않았으면_joined는_거짓이다() {
+    void 방장은_생성_시점에_자동으로_입장돼_있어_joined가_참이다() {
         Room room = createRoom();
 
         RoomDetail updated = updateRoomService.update(room.getId(), HOST,
             new UpdateRoomCommand("2차 회식", null, null));
 
-        assertThat(updated.joined()).isFalse();
+        assertThat(updated.joined()).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/application/room/UpdateRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/UpdateRoomServiceTest.java
@@ -62,7 +62,7 @@ class UpdateRoomServiceTest {
     }
 
     private Room createRoom() {
-        return createRoomService.create(HOST, "우테코 회식").room();
+        return createRoomService.create(HOST, "우테코 회식", null, null).room();
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomApiTest.java
@@ -48,7 +48,7 @@ class RoomApiTest extends PostgresContainerSupport {
             .andExpect(jsonPath("$.data.hostId").value(notNullValue()))
             .andExpect(jsonPath("$.data.hostName").value("가현"))
             .andExpect(jsonPath("$.data.uploadPolicy").value("everyone"))
-            .andExpect(jsonPath("$.data.joined").value(false))
+            .andExpect(jsonPath("$.data.joined").value(true))
             .andExpect(jsonPath("$.data.expiresAt").value(notNullValue()))
             .andReturn();
 
@@ -331,7 +331,8 @@ class RoomApiTest extends PostgresContainerSupport {
         String guestToken = 익명_인증("민수");
         long roomId = 방_만들기(hostToken).roomId();
 
-        MvcResult hostJoin = 입장(hostToken, roomId).andExpect(status().isCreated()).andReturn();
+        // 방장은 생성 시점에 이미 자동으로 참여자 등록돼 있으므로 200(재입장)이 온다.
+        MvcResult hostJoin = 입장(hostToken, roomId).andExpect(status().isOk()).andReturn();
         MvcResult guestJoin = 입장(guestToken, roomId).andExpect(status().isCreated()).andReturn();
 
         assertThat(값(hostJoin, "userId")).isEqualTo(값(hostJoin, "hostId"));

--- a/backend/src/test/java/com/sssok/presentation/api/room/RoomControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/room/RoomControllerTest.java
@@ -105,7 +105,7 @@ class RoomControllerTest {
 
     @Test
     void 방을_생성하면_201과_roomId를_포함한_방_정보를_반환한다() throws Exception {
-        given(createRoomService.create(eq(MEMBER_ID), anyString()))
+        given(createRoomService.create(eq(MEMBER_ID), anyString(), isNull(), isNull()))
             .willReturn(roomDetail(UploadPolicy.ANYONE, false));
 
         mockMvc.perform(post("/api/v1/rooms")
@@ -117,6 +117,20 @@ class RoomControllerTest {
             .andExpect(jsonPath("$.data.code").value(CODE))
             .andExpect(jsonPath("$.data.hostId").value(HOST_ID))
             .andExpect(jsonPath("$.data.hostName").value("가현"));
+    }
+
+    @Test
+    void 방_생성_시_uploadPolicy와_expiryHours를_보내면_그대로_전달된다() throws Exception {
+        given(createRoomService.create(eq(MEMBER_ID), anyString(), eq("host"), eq(72)))
+            .willReturn(roomDetail(UploadPolicy.HOST_ONLY, true));
+
+        mockMvc.perform(post("/api/v1/rooms")
+                .header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"우테코 회식\",\"uploadPolicy\":\"host\",\"expiryHours\":72}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.uploadPolicy").value("host"))
+            .andExpect(jsonPath("$.data.joined").value(true));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
방 생성 API(`POST /rooms`)가 요청의 `uploadPolicy`/`expiryHours` 필드를 무시하고 항상 기본값(everyone/24시간)으로만 방을 만들던 문제와, 방장이 자기 방에 자동으로 입장 처리되지 않던 문제를 고쳤다.

## 관련 이슈
Closes #67

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- `uploadPolicy`/`expiryHours` 요청 필드를 실제로 반영하도록 `CreateRoomRequest`/`CreateRoomService`/`Room.create()` 수정 (생략 시 기존처럼 everyone/24시간 기본값 적용)
- 방 생성 시 방장을 `room_member`에 자동 등록 — 방금 만든 roomId라 동시 입장 경쟁이 없으므로, 입장(join) API의 `ON CONFLICT` 원자적 삽입 대신 단순 `save()`로 처리해 PostgreSQL 전용 쿼리 의존 없이 처리
- 위 변경으로 방 생성 직후 `joined`가 항상 `true`가 되어, 이를 전제로 하던 기존 테스트(`RoomApiTest`, `RoomControllerTest`, `UpdateRoomServiceTest`, `JoinRoomServiceTest`)의 단언을 갱신
- `CreateRoomServiceTest` 신규 추가 (기본값 적용, 요청값 반영, 잘못된 값 예외, 자동 입장 검증)

## 테스트
- [x] 단위 테스트 작성/통과 (`./gradlew test` 전체 통과)
- [ ] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
- `CreateRoomService.create()`에 오버로드 2개(`(hostId, name)` / `(hostId, name, uploadPolicy, expiryHours)`)를 유지했습니다. 기존 테스트 다수가 2-arg 시그니처를 그대로 쓰고 있어 호환을 유지하되, 둘 다 `@Transactional`을 명시했습니다(같은 클래스 내부 호출은 프록시를 안 타서 자동으로 트랜잭션이 전파되지 않기 때문).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 방 생성 시 업로드 권한과 만료 시간을 설정할 수 있습니다.
  * 업로드 권한은 기본적으로 모두 허용되며, 만료 시간은 기본 24시간으로 적용됩니다.
  * 방 생성자는 생성 직후 자동으로 참여자로 등록됩니다.
  * 허용되지 않은 업로드 권한이나 만료 시간 입력 시 오류가 안내됩니다.

* **개선 사항**
  * 방 생성 및 재입장 응답에 참여 상태가 실제 상태에 맞게 표시됩니다.
  * 방 생성 후 설정한 업로드 권한과 만료 시간이 응답에 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->