### PR TITLE
feat: 업로드 진행 상황 바 구현

### DIFF
--- a/frontend/src/features/upload-media/index.ts
+++ b/frontend/src/features/upload-media/index.ts
@@ -1,9 +1,16 @@
 export { uploadFiles } from "./model/uploadFiles";
+export { useMediaUpload } from "./model/useMediaUpload";
+export { UploadProgressBar } from "./ui/UploadProgressBar";
 export type {
   FailedUpload,
   UploadFailureCode,
   UploadFilesOptions,
   UploadProgress,
   UploadResult,
+  UploadTargetInfo,
+  UploadedFile,
 } from "./model/types";
+export type { UploadProgressSnapshot } from "./model/uploadProgress";
+export type { UseMediaUploadOptions } from "./model/useMediaUpload";
+export type { UploadProgressBarProps } from "./ui/UploadProgressBar";
 export type { RejectedFile } from "./api/types";

--- a/frontend/src/features/upload-media/model/types.ts
+++ b/frontend/src/features/upload-media/model/types.ts
@@ -13,6 +13,24 @@ export interface UploadProgress {
 }
 
 /**
+ * 발급을 통과해 실제로 올라갈 파일 한 건.
+ * 진행 바는 이걸 받고서야 "몇 장 중 몇 장" 의 분모와 퍼센트의 분모를 확정한다 (#73) —
+ * 고른 파일 전부가 올라가는 게 아니라, 거절분이 빠진 만큼만 올라가기 때문이다.
+ */
+export interface UploadTargetInfo {
+  mediaId: number;
+  fileName: string;
+  /** 원본 `File.size`. 퍼센트의 분모로 쓰인다. */
+  size: number;
+}
+
+/** PUT 이 끝난 파일 한 건. 아직 등록 전이라 갤러리에는 없다. */
+export interface UploadedFile {
+  mediaId: number;
+  fileName: string;
+}
+
+/**
  * 전송이 어쩌다 깨진 것. `rejected` 와 달리 재시도가 의미 있다.
  * 자동 재시도를 다 쓰고도 실패한 것만 여기로 온다.
  */
@@ -61,6 +79,18 @@ export interface UploadFilesOptions {
    */
   onRejected?: (rejected: RejectedFile[]) => void;
   onProgress?: (progress: UploadProgress) => void;
+  /**
+   * 발급을 통과한 파일 목록. `onRejected` 직후, 첫 PUT 이 나가기 전에 한 번 불린다.
+   * 진행 바가 고를 때 잡아둔 잠정 장수·바이트를 여기서 확정값으로 바로잡는다 (#73).
+   */
+  onStarted?: (targets: UploadTargetInfo[]) => void;
+  /**
+   * PUT 한 건이 끝날 때마다. 진행 바의 "완료 장수" 가 여기서 오른다 (#73).
+   *
+   * 진행률 이벤트로는 이걸 대신할 수 없다 — 100% 까지 보내고도 응답이 깨져
+   * 재발급받아 처음부터 다시 올라가는 파일이 있다.
+   */
+  onUploaded?: (uploaded: UploadedFile) => void;
   /**
    * 중단하면 진행 중인 PUT 이 실제로 끊기고, 대기 중이던 파일은 출발하지 않는다.
    * 다만 **이미 올라간 파일은 그대로 등록한다** — 중단은 "아직 안 올린 것을 그만두는" 것이지

--- a/frontend/src/features/upload-media/model/uploadFiles.test.ts
+++ b/frontend/src/features/upload-media/model/uploadFiles.test.ts
@@ -125,6 +125,46 @@ describe("uploadFiles", () => {
     ]);
   });
 
+  it("발급을 통과한 목록을 첫 PUT 전에 한 번 알린다", async () => {
+    await enterRoom();
+    const onStarted = jest.fn();
+    let putSeen = false;
+
+    server.use(
+      http.put(`${MOCK_R2_BASE_URL}/*`, () => {
+        putSeen = true;
+
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    await run([fileOf("메모.txt", 3, "text/plain"), fileOf("첫째.jpg", 5)], {
+      onStarted: (targets) => {
+        // 진행 바의 분모가 잡히는 시점이다. 한 장이라도 나간 뒤면 늦다.
+        expect(putSeen).toBe(false);
+        onStarted(targets);
+      },
+    });
+
+    // 거절된 메모.txt 는 빠지고, 올라갈 파일만 크기와 함께 온다.
+    expect(onStarted).toHaveBeenCalledTimes(1);
+    expect(onStarted).toHaveBeenCalledWith([
+      expect.objectContaining({ fileName: "첫째.jpg", size: 5 }),
+    ]);
+  });
+
+  it("PUT 이 끝난 파일만, 끝나는 대로 하나씩 알린다", async () => {
+    await enterRoom();
+    interceptPuts({ statusOf: (key) => (key.endsWith(".png") ? 500 : 200) });
+    const onUploaded = jest.fn();
+
+    await run([fileOf("첫째.jpg", 3), fileOf("둘째.png", 7, "image/png")], { onUploaded });
+
+    // 재시도를 다 쓰고 실패한 파일은 세지 않는다. 등록을 기다리지도 않는다.
+    expect(onUploaded).toHaveBeenCalledTimes(1);
+    expect(onUploaded).toHaveBeenCalledWith(expect.objectContaining({ fileName: "첫째.jpg" }));
+  });
+
   it("거절된 파일은 쏘지 않고 나머지만 올린다", async () => {
     await enterRoom();
     const { records } = interceptPuts();

--- a/frontend/src/features/upload-media/model/uploadFiles.ts
+++ b/frontend/src/features/upload-media/model/uploadFiles.ts
@@ -23,6 +23,8 @@ export const uploadFiles = async ({
   folderIds,
   onRejected,
   onProgress,
+  onStarted,
+  onUploaded,
   signal,
 }: UploadFilesOptions): Promise<UploadResult> => {
   const { issued, rejected } = await issueUploadUrls(
@@ -44,12 +46,34 @@ export const uploadFiles = async ({
     onRejected?.(rejected);
   }
 
-  const results = await runWithLimit(
-    pairWithFiles(files, issued, rejected),
-    UPLOAD_CONCURRENCY,
-    (target) =>
-      uploadOne({ roomId, token, issued: target.issued, file: target.file, signal, onProgress }),
+  const targets = pairWithFiles(files, issued, rejected);
+
+  // 거절분이 빠진 뒤라야 "몇 장 중 몇 장" 의 분모가 맞는다. 첫 PUT 보다 먼저 알린다 (#73).
+  onStarted?.(
+    targets.map(({ issued: one, file }) => ({
+      mediaId: one.mediaId,
+      fileName: one.fileName,
+      size: file.size,
+    })),
   );
+
+  const results = await runWithLimit(targets, UPLOAD_CONCURRENCY, async (target) => {
+    const result = await uploadOne({
+      roomId,
+      token,
+      issued: target.issued,
+      file: target.file,
+      signal,
+      onProgress,
+    });
+
+    // 등록까지 기다리면 마지막 한 번에 몰아서 오른다. 올라간 즉시 세는 게 사용자가 보는 진행이다.
+    if (result.ok) {
+      onUploaded?.({ mediaId: target.issued.mediaId, fileName: target.issued.fileName });
+    }
+
+    return result;
+  });
 
   const uploadedIds: number[] = [];
   const failed: FailedUpload[] = [];

--- a/frontend/src/features/upload-media/model/uploadProgress.test.ts
+++ b/frontend/src/features/upload-media/model/uploadProgress.test.ts
@@ -1,0 +1,151 @@
+import {
+  loadedBytesOf,
+  percentOf,
+  snapshotOf,
+  startUploadProgress,
+  withProgress,
+  withTargets,
+  withUploaded,
+} from "./uploadProgress";
+
+const MB = 1024 * 1024;
+
+const fileOf = (fileName: string, size: number) => {
+  const file = new File(["x"], fileName, { type: "image/jpeg" });
+
+  // File 은 내용으로만 크기가 정해진다. 3MB 짜리 문자열을 만들 이유가 없어 값만 바꿔 끼운다.
+  Object.defineProperty(file, "size", { value: size });
+
+  return file;
+};
+
+const targetOf = (mediaId: number, size: number) => ({
+  mediaId,
+  fileName: `photo-${mediaId}.jpg`,
+  size,
+});
+
+const progressOf = (mediaId: number, loaded: number, total: number) => ({
+  mediaId,
+  fileName: `photo-${mediaId}.jpg`,
+  loaded,
+  total,
+});
+
+describe("startUploadProgress", () => {
+  it("발급 전에는 고른 파일 전부를 잠정 분모로 잡는다", () => {
+    const state = startUploadProgress([fileOf("a.jpg", 3 * MB), fileOf("b.jpg", 1 * MB)]);
+
+    expect(state.totalCount).toBe(2);
+    expect(state.totalBytes).toBe(4 * MB);
+    expect(state.completedCount).toBe(0);
+    expect(percentOf(state)).toBe(0);
+  });
+});
+
+describe("withTargets", () => {
+  it("거절된 파일을 장수와 바이트 양쪽에서 뺀다", () => {
+    const state = startUploadProgress([
+      fileOf("a.jpg", 3 * MB),
+      fileOf("b.txt", 1 * MB),
+      fileOf("c.jpg", 2 * MB),
+    ]);
+
+    // b.txt 는 발급이 거절했다. 올라가지 않으므로 분모에서 빠져야 한다.
+    const corrected = withTargets(state, [targetOf(1, 3 * MB), targetOf(3, 2 * MB)]);
+
+    expect(corrected.totalCount).toBe(2);
+    expect(corrected.totalBytes).toBe(5 * MB);
+  });
+});
+
+describe("withProgress", () => {
+  it("파일별 최신 바이트로 덮어쓴다 — 이벤트를 더하지 않는다", () => {
+    let state = withTargets(startUploadProgress([]), [targetOf(1, 10 * MB)]);
+
+    state = withProgress(state, progressOf(1, 2 * MB, 10 * MB));
+    state = withProgress(state, progressOf(1, 5 * MB, 10 * MB));
+
+    expect(loadedBytesOf(state)).toBe(5 * MB);
+  });
+
+  it("재발급으로 다시 올라가면 퍼센트가 뒤로 물러난다", () => {
+    let state = withTargets(startUploadProgress([]), [targetOf(1, 10 * MB), targetOf(2, 10 * MB)]);
+
+    state = withProgress(state, progressOf(1, 9 * MB, 10 * MB));
+    expect(percentOf(state)).toBe(45);
+
+    // 9MB 까지 갔다가 PUT 이 깨져 새 URL 로 처음부터 다시 올라간다.
+    state = withProgress(state, progressOf(1, 0, 10 * MB));
+    expect(percentOf(state)).toBe(0);
+  });
+
+  it("발급받은 크기보다 많이 보고돼도 그 이상 세지 않는다", () => {
+    let state = withTargets(startUploadProgress([]), [targetOf(1, 10 * MB)]);
+
+    state = withProgress(state, progressOf(1, 12 * MB, 12 * MB));
+
+    expect(loadedBytesOf(state)).toBe(10 * MB);
+    expect(percentOf(state)).toBe(100);
+  });
+
+  it("발급 전에 이벤트가 오면 이벤트가 알려준 크기를 한도로 쓴다", () => {
+    const state = withProgress(startUploadProgress([]), progressOf(1, 5 * MB, 3 * MB));
+
+    expect(loadedBytesOf(state)).toBe(3 * MB);
+  });
+});
+
+describe("withUploaded", () => {
+  it("완료 장수를 올리고 그 파일을 다 보낸 것으로 채운다", () => {
+    let state = withTargets(startUploadProgress([]), [targetOf(1, 10 * MB), targetOf(2, 10 * MB)]);
+
+    // 마지막 진행률 이벤트가 99% 에서 끊겨도 완료는 완료다.
+    state = withProgress(state, progressOf(1, 9.9 * MB, 10 * MB));
+    state = withUploaded(state, { mediaId: 1, fileName: "photo-1.jpg" });
+
+    expect(state.completedCount).toBe(1);
+    expect(loadedBytesOf(state)).toBe(10 * MB);
+    expect(percentOf(state)).toBe(50);
+  });
+});
+
+describe("percentOf", () => {
+  it("장수가 아니라 바이트로 센다", () => {
+    let state = withTargets(startUploadProgress([]), [
+      targetOf(1, 1 * MB),
+      targetOf(2, 1 * MB),
+      targetOf(3, 98 * MB),
+    ]);
+
+    // 작은 사진 두 장이 끝났다. 3장 중 2장이지만 회선으로는 2%밖에 안 나갔다.
+    state = withUploaded(state, { mediaId: 1, fileName: "photo-1.jpg" });
+    state = withUploaded(state, { mediaId: 2, fileName: "photo-2.jpg" });
+
+    expect(snapshotOf(state)).toEqual({ completedCount: 2, totalCount: 3, percent: 2 });
+  });
+
+  it("올릴 게 하나도 없으면 0% 다 — 0 으로 나누지 않는다", () => {
+    const state = withTargets(startUploadProgress([fileOf("a.txt", 1 * MB)]), []);
+
+    expect(percentOf(state)).toBe(0);
+  });
+
+  it("전부 끝나면 100% 다", () => {
+    let state = withTargets(startUploadProgress([]), [targetOf(1, 3 * MB), targetOf(2, 7 * MB)]);
+
+    state = withUploaded(state, { mediaId: 1, fileName: "photo-1.jpg" });
+    state = withUploaded(state, { mediaId: 2, fileName: "photo-2.jpg" });
+
+    expect(percentOf(state)).toBe(100);
+  });
+
+  it("소수점은 버린다 — 다 안 끝났는데 100% 로 보이면 안 된다", () => {
+    let state = withTargets(startUploadProgress([]), [targetOf(1, 1000), targetOf(2, 1)]);
+
+    state = withUploaded(state, { mediaId: 1, fileName: "photo-1.jpg" });
+
+    // 1001 바이트 중 1000 바이트 = 99.9%
+    expect(percentOf(state)).toBe(99);
+  });
+});

--- a/frontend/src/features/upload-media/model/uploadProgress.ts
+++ b/frontend/src/features/upload-media/model/uploadProgress.ts
@@ -1,0 +1,108 @@
+import type { UploadProgress, UploadTargetInfo, UploadedFile } from "./types";
+
+/**
+ * 진행 바가 그리는 상태. 파일 단위로 흩어져 오는 이벤트를 배치 하나로 합친 것이다.
+ *
+ * **"3/30장" 과 "27%" 는 서로 다른 것을 센다.** 앞은 PUT 이 끝난 파일 수고,
+ * 뒤는 지금까지 실제로 회선에 나간 바이트다. 큰 영상 한 장이 남으면
+ * 장수는 29/30 인데 퍼센트는 40% 일 수 있다 — 어긋난 게 아니라 그게 맞는 표시다.
+ *
+ * 상태를 만드는 쪽은 `useMediaUpload` 다. 여기는 순수 함수만 둔다 —
+ * 목이 즉시 응답해서 진행률은 목으로 확인할 수 없고, 계산만은 테스트로 묶어둘 수 있다.
+ */
+export interface UploadProgressState {
+  /** 올릴 파일 장수. 발급 응답이 오면 거절분이 빠진 수로 확정된다 */
+  totalCount: number;
+  /** 퍼센트의 분모. 장수와 같은 시점에 확정된다 */
+  totalBytes: number;
+  /** PUT 이 끝난 장수 */
+  completedCount: number;
+  /** mediaId → 그 파일의 전체 바이트 */
+  totalByMediaId: Record<number, number>;
+  /**
+   * mediaId → 마지막으로 보고된 전송 바이트.
+   * 더하지 않고 **덮어쓴다** — 재발급으로 다시 올라가는 파일은 0 부터 다시 쌓이고,
+   * 그때는 퍼센트가 뒤로 물러나는 게 맞다.
+   */
+  loadedByMediaId: Record<number, number>;
+}
+
+/**
+ * 파일을 고른 직후의 상태. 아직 발급 전이라 장수·바이트 모두 **잠정값**이다.
+ *
+ * 발급 응답을 기다렸다가 바를 띄우면 왕복 한 번만큼 화면이 비어 있게 된다.
+ * 잠정값으로 먼저 띄우고 `withTargets` 로 바로잡는다.
+ */
+export const startUploadProgress = (files: File[]): UploadProgressState => ({
+  totalCount: files.length,
+  totalBytes: files.reduce((sum, file) => sum + file.size, 0),
+  completedCount: 0,
+  totalByMediaId: {},
+  loadedByMediaId: {},
+});
+
+/** 발급을 통과한 목록으로 분모를 확정한다. 거절된 파일은 여기서 빠진다. */
+export const withTargets = (
+  state: UploadProgressState,
+  targets: UploadTargetInfo[],
+): UploadProgressState => ({
+  ...state,
+  totalCount: targets.length,
+  totalBytes: targets.reduce((sum, target) => sum + target.size, 0),
+  totalByMediaId: Object.fromEntries(targets.map((target) => [target.mediaId, target.size])),
+});
+
+export const withProgress = (
+  state: UploadProgressState,
+  { mediaId, loaded, total }: UploadProgress,
+): UploadProgressState => ({
+  ...state,
+  loadedByMediaId: {
+    ...state.loadedByMediaId,
+    // 발급이 알려준 크기를 넘겨 세지 않는다. 분모는 그대로인데 분자만 커지면 100% 를 넘긴다.
+    [mediaId]: Math.min(loaded, state.totalByMediaId[mediaId] ?? total),
+  },
+});
+
+export const withUploaded = (
+  state: UploadProgressState,
+  { mediaId }: UploadedFile,
+): UploadProgressState => ({
+  ...state,
+  completedCount: state.completedCount + 1,
+  loadedByMediaId: {
+    ...state.loadedByMediaId,
+    // 마지막 진행률 이벤트가 99% 에서 끊길 수 있다. 끝난 파일은 다 보낸 것으로 친다.
+    [mediaId]: state.totalByMediaId[mediaId] ?? state.loadedByMediaId[mediaId] ?? 0,
+  },
+});
+
+export const loadedBytesOf = (state: UploadProgressState) =>
+  Object.values(state.loadedByMediaId).reduce((sum, loaded) => sum + loaded, 0);
+
+/**
+ * 0~100 의 정수. **파일 수가 아니라 바이트 기준이다** (#73 완료 조건) —
+ * 3.4MB 사진과 80MB 영상을 같은 한 장으로 세면 바가 영상 구간에서 통째로 멈춘다.
+ */
+export const percentOf = (state: UploadProgressState) => {
+  if (state.totalBytes <= 0) {
+    return 0;
+  }
+
+  const percent = Math.floor((loadedBytesOf(state) / state.totalBytes) * 100);
+
+  return Math.min(Math.max(percent, 0), 100);
+};
+
+/** 화면이 실제로 읽는 세 값. 내부 장부(`UploadProgressState`)는 바깥으로 나가지 않는다. */
+export interface UploadProgressSnapshot {
+  completedCount: number;
+  totalCount: number;
+  percent: number;
+}
+
+export const snapshotOf = (state: UploadProgressState): UploadProgressSnapshot => ({
+  completedCount: state.completedCount,
+  totalCount: state.totalCount,
+  percent: percentOf(state),
+});

--- a/frontend/src/features/upload-media/model/useMediaUpload.test.tsx
+++ b/frontend/src/features/upload-media/model/useMediaUpload.test.tsx
@@ -1,0 +1,262 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import { MOCK_ROOM_ID } from "@/mocks/handlers/room";
+import { MOCK_R2_BASE_URL } from "@/mocks/handlers/upload";
+import { server } from "@/mocks/server";
+import { API_BASE_URL } from "@/shared/config";
+import { useMediaUpload } from "./useMediaUpload";
+
+const TOKEN = "mock-token-10234";
+
+const fileOf = (fileName: string, byteLength: number, type = "image/jpeg") =>
+  new File(["x".repeat(byteLength)], fileName, { type });
+
+const enterRoom = () =>
+  fetch(`${API_BASE_URL}/rooms/${MOCK_ROOM_ID}/members`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+
+/**
+ * PUT 을 붙잡아 둔다. 목은 즉시 응답해서 그냥 두면 시작하자마자 끝나 버려,
+ * "올라가는 중" 의 화면을 볼 수가 없다.
+ *
+ * 가로챈 PUT 은 목이 업로드 바이트를 기록하지 못해 완료 등록이 실패로 떨어진다.
+ * 그래서 이 헬퍼를 쓰는 검사는 등록 결과가 아니라 **진행 상태**만 본다.
+ */
+const holdPuts = (shouldHold: (key: string) => boolean = () => true) => {
+  let open = () => {};
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+
+  server.use(
+    http.put(`${MOCK_R2_BASE_URL}/*`, async ({ request }) => {
+      if (shouldHold(new URL(request.url).pathname)) {
+        await opened;
+      }
+
+      return new HttpResponse(null, { status: 200 });
+    }),
+  );
+
+  return { open: () => open() };
+};
+
+const renderUpload = (options: Partial<Parameters<typeof useMediaUpload>[0]> = {}) =>
+  renderHook(() => useMediaUpload({ roomId: MOCK_ROOM_ID, token: TOKEN, ...options }));
+
+/** `start` 는 판이 끝나야 풀린다. 도는 중을 보려면 기다리지 않고 손잡이만 받아둬야 한다. */
+const startUpload = (result: { current: ReturnType<typeof useMediaUpload> }, files: File[]) => {
+  let running: Promise<void>;
+
+  act(() => {
+    running = result.current.start(files);
+  });
+
+  return running!;
+};
+
+describe("useMediaUpload", () => {
+  it("업로드 전에는 진행 상태가 없다 — 바를 띄울 이유가 없다", () => {
+    const { result } = renderUpload();
+
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("파일을 넘기면 발급을 기다리지 않고 곧바로 진행 상태가 생긴다", async () => {
+    await enterRoom();
+    const hold = holdPuts();
+    const { result } = renderUpload();
+
+    const running = startUpload(result, [fileOf("첫째.jpg", 3), fileOf("둘째.jpg", 7)]);
+
+    // 발급 왕복 전이라 아직 잠정값이다. 그래도 바는 이미 떠 있어야 한다.
+    expect(result.current.progress).toEqual({ completedCount: 0, totalCount: 2, percent: 0 });
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+  });
+
+  it("발급이 거절한 파일은 전체 장수에서 빠진다", async () => {
+    await enterRoom();
+    const hold = holdPuts();
+    const { result } = renderUpload();
+
+    const running = startUpload(result, [
+      fileOf("첫째.jpg", 3),
+      fileOf("메모.txt", 5, "text/plain"),
+    ]);
+
+    await waitFor(() => expect(result.current.progress?.totalCount).toBe(1));
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+  });
+
+  it("PUT 이 끝날 때마다 완료 장수가 오르고, 퍼센트는 바이트로 센다", async () => {
+    await enterRoom();
+    // 영상만 붙잡아 둔다. 사진은 그대로 끝난다.
+    const hold = holdPuts((key) => key.endsWith(".mp4"));
+    const { result } = renderUpload();
+
+    const running = startUpload(result, [
+      fileOf("사진.jpg", 3),
+      fileOf("영상.mp4", 97, "video/mp4"),
+    ]);
+
+    // 2장 중 1장이 끝났지만 회선으로는 3%밖에 안 나갔다. 50% 가 아니다.
+    await waitFor(() =>
+      expect(result.current.progress).toEqual({ completedCount: 1, totalCount: 2, percent: 3 }),
+    );
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+  });
+
+  it("업로드가 끝나면 진행 상태가 사라진다 — 바가 저절로 사라진다", async () => {
+    await enterRoom();
+    const onSettled = jest.fn();
+    const { result } = renderUpload({ onSettled });
+
+    await act(async () => {
+      await result.current.start([fileOf("첫째.jpg", 3)]);
+    });
+
+    expect(result.current.progress).toBeNull();
+    expect(onSettled).toHaveBeenCalledWith(
+      expect.objectContaining({ registered: [expect.objectContaining({ fileName: "첫째.jpg" })] }),
+    );
+  });
+
+  it("취소하면 등록 왕복을 기다리지 않고 곧바로 사라진다", async () => {
+    await enterRoom();
+    const hold = holdPuts();
+    const { result } = renderUpload();
+
+    const running = startUpload(result, [fileOf("첫째.jpg", 3), fileOf("둘째.jpg", 3)]);
+
+    await waitFor(() => expect(result.current.progress).not.toBeNull());
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(result.current.progress).toBeNull();
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+  });
+
+  it("취소한 판도 결과는 그대로 알린다 — 이미 올라간 파일이 등록돼야 한다", async () => {
+    await enterRoom();
+    const hold = holdPuts();
+    const onSettled = jest.fn();
+    const { result } = renderUpload({ onSettled });
+
+    const running = startUpload(result, [fileOf("첫째.jpg", 3)]);
+
+    await waitFor(() => expect(result.current.progress).not.toBeNull());
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+
+    // 무엇이 등록되고 무엇이 실패했는지는 uploadFiles 가 가른다. 여기서는 결과가 온다는 것만 본다.
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it("취소한 판이 뒤늦게 끝나도 사라진 바를 되살리지 않는다", async () => {
+    await enterRoom();
+    const hold = holdPuts();
+    const { result } = renderUpload();
+
+    const running = startUpload(result, [fileOf("첫째.jpg", 3)]);
+
+    await waitFor(() => expect(result.current.progress).not.toBeNull());
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("도는 중에 또 시작해도 판이 겹치지 않는다", async () => {
+    await enterRoom();
+    const hold = holdPuts();
+    let issueCount = 0;
+
+    server.events.on("request:start", ({ request }) => {
+      if (new URL(request.url).pathname.endsWith("/media/upload-urls")) {
+        issueCount += 1;
+      }
+    });
+
+    const { result } = renderUpload();
+    const running = startUpload(result, [fileOf("첫째.jpg", 3)]);
+
+    await waitFor(() => expect(result.current.progress).not.toBeNull());
+
+    const ignored = startUpload(result, [fileOf("둘째.jpg", 3), fileOf("셋째.jpg", 3)]);
+
+    await act(async () => {
+      await ignored;
+    });
+
+    // 두 번째 호출은 아무 일도 하지 않는다. 첫 판의 장수가 그대로여야 한다.
+    expect(result.current.progress?.totalCount).toBe(1);
+
+    hold.open();
+    await act(async () => {
+      await running;
+    });
+
+    expect(issueCount).toBe(1);
+  });
+
+  it("빈 목록으로 시작하면 바를 띄우지 않는다", async () => {
+    await enterRoom();
+    const { result } = renderUpload();
+
+    await act(async () => {
+      await result.current.start([]);
+    });
+
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("방·권한 문제로 배치 전체가 막히면 바를 치우고 알린다", async () => {
+    const onError = jest.fn();
+    const { result } = renderUpload({ onError });
+
+    // 입장하지 않은 방이라 발급부터 403 이다.
+    await act(async () => {
+      await result.current.start([fileOf("첫째.jpg", 3)]);
+    });
+
+    expect(result.current.progress).toBeNull();
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: "NOT_ROOM_MEMBER" }));
+  });
+});
+
+afterEach(() => server.events.removeAllListeners());

--- a/frontend/src/features/upload-media/model/useMediaUpload.ts
+++ b/frontend/src/features/upload-media/model/useMediaUpload.ts
@@ -1,0 +1,109 @@
+import { useRef, useState } from "react";
+
+import type { RejectedFile } from "../api/types";
+import type { UploadProgressState } from "./uploadProgress";
+import {
+  snapshotOf,
+  startUploadProgress,
+  withProgress,
+  withTargets,
+  withUploaded,
+} from "./uploadProgress";
+import type { UploadResult } from "./types";
+import { uploadFiles } from "./uploadFiles";
+
+export interface UseMediaUploadOptions {
+  roomId: number;
+  token: string;
+  /** 지금 열어둔 폴더. 없으면 루트로 올라간다. */
+  folderIds?: number[];
+  /** 발급이 거절한 파일. 업로드가 끝나기 전에 먼저 온다. */
+  onRejected?: (rejected: RejectedFile[]) => void;
+  /** 등록까지 끝났을 때. 갤러리 갱신과 실패 모달(#74)이 여기서 갈린다. */
+  onSettled?: (result: UploadResult) => void;
+  /** 방·권한 문제라 배치 전체가 못 올라간 경우 (403·410 등). */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * 업로드 한 판을 굴리면서 진행 바가 볼 상태를 들고 있는다.
+ *
+ * `progress` 가 `null` 이면 업로드 중이 아니다 — 바를 띄울지 말지가 이 한 값으로 정해진다.
+ */
+export const useMediaUpload = ({
+  roomId,
+  token,
+  folderIds,
+  onRejected,
+  onSettled,
+  onError,
+}: UseMediaUploadOptions) => {
+  const [progress, setProgress] = useState<UploadProgressState | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  /**
+   * 지금 화면이 따라가는 실행. 취소하거나 새로 시작하면 번호가 바뀐다.
+   * 번호가 어긋난 실행의 콜백은 화면을 건드리지 못한다 — 취소한 판이 뒤늦게
+   * 진행률을 흘려서 사라진 바를 되살리는 걸 막는다.
+   */
+  const runIdRef = useRef(0);
+
+  const start = async (files: File[]) => {
+    // 이미 한 판이 돌고 있다. 두 판을 겹치면 진행 바가 어느 쪽을 세는지 알 수 없다.
+    if (files.length === 0 || abortRef.current !== null) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    abortRef.current = controller;
+    runIdRef.current += 1;
+
+    const runId = runIdRef.current;
+    const isCurrent = () => runIdRef.current === runId;
+    const update = (next: (state: UploadProgressState) => UploadProgressState) =>
+      setProgress((current) => (current === null || !isCurrent() ? current : next(current)));
+
+    // 발급 왕복을 기다리지 않고 먼저 띄운다. 장수와 바이트는 잠정값이다.
+    setProgress(startUploadProgress(files));
+
+    try {
+      const result = await uploadFiles({
+        roomId,
+        files,
+        token,
+        folderIds,
+        signal: controller.signal,
+        onRejected,
+        onStarted: (targets) => update((state) => withTargets(state, targets)),
+        onProgress: (one) => update((state) => withProgress(state, one)),
+        onUploaded: (one) => update((state) => withUploaded(state, one)),
+      });
+
+      // 취소한 판이라도 알린다. 취소 전에 올라간 파일은 그대로 등록돼 갤러리에 남는다 (#73).
+      onSettled?.(result);
+    } catch (error) {
+      onError?.(error);
+    } finally {
+      if (isCurrent()) {
+        abortRef.current = null;
+        setProgress(null);
+      }
+    }
+  };
+
+  /**
+   * 진행 중인 PUT 을 끊고 바를 곧바로 치운다.
+   *
+   * 완료 등록은 뒤에서 계속 나간다 — 중단은 "아직 안 올린 것을 그만두는" 것이지
+   * "올린 것을 무르는" 게 아니다 (#73 완료 조건). 그 왕복을 기다리느라 바를 남겨두면
+   * 사용자는 취소가 안 먹은 걸로 본다.
+   */
+  const cancel = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    runIdRef.current += 1;
+    setProgress(null);
+  };
+
+  return { progress: progress === null ? null : snapshotOf(progress), start, cancel };
+};

--- a/frontend/src/features/upload-media/ui/UploadProgressBar.stories.tsx
+++ b/frontend/src/features/upload-media/ui/UploadProgressBar.stories.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { Button } from "@/shared/ui/button";
+import type { UploadProgressState } from "../model/uploadProgress";
+import {
+  snapshotOf,
+  startUploadProgress,
+  withProgress,
+  withTargets,
+  withUploaded,
+} from "../model/uploadProgress";
+import { UploadProgressBar } from "./UploadProgressBar";
+
+const meta = {
+  title: "features/upload-media/UploadProgressBar",
+  component: UploadProgressBar,
+  parameters: {
+    // 화면 하단에 고정되는 바다. 캔버스를 꽉 채워야 실제로 앉는 자리가 보인다.
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof UploadProgressBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 03 · 업로드 진행 — 막 시작해 아직 한 장도 못 올린 상태 */
+export const Starting: Story = {
+  args: {
+    completedCount: 0,
+    totalCount: 24,
+    percent: 0,
+    onCancel: () => {},
+  },
+};
+
+/** 03 · 업로드 진행 — 절반쯤 올라간 상태 */
+export const Uploading: Story = {
+  args: {
+    completedCount: 20,
+    totalCount: 24,
+    percent: 62,
+    onCancel: () => {},
+  },
+};
+
+/**
+ * 03 · 업로드 진행 — 큰 영상 한 장만 남은 상태.
+ *
+ * 장수는 2/3 인데 퍼센트는 2% 다. 어긋난 게 아니라, 장수는 파일을 세고
+ * 퍼센트는 바이트를 세기 때문이다 (#73 완료 조건).
+ */
+export const LargeVideoRemaining: Story = {
+  args: {
+    completedCount: 2,
+    totalCount: 3,
+    percent: 2,
+    onCancel: () => {},
+  },
+};
+
+const MB = 1024 * 1024;
+const TICK_MS = 100;
+const BYTES_PER_TICK = 2 * MB;
+
+const TARGETS = [
+  { mediaId: 1, fileName: "사진1.jpg", size: 3 * MB },
+  { mediaId: 2, fileName: "사진2.jpg", size: 5 * MB },
+  { mediaId: 3, fileName: "영상.mp4", size: 92 * MB },
+];
+
+const initialState = () => withTargets(startUploadProgress([]), TARGETS);
+
+/**
+ * 실제 진행을 흉내 내 바가 차오르는 것을 눈으로 본다.
+ *
+ * 목(MSW)은 즉시 응답해서 진행률 이벤트가 단계적으로 오지 않는다. 그래서 여기서는
+ * 화면이 쓰는 것과 **같은 계산 함수**(`withProgress`·`withUploaded`)에 바이트를 흘려
+ * 채움 애니메이션·자동 사라짐·취소를 확인한다.
+ */
+const UploadSimulation = () => {
+  const [state, setState] = useState<UploadProgressState | null>(initialState);
+  const cursor = useRef({ index: 0, loaded: 0 });
+
+  const isRunning = state !== null;
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      const { index, loaded } = cursor.current;
+      const target = TARGETS[index];
+
+      // 마지막 장까지 끝났다. 부르는 쪽이 바를 치우는 것으로 업로드가 끝난다.
+      if (target === undefined) {
+        setState(null);
+
+        return;
+      }
+
+      const next = loaded + BYTES_PER_TICK;
+
+      if (next >= target.size) {
+        cursor.current = { index: index + 1, loaded: 0 };
+        setState((current) => (current === null ? current : withUploaded(current, target)));
+
+        return;
+      }
+
+      cursor.current = { index, loaded: next };
+      setState((current) =>
+        current === null
+          ? current
+          : withProgress(current, {
+              mediaId: target.mediaId,
+              fileName: target.fileName,
+              loaded: next,
+              total: target.size,
+            }),
+      );
+    }, TICK_MS);
+
+    return () => clearInterval(timer);
+  }, [isRunning]);
+
+  const restart = () => {
+    cursor.current = { index: 0, loaded: 0 };
+    setState(initialState());
+  };
+
+  if (state === null) {
+    return <Button onClick={restart}>다시 올리기</Button>;
+  }
+
+  return <UploadProgressBar {...snapshotOf(state)} onCancel={() => setState(null)} />;
+};
+
+/** 03 · 업로드 진행 — 차오르는 것부터 사라지는 것까지 (취소를 눌러보세요) */
+export const Simulation: Story = {
+  args: {
+    completedCount: 0,
+    totalCount: 0,
+    percent: 0,
+    onCancel: () => {},
+  },
+  render: () => <UploadSimulation />,
+};

--- a/frontend/src/features/upload-media/ui/UploadProgressBar.styles.ts
+++ b/frontend/src/features/upload-media/ui/UploadProgressBar.styles.ts
@@ -1,0 +1,100 @@
+import styled from "@emotion/styled";
+
+import { colors, spacing, typography } from "@/shared/styles/tokens";
+import { Badge } from "@/shared/ui/badge";
+
+/**
+ * 화면 하단에 띄우는 자리. 모달(1000)보다 낮게 둔다 —
+ * 업로드가 끝나고 실패 모달(#74)이 뜨면 그쪽이 위여야 한다.
+ */
+export const Dock = styled.div`
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  /* 아이폰 홈 인디케이터에 바가 물리지 않게 한다. */
+  padding: ${spacing[16]} ${spacing[16]} calc(${spacing[16]} + env(safe-area-inset-bottom));
+  z-index: 900;
+  /* 바 바깥은 갤러리가 그대로 눌려야 한다. */
+  pointer-events: none;
+
+  > * {
+    pointer-events: auto;
+  }
+`;
+
+export const Count = styled.span`
+  flex-shrink: 0;
+  color: ${colors.textStrong};
+
+  ${typography.label2}
+`;
+
+/**
+ * 진행률 알약. 색과 모양은 `Badge` 의 `soft` 변형을 그대로 쓴다 —
+ * 이슈가 정한 `primarySubtle` 배경 + `textAccent` 글자가 곧 그 변형이고,
+ * 채움이 알약 밖으로 새지 않게 하는 `overflow: hidden` 도 거기 딸려 온다 (#73).
+ *
+ * 덮어쓰는 것들은 배지로 안 되는 부분이다. Badge 는 내용만큼만 차지하고 `position` 이 없어서,
+ * 그대로 두면 바를 가로지르지도 채움 띠를 담지도 못한다.
+ * 높이와 글자 크기도 배지 기본값(24px·caption2)이 아니라 디자인에 맞춘 값이다.
+ */
+export const Status = styled(Badge)`
+  position: relative;
+  flex: 1;
+  height: auto;
+  gap: ${spacing[4]};
+  padding: ${spacing[8]} ${spacing[12]};
+
+  ${typography.caption1}
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+/**
+ * 퍼센트만큼 차오르는 띠. 숫자와 같은 값을 보지만 눈으로 먼저 읽힌다.
+ * 너비는 진행률 이벤트마다 바뀌므로 클래스가 아니라 인라인 스타일로 준다.
+ */
+export const Fill = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background: ${colors.primary};
+  opacity: 0.24;
+  transition: width 0.2s ease-out;
+`;
+
+/** 채움 위에 얹는다. 같은 칸을 쓰므로 쌓임 순서를 명시한다. */
+export const StatusText = styled.span`
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: ${spacing[4]};
+`;
+
+export const CancelButton = styled.button`
+  flex-shrink: 0;
+  color: ${colors.textStrong};
+
+  ${typography.label2}
+`;
+
+export const Spinner = styled.span`
+  display: flex;
+
+  svg {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;

--- a/frontend/src/features/upload-media/ui/UploadProgressBar.test.tsx
+++ b/frontend/src/features/upload-media/ui/UploadProgressBar.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { UploadProgressBarProps } from "./UploadProgressBar";
+import { UploadProgressBar } from "./UploadProgressBar";
+
+const renderBar = (props: Partial<UploadProgressBarProps> = {}) =>
+  render(
+    <UploadProgressBar
+      completedCount={0}
+      totalCount={1}
+      percent={0}
+      onCancel={jest.fn()}
+      {...props}
+    />,
+  );
+
+describe("UploadProgressBar", () => {
+  it("몇 장 중 몇 장이 끝났는지 보여준다", () => {
+    renderBar({ completedCount: 20, totalCount: 24 });
+
+    expect(screen.getByText("20 / 24")).toBeInTheDocument();
+  });
+
+  it("퍼센트를 글자와 값 양쪽으로 알린다 — 눈으로도, 보조 기기로도 읽힌다", () => {
+    renderBar({ percent: 62 });
+
+    const progressbar = screen.getByRole("progressbar", { name: "업로드 진행률" });
+
+    expect(progressbar).toHaveTextContent("업로드 중... 62%");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "62");
+  });
+
+  it("장수와 퍼센트는 서로 다른 것을 센다 — 어긋나 보여도 그대로 그린다", () => {
+    // 작은 사진 두 장이 끝나고 큰 영상 한 장이 남았다. 2/3 장이지만 회선으로는 2% 다.
+    renderBar({ completedCount: 2, totalCount: 3, percent: 2 });
+
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveTextContent("업로드 중... 2%");
+  });
+
+  it("취소를 누르면 되묻지 않고 곧바로 전달한다", async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    renderBar({ onCancel });
+
+    await user.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/upload-media/ui/UploadProgressBar.tsx
+++ b/frontend/src/features/upload-media/ui/UploadProgressBar.tsx
@@ -1,0 +1,64 @@
+import { LuLoaderCircle } from "react-icons/lu";
+
+import { FloatingBar } from "@/shared/ui/floating-bar";
+import {
+  CancelButton,
+  Count,
+  Dock,
+  Fill,
+  Spinner,
+  Status,
+  StatusText,
+} from "./UploadProgressBar.styles";
+
+export interface UploadProgressBarProps {
+  /** PUT 이 끝난 장수 */
+  completedCount: number;
+  /** 올리는 중인 전체 장수. 거절된 파일은 빠져 있다 */
+  totalCount: number;
+  /** 0~100. 장수가 아니라 바이트 기준이다 */
+  percent: number;
+  onCancel: () => void;
+}
+
+/**
+ * 업로드가 도는 동안 화면 하단에 떠 있는 바 (#73).
+ *
+ * 상태를 스스로 만들지 않는다 — 띄울지 말지, 몇 퍼센트인지는 전부 부르는 쪽이 정한다.
+ * 업로드가 끝나면 부르는 쪽이 이 컴포넌트를 렌더링하지 않는 것으로 바가 사라진다.
+ */
+export const UploadProgressBar = ({
+  completedCount,
+  totalCount,
+  percent,
+  onCancel,
+}: UploadProgressBarProps) => {
+  return (
+    <Dock>
+      <FloatingBar>
+        <Count>
+          {completedCount} / {totalCount}
+        </Count>
+        <Status
+          variant="soft"
+          role="progressbar"
+          aria-label="업로드 진행률"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={percent}
+        >
+          <Fill style={{ width: `${percent}%` }} />
+          <StatusText>
+            <Spinner>
+              <LuLoaderCircle />
+            </Spinner>
+            업로드 중... {percent}%
+          </StatusText>
+        </Status>
+        <CancelButton type="button" onClick={onCancel}>
+          취소
+        </CancelButton>
+      </FloatingBar>
+    </Dock>
+  );
+};


### PR DESCRIPTION
🚨 브랜치를 main이 아니라 #75에서 땄습니다!

## 작업 내용

업로드가 도는 동안 화면 하단에 진행 바를 띄웁니다. 완료 장수와 진행률을 실시간으로 보여주고, 취소하면 진행 중인 전송을 끊습니다.

설계의 핵심은 **"3/30장" 과 "27%" 가 서로 다른 것을 센다**는 점입니다. 앞은 PUT 이 끝난 파일 수고, 뒤는 지금까지 실제로 회선에 나간 바이트다. 큰 영상 한 장이 남으면 장수는 29/30 인데 퍼센트는 40% 일 수 있습니다. 파일 수로 퍼센트를 세면 3.4MB 사진과 80MB 영상이 같은 한 장이 돼서 바가 영상 구간에서 통째로 멈춥니다.

진행 바가 쓸 부품(계산·훅·컴포넌트)까지가 이 PR 의 범위입니다. **갤러리에서 파일을 골라 실제로 띄우는 연결은 #72 에서 합니.**

## 관련 이슈

Closes #73

## 작업 영역

- [x] Frontend
- [ ] Backend

## 변경 사항

- [x] `uploadFiles` 에 `onStarted` / `onUploaded` 콜백 추가
  - `onStarted` — 발급을 통과한 목록을 **첫 PUT 전에** 한 번 알린다. 거절분이 빠진 뒤라야 분모가 맞는다
  - `onUploaded` — PUT 한 건이 끝날 때마다 알린다. 완료 등록까지 기다리면 마지막에 몰아서 오른다
- [x] `uploadProgress` — 파일 단위로 흩어져 오는 이벤트를 배치 하나의 상태로 합치는 순수 함수들
  - 퍼센트는 **바이트 기준**으로 계산 (완료 조건)
  - 진행률 이벤트는 더하지 않고 **덮어쓴다**. XHR 의 `loaded` 는 누적값이라 더하면 이중 계산되고, 재발급으로 다시 올라가는 파일은 0 부터 다시 쌓여 퍼센트가 뒤로 물러나는 게 맞다
- [x] `useMediaUpload` — 업로드 한 판의 수명과 진행 상태를 들고 있는 훅
  - 발급 왕복을 기다리지 않고 잠정값으로 먼저 띄운 뒤 `onStarted` 로 교정한다. 안 그러면 파일 고른 뒤 왕복 한 번만큼 화면이 비어 있다
  - 취소하면 등록 왕복을 기다리지 않고 바를 즉시 치운다. 이미 올라간 파일은 그대로 등록된다
  - 취소한 판의 뒤늦은 콜백이 사라진 바를 되살리지 않도록 실행 번호로 막았다
- [x] `UploadProgressBar` — 상태를 스스로 만들지 않는 표현 컴포넌트
  - `shared/ui/floating-bar` 의 `FloatingBar` 사용
  - 진행률 알약은 `Badge` 의 `soft` 변형(`primarySubtle` 배경 + `textAccent` 글자)을 그대로 쓴다
  - 실패 모달(#74)이 위로 오도록 `z-index` 를 모달(1000)보다 낮게 뒀다
- [x] 스토리북 스토리 4종 (정적 3 + 진행 재현 1)

## 테스트

- [x] 단위 테스트 작성/통과 — 전체 250개 통과
  - `uploadProgress.test.ts` — 바이트 기준 퍼센트, 거절분 제외, 재발급 시 후퇴, 0 나눗셈, 소수점 버림
  - `useMediaUpload.test.tsx` — 바가 뜨고 사라지는 시점, 취소, 판 겹침 방지, 권한 실패
  - `uploadFiles.test.ts` — `onStarted` 가 첫 PUT 보다 먼저 불리는 것, 실패한 파일은 세지 않는 것
  - `UploadProgressBar.test.tsx` — 장수·퍼센트 표시, `aria-valuenow`, 취소 전달
- [ ] 로컬 동작 확인 — **앱에서는 확인 불가.** 파일 선택 진입점(#72)이 없어 업로드를 시작할 방법이 없다. 스토리북 `Simulation` 스토리로 대체 확인

## 리뷰 요청 사항 (선택)

**1. 선행 PR**

#93 (#75 presigned 업로드 흐름) 위에 쌓인 브랜치입니다. **#93 머지 후에 봐주세요.** 지금 diff 에는 #93 의 코드가 섞여 보입니다.

**2. 진행률은 목으로 확인되지 않습니다**

MSW 는 점진적 진행 이벤트를 못 흘려서 퍼센트가 `0% → 100%` 로 튑니다. 그래서 계산을 순수 함수로 떼어내 테스트로 묶고, 스토리북 `Simulation` 스토리에서 같은 함수에 바이트를 흘려 넣어 눈으로 확인하게 했습니다. 실제 회선에서의 확인은 진입점(#72)이 붙은 뒤에 가능합니다.

**3. 토큰이 없는 값 — `Fill` 의 `opacity: 0.24`**

채움 띠가 `primarySubtle` 배경 위에 얹혀서 `primary` 를 흐리게 깔았는데, 이 값을 뒷받침하는 디자인 토큰이 없습니다. "진행 채움" 색이 토큰에 추가되면 그걸로 바꾸는 게 맞습니다.

**4. 진행률 알약의 크기**

`Badge` 를 쓰되 높이와 글자 크기는 덮어썼습니다. 배지 기본값은 24px·`caption2` 인데 디자인은 36px·`caption1` 이라서요. 색·모양(`radius.full`, `overflow: hidden`)은 `Badge` 에서 그대로 받습니다.