### PR TITLE
deploy: main 배포 반영 (RDS 전환·감사 컬럼 통일)

### DIFF
--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -4,8 +4,8 @@
 # 이 파일은 서버에서 최초 1회만 만들면 되고, 배포할 때 CI가 덮어쓰지 않는다.
 # 이미지 태그는 CI가 image.env 에 따로 기록한다.
 
-# --- PostgreSQL (compose 내부 컨테이너) ---
-DB_NAME=sssok
+# --- PostgreSQL (RDS) ---
+DB_URL=jdbc:postgresql://<rds-endpoint>:5432/sssok
 DB_USERNAME=sssok
 DB_PASSWORD=
 

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -2,42 +2,21 @@
 #   docker compose --env-file .env --env-file image.env -f docker-compose.prod.yml up -d
 # 형태로 실행한다.
 #
-# .env       : 서버에서 최초 1회 수동 생성 (DB 계정, JWT, R2 자격증명)
+# .env       : 서버에서 최초 1회 수동 생성 (DB 접속 정보, JWT, R2 자격증명)
 # image.env  : 배포마다 CI가 덮어씀 (BACKEND_IMAGE=ghcr.io/...:<sha>)
+#
+# DB는 RDS를 쓴다. 컨테이너로 띄우지 않으므로 DB_URL은 RDS 엔드포인트를 가리켜야 한다.
 
 services:
-  postgres:
-    image: postgres:16-alpine
-    container_name: sssok-postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USERNAME}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=C"
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME}"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 10s
-    networks:
-      - sssok
-
   app:
     image: ${BACKEND_IMAGE}
     container_name: sssok-app
     restart: unless-stopped
-    depends_on:
-      postgres:
-        condition: service_healthy
     ports:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      DB_URL: jdbc:postgresql://postgres:5432/${DB_NAME}
+      DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
@@ -59,9 +38,6 @@ services:
         max-file: "3"
     networks:
       - sssok
-
-volumes:
-  postgres-data:
 
 networks:
   sssok:

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/BaseEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/BaseEntity.java
@@ -1,0 +1,43 @@
+package com.sssok.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.Instant;
+import lombok.Getter;
+
+// 생성·수정 시각은 도메인이 아니라 저장의 관심사라 JPA 엔티티에만 둔다.
+// 도메인이 시각을 직접 다루는 경우는 그대로 도메인이 갖고,
+// 어댑터가 넘긴 값을 여기서 덮어쓰지 않는다.
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected BaseEntity() {
+    }
+
+    protected BaseEntity(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @PrePersist
+    void onPersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/auth/LinkCodeJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "link_code")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LinkCodeJpaEntity {
+public class LinkCodeJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
@@ -3,6 +3,7 @@ package com.sssok.infrastructure.persistence.file;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "stored_file")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StoredFileJpaEntity {
+public class StoredFileJpaEntity extends BaseEntity {
 
     @Id
     private Long id;

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderJpaEntity {
+public class FolderJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,13 +32,10 @@ public class FolderJpaEntity {
     @Column(nullable = false, length = 12)
     private String name;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     public FolderJpaEntity(Long id, Long roomId, String name, Instant createdAt) {
+        super(createdAt);
         this.id = id;
         this.roomId = roomId;
         this.name = name;
-        this.createdAt = createdAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderMediaJpaEntity {
+public class FolderMediaJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaRepository.java
@@ -35,10 +35,11 @@ public interface FolderMediaJpaRepository extends JpaRepository<FolderMediaJpaEn
     int deleteByRoomId(@Param("roomId") Long roomId);
 
     // 동시에 같은 조합을 담으려는 요청이 있어도 관계는 하나만 남도록 DB에 맡긴다.
+    // JPA 를 거치지 않아 BaseEntity 의 @PrePersist 가 돌지 않으므로 감사 컬럼을 직접 넣는다.
     @Modifying
     @Query(value = """
-        INSERT INTO folder_media (folder_id, media_id)
-        VALUES (:folderId, :mediaId)
+        INSERT INTO folder_media (folder_id, media_id, created_at, updated_at)
+        VALUES (:folderId, :mediaId, now(), now())
         ON CONFLICT (folder_id, media_id) DO NOTHING
         """, nativeQuery = true)
     int insertIfAbsent(@Param("folderId") Long folderId, @Param("mediaId") Long mediaId);

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberJpaEntity {
+public class MemberJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,12 +25,9 @@ public class MemberJpaEntity {
     @Column(name = "nickname", nullable = false, length = 12)
     private String nickname;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     public MemberJpaEntity(Long id, String nickname, Instant createdAt) {
+        super(createdAt);
         this.id = id;
         this.nickname = nickname;
-        this.createdAt = createdAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.Version;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "room")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomJpaEntity {
+public class RoomJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,9 +44,6 @@ public class RoomJpaEntity {
     @Column(name = "host_id", nullable = false)
     private Long hostId;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
@@ -61,6 +59,7 @@ public class RoomJpaEntity {
         Instant createdAt,
         Instant deletedAt
     ) {
+        super(createdAt);
         this.id = id;
         this.version = version;
         this.code = code;
@@ -69,7 +68,6 @@ public class RoomJpaEntity {
         this.expiresAt = expiresAt;
         this.uploadPolicy = uploadPolicy;
         this.hostId = hostId;
-        this.createdAt = createdAt;
         this.deletedAt = deletedAt;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomMemberJpaEntity {
+public class RoomMemberJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/room/RoomMemberJpaRepository.java
@@ -24,8 +24,8 @@ public interface RoomMemberJpaRepository extends JpaRepository<RoomMemberJpaEnti
     // 동시 입장에서도 하나만 통과하도록 DB에 맡긴다.
     @Modifying
     @Query(value = """
-        INSERT INTO room_member (room_id, member_id, joined_at)
-        VALUES (:roomId, :memberId, :joinedAt)
+        INSERT INTO room_member (room_id, member_id, joined_at, created_at, updated_at)
+        VALUES (:roomId, :memberId, :joinedAt, :joinedAt, :joinedAt)
         ON CONFLICT (room_id, member_id) DO NOTHING
         """, nativeQuery = true)
     int insertIfAbsent(

--- a/backend/src/main/java/com/sssok/infrastructure/realtime/RoomEventJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/realtime/RoomEventJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import com.sssok.infrastructure.persistence.BaseEntity;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "room_events")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomEventJpaEntity {
+public class RoomEventJpaEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,13 +33,10 @@ public class RoomEventJpaEntity {
     @Column(name = "payload", nullable = false)
     private String payload;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
     public RoomEventJpaEntity(Long roomId, String eventType, String payload, Instant createdAt) {
+        super(createdAt);
         this.roomId = roomId;
         this.eventType = eventType;
         this.payload = payload;
-        this.createdAt = createdAt;
     }
 }

--- a/backend/src/main/resources/db/migration/V12__add_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V12__add_audit_columns.sql
@@ -26,3 +26,6 @@ ALTER TABLE link_code ADD COLUMN updated_at TIMESTAMPTZ;
 UPDATE link_code SET created_at = expires_at - INTERVAL '5 minutes', updated_at = expires_at - INTERVAL '5 minutes';
 ALTER TABLE link_code ALTER COLUMN created_at SET NOT NULL;
 ALTER TABLE link_code ALTER COLUMN updated_at SET NOT NULL;
+ALTER TABLE folder ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE folder SET updated_at = created_at;
+ALTER TABLE folder ALTER COLUMN updated_at SET NOT NULL;

--- a/backend/src/main/resources/db/migration/V13__add_audit_columns_to_media.sql
+++ b/backend/src/main/resources/db/migration/V13__add_audit_columns_to_media.sql
@@ -1,0 +1,13 @@
+-- #69 BaseEntity: 나중에 들어온 stored_file·folder_media 에도 같은 감사 컬럼을 맞춘다.
+-- 기존 행은 수정된 적이 없어 updated_at 을 created_at 과 같게 둔다.
+
+ALTER TABLE stored_file ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE stored_file SET updated_at = created_at;
+ALTER TABLE stored_file ALTER COLUMN updated_at SET NOT NULL;
+
+-- 담긴 시각을 남기지 않아 기존 행은 알 방법이 없다. 지금 시각으로 채운다.
+ALTER TABLE folder_media ADD COLUMN created_at TIMESTAMPTZ;
+ALTER TABLE folder_media ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE folder_media SET created_at = now(), updated_at = now();
+ALTER TABLE folder_media ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE folder_media ALTER COLUMN updated_at SET NOT NULL;

--- a/backend/src/main/resources/db/migration/V9__add_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V9__add_audit_columns.sql
@@ -1,0 +1,28 @@
+-- #69 BaseEntity: 생성·수정 시각을 모든 테이블에 같은 이름으로 둔다.
+-- 기존 행은 의미가 가장 가까운 값으로 채운다. 수정된 적이 없으므로 updated_at 은 생성 시각과 같다.
+
+ALTER TABLE room ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE room SET updated_at = created_at;
+ALTER TABLE room ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE member ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE member SET updated_at = created_at;
+ALTER TABLE member ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE room_events ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE room_events SET updated_at = created_at;
+ALTER TABLE room_events ALTER COLUMN updated_at SET NOT NULL;
+
+-- 입장 기록은 joined_at 이 곧 만들어진 시각이다.
+ALTER TABLE room_member ADD COLUMN created_at TIMESTAMPTZ;
+ALTER TABLE room_member ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE room_member SET created_at = joined_at, updated_at = joined_at;
+ALTER TABLE room_member ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE room_member ALTER COLUMN updated_at SET NOT NULL;
+
+-- 연결 코드는 만들어진 시각을 남기지 않았다. 5분 TTL 이라 만료 시각에서 거꾸로 잡는다.
+ALTER TABLE link_code ADD COLUMN created_at TIMESTAMPTZ;
+ALTER TABLE link_code ADD COLUMN updated_at TIMESTAMPTZ;
+UPDATE link_code SET created_at = expires_at - INTERVAL '5 minutes', updated_at = expires_at - INTERVAL '5 minutes';
+ALTER TABLE link_code ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE link_code ALTER COLUMN updated_at SET NOT NULL;

--- a/backend/src/test/java/com/sssok/application/mediafolder/AddMediaToFoldersServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/mediafolder/AddMediaToFoldersServiceTest.java
@@ -35,8 +35,8 @@ class AddMediaToFoldersServiceTest extends PostgresContainerSupport {
     private Long existingMedia(long id) {
         jdbcTemplate.update("""
             INSERT INTO stored_file
-                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at)
-            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now())
+                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at, updated_at)
+            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now(), now())
             """, id, "test-key-" + id);
         return id;
     }

--- a/backend/src/test/java/com/sssok/infrastructure/persistence/BaseEntityTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/persistence/BaseEntityTest.java
@@ -1,0 +1,105 @@
+package com.sssok.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.application.room.UpdateRoomCommand;
+import com.sssok.application.room.UpdateRoomService;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.security.SecureRandom;
+import com.sssok.infrastructure.persistence.member.MemberJpaEntity;
+import com.sssok.infrastructure.persistence.member.MemberJpaRepository;
+import com.sssok.infrastructure.persistence.room.RoomJpaEntity;
+import com.sssok.infrastructure.persistence.room.RoomJpaRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BaseEntityTest {
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    UpdateRoomService updateRoomService;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    RoomRepository roomRepository;
+
+    @Autowired
+    RoomJpaRepository roomJpaRepository;
+
+    @Autowired
+    MemberJpaRepository memberJpaRepository;
+
+    private Long hostId;
+
+    @BeforeEach
+    void setUp() {
+        hostId = anonymousAuthService.authenticate("가현").userId();
+    }
+
+    @Test
+    void 저장하면_생성_시각과_수정_시각이_채워진다() {
+        MemberJpaEntity member = memberJpaRepository.findById(hostId).orElseThrow();
+
+        assertThat(member.getCreatedAt()).isCloseTo(Instant.now(), within(1, ChronoUnit.MINUTES));
+        assertThat(member.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void 수정하면_수정_시각만_바뀌고_생성_시각은_그대로다() {
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
+        RoomJpaEntity before = roomJpaRepository.findById(room.getId()).orElseThrow();
+        Instant createdAt = before.getCreatedAt();
+        Instant updatedAt = before.getUpdatedAt();
+
+        updateRoomService.update(room.getId(), hostId, new UpdateRoomCommand("2차 회식", null, null));
+
+        RoomJpaEntity after = roomJpaRepository.findById(room.getId()).orElseThrow();
+        assertThat(after.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(after.getUpdatedAt()).isAfterOrEqualTo(updatedAt);
+    }
+
+    @Test
+    void 어댑터가_넘긴_생성_시각을_덮어쓰지_않는다() {
+        Instant past = Instant.now().minus(Duration.ofDays(3));
+        Room saved = roomRepository.save(오래전에_만든_방(past));
+
+        assertThat(roomJpaRepository.findById(saved.getId()).orElseThrow().getCreatedAt())
+            .isCloseTo(past, within(1, ChronoUnit.SECONDS));
+    }
+
+    private Room 오래전에_만든_방(Instant createdAt) {
+        return Room.reconstruct(
+            null,
+            null,
+            RoomCode.generate(new SecureRandom()),
+            new RoomName("지난 회식"),
+            RoomStatus.initial(),
+            new RoomExpiration(Instant.now().plus(Duration.ofHours(24))),
+            UploadPolicy.ANYONE,
+            hostId,
+            createdAt,
+            null
+        );
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/mediafolder/MediaFolderApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/mediafolder/MediaFolderApiTest.java
@@ -237,8 +237,8 @@ class MediaFolderApiTest extends PostgresContainerSupport {
         long mediaId = MEDIA_ID_SEQUENCE.incrementAndGet();
         jdbcTemplate.update("""
             INSERT INTO stored_file
-                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at)
-            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now())
+                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes, storage_key, status, created_at, updated_at)
+            VALUES (?, 1, 1, 'test.jpg', 'JPEG', 1024, ?, 'COMPLETED', now(), now())
             """, mediaId, "test-key-" + mediaId);
         return mediaId;
     }

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -15,8 +15,10 @@ main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions (
                                             │ 로컬 명령 (SSH 없음)
                                             ▼
                                     EC2 (Docker + compose)
-                                    ├─ sssok-app       (GHCR 에서 pull)
-                                    └─ sssok-postgres  (볼륨 영속)
+                                    └─ sssok-app  (GHCR 에서 pull)
+                                            │
+                                            ▼
+                                    RDS (PostgreSQL)
 ```
 
 - 이미지 빌드는 GitHub-hosted 러너에서, 서버 배포는 **EC2 위에 설치된 self-hosted 러너**에서 실행된다. 배포 잡이 러너 자체이자 배포 대상이므로 SSH/SCP가 필요 없다.
@@ -31,7 +33,7 @@ main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions (
 
 | 파일 | 만드는 주체 | 설명 |
 | --- | --- | --- |
-| `.env` | **사람이 1회 수동 생성** | DB 계정, JWT, R2 자격증명 |
+| `.env` | **사람이 1회 수동 생성** | DB 접속 정보(RDS), JWT, R2 자격증명 |
 | `image.env` | CI가 배포마다 덮어씀 | `BACKEND_IMAGE=ghcr.io/...:<sha>` |
 | `image.env.prev` | CI가 자동 생성 | 롤백용 직전 태그 |
 | `docker-compose.prod.yml` | CI가 배포마다 전송 | 컨테이너 정의 |
@@ -49,7 +51,15 @@ main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions (
 
 CI(GitHub Actions)는 self-hosted 러너를 통해 EC2 내부에서 직접 실행되므로, 22번 포트를 CI용으로 별도 개방할 필요가 없다.
 
-### 2. Docker 설치
+### 2. RDS 준비
+
+DB는 컨테이너가 아니라 RDS(PostgreSQL)를 쓴다.
+
+- RDS는 퍼블릭 서브넷에 두지 않는다.
+- RDS 보안 그룹의 인바운드에 EC2 보안 그룹발 5432 포트를 허용한다 (EC2가 있는 VPC/서브넷에서만 접근 가능하도록).
+- 마스터 계정과 DB 이름은 `.env`의 `DB_USERNAME`/`DB_PASSWORD`, `DB_URL`의 경로 부분과 일치시킨다.
+
+### 3. Docker 설치
 
 ```bash
 sudo apt-get update
@@ -65,7 +75,7 @@ sudo usermod -aG docker $USER
 
 `usermod` 이후 **SSH 재접속**해야 sudo 없이 docker를 쓸 수 있다. CI 스크립트가 sudo 없이 실행되므로 이 단계는 필수다.
 
-### 3. 배포 디렉터리와 `.env` 생성
+### 4. 배포 디렉터리와 `.env` 생성
 
 ```bash
 mkdir -p ~/app && cd ~/app
@@ -75,9 +85,9 @@ mkdir -p ~/app && cd ~/app
 
 ```bash
 cat > .env <<'EOF'
-DB_NAME=sssok
+DB_URL=jdbc:postgresql://<rds-endpoint>:5432/sssok
 DB_USERNAME=sssok
-DB_PASSWORD=여기에_강한_비밀번호
+DB_PASSWORD=여기에_RDS_마스터_비밀번호
 JWT_SECRET=여기에_openssl_rand_base64_32_결과
 R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
 R2_ACCESS_KEY=
@@ -88,7 +98,7 @@ EOF
 chmod 600 .env
 ```
 
-### 4. self-hosted 러너 설치 (EC2 내부)
+### 5. self-hosted 러너 설치 (EC2 내부)
 
 `Settings → Actions → Runners → New self-hosted runner` 에서 OS/아키텍처(Linux, ARM64)를 선택하면
 등록 토큰이 포함된 설치 명령이 나온다. 그 명령을 EC2 에서 그대로 실행한다. 등록 토큰은 1시간 안에 써야 한다.
@@ -112,7 +122,7 @@ sudo ./svc.sh status   # active (running) 확인
 
 > **보안**: self-hosted 러너는 그 서버에서 임의 코드를 실행할 권한을 가진다. 이 워크플로는 `deploy` 브랜치 push(이미 리뷰된 코드)에만 반응하므로 위험이 낮지만, 이 리포에서 외부 기여자의 fork PR을 받게 되면 `Settings → Actions → General` 에서 fork PR의 워크플로 자동 실행을 반드시 막아야 한다.
 
-### 5. GitHub Secrets 등록
+### 6. GitHub Secrets 등록
 
 `Settings → Environments → production → Environment secrets`
 
@@ -122,7 +132,7 @@ sudo ./svc.sh status   # active (running) 확인
 
 DB·JWT·R2 값은 서버 `.env` 에 있으므로 GitHub Secret으로 넣지 않는다. (SSH 기반이 아니므로 `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_SSH_KEY`/`DEPLOY_PORT` 는 더 이상 사용하지 않는다.)
 
-### 6. GHCR 패키지 접근 권한
+### 7. GHCR 패키지 접근 권한
 
 첫 배포 후 패키지가 생성되면
 `https://github.com/orgs/woowacourse-teams/packages` 에서 `2026-sssok/backend` 를 열고
@@ -192,3 +202,4 @@ backend/src/main/resources/db/migration/
 | 헬스체크 실패 후 롤백됨 | `$COMPOSE logs app` 확인. 대부분 `.env` 값 누락 또는 Flyway 마이그레이션 오류 |
 | `Schema-validation: missing table` | 엔티티에 대응하는 마이그레이션 SQL 미작성 |
 | compose 가 `BACKEND_IMAGE` 를 못 찾음 | `image.env` 부재. 최초 배포 전이거나 경로가 틀림 |
+| DB 연결 타임아웃 (`Connection refused`, `timeout`) | RDS 보안 그룹에 EC2 보안 그룹발 5432 인바운드가 없거나, `.env`의 `DB_URL`이 RDS 엔드포인트를 가리키지 않음 |


### PR DESCRIPTION
## 배포 개요

지난 배포([PR #83](https://github.com/woowacourse-teams/2026-sssOK/pull/83)) 이후 `main`에 새로 머지된 PR 2건을 배포합니다.

- [#86 chore: 운영 DB를 RDS로 전환](https://github.com/woowacourse-teams/2026-sssOK/pull/86) — **인프라 변경 포함**
- [#82 refactor: JPA 엔티티 감사 컬럼(BaseEntity) 통일](https://github.com/woowacourse-teams/2026-sssOK/pull/82)

`main` 최신 커밋(`e85bd00`) CI·CodeRabbit 통과 확인됨.

## 변경 사항

### #86 — 운영 DB: EC2 컨테이너 PostgreSQL → RDS

- `docker-compose.prod.yml`에서 `postgres` 컨테이너 서비스·볼륨·`depends_on` 제거. `app`은 환경변수 `DB_URL`(RDS 엔드포인트)을 그대로 사용
- `.env.prod.example`의 `DB_NAME` 항목을 `DB_URL`(RDS 접속 문자열)로 교체
- `DEPLOYMENT.md`에 RDS 준비(보안 그룹·서브넷) 절차와 연결 오류 트러블슈팅 추가
- **PR 범위 밖으로 명시된 후속 작업**: 기존 데이터 이관(pg_dump/psql), sslmode(verify-full) 결정과 인증서 마운트 — 아직 미완료

### #82 — JPA 엔티티 감사 컬럼(BaseEntity) 통일

- 엔티티 8개 전부 `created_at`/`updated_at`을 `BaseEntity`로 공통화, 없던 컬럼은 마이그레이션으로 백필
- 마이그레이션 `V12__add_audit_columns.sql`, `V13__add_audit_columns_to_media.sql` 추가
- `ON CONFLICT` 네이티브 INSERT 2곳(방 입장, 폴더에 미디어 담기)에 감사 컬럼 값을 직접 채우도록 수정 — 빠지면 해당 기능 전체 실패

## ⚠️ 서버에서 배포 전 반드시 해야 하는 작업

이번 배포는 **운영 DB 자체를 옮기는 전환**이라 다른 배포보다 위험도가 높습니다. CI/CD가 자동으로 처리해주지 않는 부분입니다.

1. **RDS 인스턴스 준비**: 퍼블릭 서브넷에 두지 않고, 보안 그룹 인바운드에 EC2 보안 그룹발 5432 포트를 허용
2. **기존 데이터 이관 (가장 중요, PR 범위 밖 수동 작업)**
   - 지금 EC2의 `sssok-postgres` 컨테이너에 있는 방·회원·폴더 데이터를 `pg_dump`로 덤프해 RDS로 `psql`/`pg_restore` 이관
   - **이 작업을 건너뛰고 배포하면 compose 정의에서 postgres 컨테이너 자체가 사라지므로 기존 데이터에 접근할 방법이 없어집니다.**
3. **서버 `.env` 수정**: `DB_NAME` 줄을 지우고 `DB_URL=jdbc:postgresql://<rds-endpoint>:5432/sssok` 추가 (`DB_USERNAME`/`DB_PASSWORD`는 RDS 마스터 계정과 일치시킴)
   - sslmode는 아직 미정 상태로 배포됩니다 (verify-full 인증서 검증은 후속 작업으로 보류 — 지금은 기본 SSL 모드로 연결)
4. **Flyway 마이그레이션**: 앱 기동 시 V12·V13이 RDS에 자동 적용됩니다. `ddl-auto: validate` 조합이라 실패하면 앱이 뜨지 않습니다
5. **이관 확인 후 고아 컨테이너 정리**: `docker compose --env-file .env --env-file image.env -f docker-compose.prod.yml up -d --remove-orphans`로 이전 `sssok-postgres` 컨테이너 정리
6. **롤백 주의**: 헬스체크 실패 시 CI가 자동으로 직전 이미지로 롤백하지만, **DB 자체가 RDS로 바뀌는 전환이라 이미지 롤백만으로는 예전 EC2 컨테이너 DB로 돌아가지 않습니다.** 데이터 이관이 검증되기 전까지는 기존 `sssok-postgres` 컨테이너·볼륨을 지우지 말고 보존해두세요.

## 체크리스트

- [ ] RDS 인스턴스 및 보안 그룹 준비 완료
- [ ] 기존 EC2 postgres 데이터 RDS로 이관 완료 (pg_dump/restore), 이관 결과 검증
- [ ] 서버 `.env`의 `DB_URL` 값 교체 완료
- [ ] 이관 검증 전까지 기존 `sssok-postgres` 컨테이너·볼륨 보존
- [ ] 배포 후 `$COMPOSE logs -f app`으로 RDS 연결·마이그레이션 정상 확인
