### PR TITLE
refactor: BaseEntity로 생성/수정 시간 공통 처리 - #69

### DIFF
--- a/backend/src/main/java/com/sssok/infrastructure/persistence/BaseEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/BaseEntity.java
@@ -1,0 +1,43 @@
+package com.sssok.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.Instant;
+import lombok.Getter;
+
+// 생성·수정 시각은 도메인이 아니라 저장의 관심사라 JPA 엔티티에만 둔다.
+// 도메인이 시각을 직접 다루는 경우는 그대로 도메인이 갖고,
+// 어댑터가 넘긴 값을 여기서 덮어쓰지 않는다.
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected BaseEntity() {
+    }
+
+    protected BaseEntity(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @PrePersist
+    void onPersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "link_code")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LinkCodeJpaEntity {
+public class LinkCodeJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
@@ -3,6 +3,7 @@ package com.sssok.infrastructure.persistence.file;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "stored_file")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StoredFileJpaEntity {
+public class StoredFileJpaEntity extends BaseEntity {
 
     @Id
     private Long id;

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderJpaEntity {
+public class FolderJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,13 +32,10 @@ public class FolderJpaEntity {
     @Column(nullable = false, length = 12)
     private String name;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     public FolderJpaEntity(Long id, Long roomId, String name, Instant createdAt) {
+        super(createdAt);
         this.id = id;
         this.roomId = roomId;
         this.name = name;
-        this.createdAt = createdAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderMediaJpaEntity {
+public class FolderMediaJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaRepository.java
@@ -35,10 +35,11 @@ public interface FolderMediaJpaRepository extends JpaRepository<FolderMediaJpaEn
     int deleteByRoomId(@Param("roomId") Long roomId);
 
     // 동시에 같은 조합을 담으려는 요청이 있어도 관계는 하나만 남도록 DB에 맡긴다.
+    // JPA 를 거치지 않아 BaseEntity 의 @PrePersist 가 돌지 않으므로 감사 컬럼을 직접 넣는다.
     @Modifying
     @Query(value = """
-        INSERT INTO folder_media (folder_id, media_id)
-        VALUES (:folderId, :mediaId)
+        INSERT INTO folder_media (folder_id, media_id, created_at, updated_at)
+        VALUES (:folderId, :mediaId, now(), now())
         ON CONFLICT (folder_id, media_id) DO NOTHING
         """, nativeQuery = true)
     int insertIfAbsent(@Param("folderId") Long folderId, @Param("mediaId") Long mediaId);

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberJpaEntity {
+public class MemberJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,12 +25,9 @@ public class MemberJpaEntity {
     @Column(name = "nickname", nullable = false, length = 12)
     private String nickname;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     public MemberJpaEntity(Long id, String nickname, Instant createdAt) {
+        super(createdAt);
         this.id = id;
         this.nickname = nickname;
-        this.createdAt = createdAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.Version;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "room")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomJpaEntity {
+public class RoomJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,9 +44,6 @@ public class RoomJpaEntity {
     @Column(name = "host_id", nullable = false)
     private Long hostId;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
@@ -61,6 +59,7 @@ public class RoomJpaEntity {
         Instant createdAt,
         Instant deletedAt
     ) {
+        super(createdAt);
         this.id = id;
         this.version = version;
         this.code = code;
@@ -69,7 +68,6 @@ public class RoomJpaEntity {
         this.expiresAt = expiresAt;
         this.uploadPolicy = uploadPolicy;
         this.hostId = hostId;
-        this.createdAt = createdAt;
         this.deletedAt = deletedAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomMemberJpaEntity {
+public class RoomMemberJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaRepository.java
@@ -24,8 +24,8 @@ public interface RoomMemberJpaRepository extends JpaRepository<RoomMemberJpaEnti
     // 동시 입장에서도 하나만 통과하도록 DB에 맡긴다.
     @Modifying
     @Query(value = """
-        INSERT INTO room_member (room_id, member_id, joined_at)
-        VALUES (:roomId, :memberId, :joinedAt)
+        INSERT INTO room_member (room_id, member_id, joined_at, created_at, updated_at)
+        VALUES (:roomId, :memberId, :joinedAt, :joinedAt, :joinedAt)
         ON CONFLICT (room_id, member_id) DO NOTHING
         """, nativeQuery = true)
     int insertIfAbsent(

--- a/backend/src/main/java/com/sssok/infrastructure/realtime/RoomEventJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/realtime/RoomEventJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "room_events")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomEventJpaEntity {
+public class RoomEventJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,13 +33,10 @@ public class RoomEventJpaEntity {
     @Column(name = "payload", nullable = false)
     private String payload;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     public RoomEventJpaEntity(Long roomId, String eventType, String payload, Instant createdAt) {
+        super(createdAt);
         this.roomId = roomId;
         this.eventType = eventType;
         this.payload = payload;
-        this.createdAt = createdAt;
     }
 }

--- a/backend/src/main/resources/db/migration/V12__add_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V12__add_audit_columns.sql
@@ -26,3 +26,6 @@ ALTER TABLE link_code ADD COLUMN updated_at TIMESTAMPTZ;
 UPDATE link_code SET created_at = expires_at - INTERVAL '5 minutes', updated_at = expires_at - INTERVAL '5 minutes';
 ALTER TABLE link_code ALTER COLUMN created_at SET NOT NULL;
 ALTER TABLE link_code ALTER COLUMN updated_at SET NOT NULL;
+ALTER TABLE folder ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE folder SET updated_at = created_at;
+ALTER TABLE folder ALTER COLUMN updated_at SET NOT NULL;

--- a/backend/src/main/resources/db/migration/V13__add_audit_columns_to_media.sql
+++ b/backend/src/main/resources/db/migration/V13__add_audit_columns_to_media.sql
@@ -1,0 +1,13 @@
+-- #69 BaseEntity: 나중에 들어온 stored_file·folder_media 에도 같은 감사 컬럼을 맞춘다.
+-- 기존 행은 수정된 적이 없어 updated_at 을 created_at 과 같게 둔다.
+
+ALTER TABLE stored_file ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE stored_file SET updated_at = created_at;
+ALTER TABLE stored_file ALTER COLUMN updated_at SET NOT NULL;
+
+-- 담긴 시각을 남기지 않아 기존 행은 알 방법이 없다. 지금 시각으로 채운다.
+ALTER TABLE folder_media ADD COLUMN created_at TIMESTAMPTZ;
+ALTER TABLE folder_media ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE folder_media SET created_at = now(), updated_at = now();
+ALTER TABLE folder_media ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE folder_media ALTER COLUMN updated_at SET NOT NULL;

--- a/backend/src/main/resources/db/migration/V9__add_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V9__add_audit_columns.sql
@@ -1,0 +1,28 @@
+-- #69 BaseEntity: 생성·수정 시각을 모든 테이블에 같은 이름으로 둔다.
+-- 기존 행은 의미가 가장 가까운 값으로 채운다. 수정된 적이 없으므로 updated_at 은 생성 시각과 같다.
+
+ALTER TABLE room ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE room SET updated_at = created_at;
+ALTER TABLE room ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE member ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE member SET updated_at = created_at;
+ALTER TABLE member ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE room_events ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE room_events SET updated_at = created_at;
+ALTER TABLE room_events ALTER COLUMN updated_at SET NOT NULL;
+
+-- 입장 기록은 joined_at 이 곧 만들어진 시각이다.
+ALTER TABLE room_member ADD COLUMN created_at TIMESTAMPTZ;
+ALTER TABLE room_member ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE room_member SET created_at = joined_at, updated_at = joined_at;
+ALTER TABLE room_member ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE room_member ALTER COLUMN updated_at SET NOT NULL;
+
+-- 연결 코드는 만들어진 시각을 남기지 않았다. 5분 TTL 이라 만료 시각에서 거꾸로 잡는다.
+ALTER TABLE link_code ADD COLUMN created_at TIMESTAMPTZ;
+ALTER TABLE link_code ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE link_code SET created_at = expires_at - INTERVAL '5 minutes', updated_at = expires_at - INTERVAL '5 minutes';
+ALTER TABLE link_code ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE link_code ALTER COLUMN updated_at SET NOT NULL;

--- a/backend/src/test/java/com/sssok/application/mediafolder/AddMediaToFoldersServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/mediafolder/AddMediaToFoldersServiceTest.java
@@ -35,8 +35,8 @@ class AddMediaToFoldersServiceTest extends PostgresContainerSupport {
     private Long existingMedia(long id) {
         jdbcTemplate.update("""
             INSERT INTO stored_file
-                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at)
-            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now())
+                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at, updated_at)
+            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now(), now())
             """, id, "test-key-" + id);
         return id;
     }

--- a/backend/src/test/java/com/sssok/infrastructure/persistence/BaseEntityTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/persistence/BaseEntityTest.java
@@ -1,0 +1,105 @@
+package com.sssok.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.application.room.UpdateRoomCommand;
+import com.sssok.application.room.UpdateRoomService;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.security.SecureRandom;
+import com.sssok.infrastructure.persistence.member.MemberJpaEntity;
+import com.sssok.infrastructure.persistence.member.MemberJpaRepository;
+import com.sssok.infrastructure.persistence.room.RoomJpaEntity;
+import com.sssok.infrastructure.persistence.room.RoomJpaRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BaseEntityTest {
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    UpdateRoomService updateRoomService;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    RoomRepository roomRepository;
+
+    @Autowired
+    RoomJpaRepository roomJpaRepository;
+
+    @Autowired
+    MemberJpaRepository memberJpaRepository;
+
+    private Long hostId;
+
+    @BeforeEach
+    void setUp() {
+        hostId = anonymousAuthService.authenticate("가현").userId();
+    }
+
+    @Test
+    void 저장하면_생성_시각과_수정_시각이_채워진다() {
+        MemberJpaEntity member = memberJpaRepository.findById(hostId).orElseThrow();
+
+        assertThat(member.getCreatedAt()).isCloseTo(Instant.now(), within(1, ChronoUnit.MINUTES));
+        assertThat(member.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void 수정하면_수정_시각만_바뀌고_생성_시각은_그대로다() {
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
+        RoomJpaEntity before = roomJpaRepository.findById(room.getId()).orElseThrow();
+        Instant createdAt = before.getCreatedAt();
+        Instant updatedAt = before.getUpdatedAt();
+
+        updateRoomService.update(room.getId(), hostId, new UpdateRoomCommand("2차 회식", null, null));
+
+        RoomJpaEntity after = roomJpaRepository.findById(room.getId()).orElseThrow();
+        assertThat(after.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(after.getUpdatedAt()).isAfterOrEqualTo(updatedAt);
+    }
+
+    @Test
+    void 어댑터가_넘긴_생성_시각을_덮어쓰지_않는다() {
+        Instant past = Instant.now().minus(Duration.ofDays(3));
+        Room saved = roomRepository.save(오래전에_만든_방(past));
+
+        assertThat(roomJpaRepository.findById(saved.getId()).orElseThrow().getCreatedAt())
+            .isCloseTo(past, within(1, ChronoUnit.SECONDS));
+    }
+
+    private Room 오래전에_만든_방(Instant createdAt) {
+        return Room.reconstruct(
+            null,
+            null,
+            RoomCode.generate(new SecureRandom()),
+            new RoomName("지난 회식"),
+            RoomStatus.initial(),
+            new RoomExpiration(Instant.now().plus(Duration.ofHours(24))),
+            UploadPolicy.ANYONE,
+            hostId,
+            createdAt,
+            null
+        );
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/mediafolder/MediaFolderApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/mediafolder/MediaFolderApiTest.java
@@ -237,8 +237,8 @@ class MediaFolderApiTest extends PostgresContainerSupport {
         long mediaId = MEDIA_ID_SEQUENCE.incrementAndGet();
         jdbcTemplate.update("""
             INSERT INTO stored_file
-                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at)
-            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now())
+                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at, updated_at)
+            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now(), now())
             """, mediaId, "test-key-" + mediaId);
         return mediaId;
     }


### PR DESCRIPTION
## 작업 내용
엔티티마다 흩어져 있던 생성·수정 시각을 `BaseEntity` 로 공통화
- 감사 시각(`created_at`·`updated_at`)은 JPA 엔티티, 비즈니스 시각은 도메인이 갖도록 기준을 정함
- **JPA 엔티티 8개 전부** `BaseEntity` 상속, 빠져 있던 컬럼은 마이그레이션으로 채움

## 관련 이슈
Closes #69

## 작업 영역
- [ ] Frontend
- [x] Backend

## 무엇이 문제였나

`created_at` 이 엔티티마다 따로 선언돼 있었고, **`updated_at` 은 스키마·엔티티·코드 어디에도 없었다.**

| 테이블 | `created_at` | `updated_at` | 비즈니스 시각 |
| --- | --- | --- | --- |
| `room` | O | X | `expires_at`, `deleted_at` |
| `member` | O | X | — |
| `room_events` | O | X | — |
| `folder` | O | X | — |
| `stored_file` | O (매핑 안 됨) | X | — |
| `link_code` | X | X | `expires_at` |
| `room_member` | X | X | `joined_at` |
| `folder_media` | X | X | — |

## 설계 — 이슈가 짚은 논의 지점

> domain을 순수하게 유지할지, JpaEntity에만 BaseEntity를 적용할지 설계 논의 필요

**JpaEntity 에만 적용했습니다.** 도메인에 Spring·jakarta import 가 하나도 없어서(`domain/` 전체 검색으로 확인), `@MappedSuperclass` 를 도메인에 넣으면 그 규칙이 깨집니다.

시각을 두 종류로 나눴습니다.

| 종류 | 예 | 소유 |
| --- | --- | --- |
| **감사 시각** | `created_at`, `updated_at` | `BaseEntity` (저장 계층) |
| **비즈니스 시각** | `expires_at`, `deleted_at`, `joined_at` | 도메인 |

`joined_at` 은 응답에 `"최초로 입장한 시각. 재입장해도 바뀌지 않는다"` 로 나가는 값이라 감사 시각으로 대체하지 않고 그대로 뒀습니다.

### Spring Data Auditing 대신 라이프사이클 콜백을 쓴 이유

`Room.createdAt` 은 **응답에 나가는 도메인 값**입니다. 그런데 어댑터가 저장할 때마다 엔티티를 새로 만드는 구조라, `@CreatedDate` 를 쓰면 도메인이 넘긴 생성 시각을 persist 시점에 덮어씁니다.

```java
@PrePersist
void onPersist() {
    Instant now = Instant.now();
    if (createdAt == null) {   // 어댑터가 넘긴 값이 있으면 그대로 둔다
        createdAt = now;
    }
    updatedAt = now;
}

@PreUpdate
void onUpdate() {
    updatedAt = Instant.now();
}
```

`created_at` 은 `updatable = false` 라 merge 로 저장해도 UPDATE 문에서 빠집니다.

## 변경 사항

### BaseEntity 신설
- `@MappedSuperclass` 로 `createdAt`·`updatedAt` 을 공통화. 엔티티 8개가 상속하고, 각자 갖고 있던 `createdAt` 선언은 제거했다.

### 마이그레이션 (V12, V13)
- 없던 컬럼을 채우고, **기존 행은 의미가 가장 가까운 값으로 백필했다**.

| 테이블 | 백필 기준 |
| --- | --- |
| `room`·`member`·`room_events`·`folder`·`stored_file` | 수정된 적이 없으므로 `updated_at = created_at` |
| `room_member` | `joined_at` 이 곧 만들어진 시각 |
| `link_code` | 발급 시각을 남기지 않아 만료 시각에서 TTL(5분)만큼 뺀 값 |
| `folder_media` | 담긴 시각을 남긴 적이 없어 `now()` |

### 네이티브 INSERT 대응 (2곳)
동시성 때문에 `ON CONFLICT` 네이티브 쿼리를 쓰는 자리가 둘 있다. **JPA 를 거치지 않아 `@PrePersist` 가 돌지 않으므로**, NOT NULL 인 감사 컬럼을 쿼리에 직접 넣었다. 이걸 놓치면 해당 기능이 전부 실패한다.

```sql
-- 입장
INSERT INTO room_member (room_id, member_id, joined_at, created_at, updated_at)
VALUES (:roomId, :memberId, :joinedAt, :joinedAt, :joinedAt)
ON CONFLICT (room_id, member_id) DO NOTHING

-- 미디어 담기
INSERT INTO folder_media (folder_id, media_id, created_at, updated_at)
VALUES (:folderId, :mediaId, now(), now())
ON CONFLICT (folder_id, media_id) DO NOTHING
```

같은 이유로 `stored_file` 을 직접 채우는 테스트 픽스처 2곳도 함께 고쳤다.

### 작업 중 머지된 API 대응
브랜치가 열려 있는 동안 폴더 API(#48·#78)와 미디어·폴더 API(#81)가 머지되면서 엔티티가 5개에서 8개로 늘었다. 세 번의 병합에서 함께 맞췄다.

- **마이그레이션 버전 충돌**: #78 이 `V9` 를 먼저 쓰면서 같은 번호가 둘이 됐다. Flyway 는 기동 단계에서 막혀 CI 가 전부 실패한다. `V12` 로 옮겼다.
- `folder`·`stored_file`·`folder_media` 도 `BaseEntity` 를 상속하도록 맞췄다.

## 테스트
- [x] 단위 테스트 작성/통과 (`./gradlew test` 577개 전체 통과)
- [x] 로컬 동작 확인

`BaseEntityTest` 3개를 추가했다.

| 테스트 | 검증 대상 |
| --- | --- |
| `저장하면_생성_시각과_수정_시각이_채워진다` | `@PrePersist` 가 두 값을 채우는지 |
| `수정하면_수정_시각만_바뀌고_생성_시각은_그대로다` | `@PreUpdate` 와 `updatable = false` |
| `어댑터가_넘긴_생성_시각을_덮어쓰지_않는다` | 도메인 값 보존 |

### 되돌려서 실제로 실패하는지 확인

| 되돌린 것 | 실패한 테스트 |
| --- | --- |
| 생성 시각 보존(`if (createdAt == null)`) | `어댑터가_넘긴_생성_시각을_덮어쓰지_않는다` |
| `@PreUpdate` | `수정하면_수정_시각만_바뀌고_생성_시각은_그대로다` |
| 마이그레이션 `room_member.created_at` | `JoinRoomServiceTest` 다수 |
| 마이그레이션 `room.updated_at` | `RoomApiTest` 다수 |
| 마이그레이션 `folder_media.created_at` | `MediaFolderApiTest` 다수 |

### 스키마 불일치가 배포 전에 잡히는지

운영·로컬이 `ddl-auto: validate` 라, 엔티티와 마이그레이션이 어긋나면 **기동 자체가 막힙니다.** `RoomApiTest` 가 PostgreSQL + Flyway + `validate` 조합으로 돌아서 이 불일치를 잡습니다. 마이그레이션에서 `room.updated_at` 을 빼보고 실제로 실패하는 것을 확인했습니다.

H2 테스트는 `ddl-auto: create-drop` 에 Flyway 를 끄고 돌아서 마이그레이션을 타지 않습니다. 마이그레이션 검증은 Testcontainers 테스트가 맡습니다.

## 리뷰 요청 사항 (선택)
- **`room_member` 에 `joined_at` 과 `created_at` 이 둘 다 생깁니다.** 같은 뜻이라 중복인데, `joined_at` 은 응답에 나가는 도메인 값이라 없애지 않았습니다. ① 지금처럼 둘 다 두거나 ② `joined_at` 을 걷어내고 `created_at` 을 응답에 쓰는 선택지가 있는데, ②는 도메인·응답 계약이 바뀌어 이번 범위 밖으로 봤습니다.
- **`link_code`·`folder_media` 에도 감사 컬럼이 붙습니다.** 연결 코드는 5분 TTL 이고 폴더-미디어는 연결 테이블이라 실익이 적은데, 완료 조건의 "모든 엔티티에 일관되게"를 따랐습니다. 빼는 게 나으면 말씀해주세요.
- **`StoredFileJpaEntity` 는 아직 `id` 만 매핑하는 최소 구현입니다.** 여기에 `BaseEntity` 를 붙여 감사 시각까지는 매핑되지만, 나머지 컬럼은 업로드 파이프라인(#16)이 채우게 됩니다. 지금 붙이는 게 맞는지 봐주세요.
- **Spring Data Auditing 대신 `@PrePersist`/`@PreUpdate` 를 쓴 선택**을 봐주세요. 위에 적은 대로 어댑터가 엔티티를 새로 만드는 구조 때문인데, 반대로 어댑터를 영속 엔티티 수정 방식으로 바꾸면 `@CreatedDate` 를 쓸 수 있습니다. 그건 어댑터 전체를 건드리는 일이라 이번엔 하지 않았습니다.
- **기존 `link_code`·`folder_media` 행의 시각은 정확하지 않습니다.** 실제 발급·담긴 시각을 알 수 없어 각각 TTL 역산과 `now()` 로 채웠습니다. 어차피 곧 지워지거나 참고용이라 이 정도면 된다고 봤습니다.
