### PR TITLE
feat: 다운로드 API 구현 (단건 다운로드 + zip 압축 요청) - #84

### DIFF
--- a/backend/src/main/java/com/sssok/application/download/CreateDownloadJobResult.java
+++ b/backend/src/main/java/com/sssok/application/download/CreateDownloadJobResult.java
@@ -1,0 +1,18 @@
+package com.sssok.application.download;
+
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.domain.download.DownloadJobStatus;
+
+public record CreateDownloadJobResult(
+    Long jobId,
+    DownloadJobStatus status,
+    int mediaCount,
+    long totalSize,
+    String fileName
+) {
+
+    public static CreateDownloadJobResult from(DownloadJob job) {
+        return new CreateDownloadJobResult(
+            job.getId(), job.getStatus(), job.getMediaCount(), job.getTotalSizeBytes(), job.getFileName());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/CreateDownloadJobService.java
+++ b/backend/src/main/java/com/sssok/application/download/CreateDownloadJobService.java
@@ -1,0 +1,46 @@
+package com.sssok.application.download;
+
+import com.sssok.application.download.exception.DownloadRateLimitedException;
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.domain.file.DownloadFileNames;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.infrastructure.config.DownloadProperties;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class CreateDownloadJobService {
+
+    private static final List<DownloadJobStatus> ACTIVE_STATUSES =
+        List.of(DownloadJobStatus.QUEUED, DownloadJobStatus.RUNNING);
+
+    private final DownloadTargetResolver downloadTargetResolver;
+    private final DownloadJobRepository downloadJobRepository;
+    private final DownloadProperties downloadProperties;
+
+    @Transactional
+    public CreateDownloadJobResult create(Long roomId, Long requesterId, List<Long> mediaIds, Long folderId) {
+        long activeJobCount = downloadJobRepository.countByRequesterIdAndStatusIn(requesterId, ACTIVE_STATUSES);
+        if (activeJobCount >= downloadProperties.maxConcurrentJobsPerRequester()) {
+            throw new DownloadRateLimitedException();
+        }
+
+        List<StoredFile> targets = downloadTargetResolver.resolve(roomId, mediaIds, folderId);
+        int mediaCount = targets.size();
+        long totalSizeBytes = targets.stream().mapToLong(file -> file.getFileSize().bytes()).sum();
+        String fileName = DownloadFileNames.zipNameOf(roomId);
+
+        DownloadJob job = DownloadJob.create(roomId, requesterId, mediaCount, totalSizeBytes, fileName, Instant.now());
+        DownloadJob saved = downloadJobRepository.save(job);
+        downloadJobRepository.saveJobMedia(saved.getId(), targets.stream().map(StoredFile::getId).toList());
+
+        return CreateDownloadJobResult.from(saved);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/DownloadTargetResolver.java
+++ b/backend/src/main/java/com/sssok/application/download/DownloadTargetResolver.java
@@ -1,0 +1,75 @@
+package com.sssok.application.download;
+
+import com.sssok.application.download.exception.InvalidDownloadParamException;
+import com.sssok.application.download.exception.TooManyFilesException;
+import com.sssok.application.folder.exception.FolderNotFoundException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.application.port.out.FolderRepository;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// zip 압축 다운로드(POST /rooms/{roomId}/downloads)의 대상을 정한다.
+// mediaIds/folderId 중 하나만 쓸 수 있고, 둘 다 생략하면 방 전체가 대상이다.
+// 어느 경로든 마지막엔 READY 상태만 남긴다 — PROCESSING/RESERVED/FAILED는 실물이 없거나
+// 아직 압축할 수 없는 상태라 대상에서 빠지고, 그 결과 대상이 하나도 없으면 404로 본다
+// (요청한 id가 전부 없는 경우와, 존재는 하지만 전부 READY가 아닌 경우를 같은 경로로 처리).
+@Component
+@RequiredArgsConstructor
+class DownloadTargetResolver {
+
+    private static final int MAX_MEDIA_IDS = 1000;
+
+    private final FileRepository fileRepository;
+    private final FolderRepository folderRepository;
+    private final FolderMediaRepository folderMediaRepository;
+
+    List<StoredFile> resolve(Long roomId, List<Long> mediaIds, Long folderId) {
+        if (mediaIds != null && folderId != null) {
+            throw new InvalidDownloadParamException();
+        }
+        if (mediaIds != null) {
+            return resolveByMediaIds(roomId, mediaIds);
+        }
+        if (folderId != null) {
+            return resolveByFolderId(roomId, folderId);
+        }
+        return requireReady(fileRepository.findAllByRoomId(roomId));
+    }
+
+    private List<StoredFile> resolveByMediaIds(Long roomId, List<Long> mediaIds) {
+        List<Long> distinctIds = mediaIds.stream().distinct().toList();
+        if (distinctIds.size() > MAX_MEDIA_IDS) {
+            throw new TooManyFilesException(MAX_MEDIA_IDS);
+        }
+
+        // 다른 방 미디어는 존재 자체를 드러내지 않는다 — 대상에서 조용히 빠진다.
+        List<StoredFile> inRoom = fileRepository.findAllByIdIn(distinctIds).stream()
+            .filter(file -> file.getRoomId().equals(roomId))
+            .toList();
+        return requireReady(inRoom);
+    }
+
+    private List<StoredFile> resolveByFolderId(Long roomId, Long folderId) {
+        folderRepository.findById(folderId)
+            .filter(folder -> folder.belongsTo(roomId))
+            .orElseThrow(() -> new FolderNotFoundException(folderId));
+
+        List<Long> mediaIds = folderMediaRepository.findMediaIdsByFolderId(folderId);
+        return requireReady(fileRepository.findAllByIdIn(mediaIds));
+    }
+
+    private List<StoredFile> requireReady(List<StoredFile> files) {
+        List<StoredFile> ready = files.stream()
+            .filter(file -> file.getStatus() == UploadStatus.READY)
+            .toList();
+        if (ready.isEmpty()) {
+            throw new MediaNotFoundException();
+        }
+        return ready;
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/exception/DownloadRateLimitedException.java
+++ b/backend/src/main/java/com/sssok/application/download/exception/DownloadRateLimitedException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.download.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class DownloadRateLimitedException extends SssOkException {
+
+    public DownloadRateLimitedException() {
+        super(ErrorCode.RATE_LIMITED);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/exception/InvalidDownloadParamException.java
+++ b/backend/src/main/java/com/sssok/application/download/exception/InvalidDownloadParamException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.download.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class InvalidDownloadParamException extends SssOkException {
+
+    public InvalidDownloadParamException() {
+        super(ErrorCode.INVALID_PARAM, "다운로드 조건이 올바르지 않습니다");
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/exception/TooManyFilesException.java
+++ b/backend/src/main/java/com/sssok/application/download/exception/TooManyFilesException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.download.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class TooManyFilesException extends SssOkException {
+
+    public TooManyFilesException(int maxCount) {
+        super(ErrorCode.TOO_MANY_FILES, maxCount);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/GetMediaDownloadUrlService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetMediaDownloadUrlService.java
@@ -1,0 +1,40 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.MediaNotReadyException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.file.DownloadFileNames;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import com.sssok.infrastructure.config.DownloadProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class GetMediaDownloadUrlService {
+
+    private final FileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+    private final DownloadProperties downloadProperties;
+
+    public String getUrl(Long roomId, Long mediaId) {
+        StoredFile file = fileRepository.findById(mediaId)
+            .filter(found -> found.getRoomId().equals(roomId))
+            .orElseThrow(MediaNotFoundException::new);
+
+        if (file.getStatus() == UploadStatus.PROCESSING) {
+            throw new MediaNotReadyException();
+        }
+        // RESERVED/FAILED는 실물이 스토리지에 없는 상태라, 존재하지 않는 것과 동일하게 취급한다.
+        if (file.getStatus() != UploadStatus.READY) {
+            throw new MediaNotFoundException();
+        }
+
+        String contentDisposition = DownloadFileNames.contentDispositionOf(file.getOriginalFileName());
+        return fileStoragePort.presignGet(file.getStorageKey(), contentDisposition,
+            file.getMediaType().contentType(), downloadProperties.presignedGetTtl());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/exception/MediaNotReadyException.java
+++ b/backend/src/main/java/com/sssok/application/media/exception/MediaNotReadyException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.media.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class MediaNotReadyException extends SssOkException {
+
+    public MediaNotReadyException() {
+        super(ErrorCode.MEDIA_NOT_READY);
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/DownloadProperties.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/DownloadProperties.java
@@ -1,0 +1,8 @@
+package com.sssok.infrastructure.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "download")
+public record DownloadProperties(Duration presignedGetTtl, int maxConcurrentJobsPerRequester) {
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
@@ -42,6 +42,8 @@ public class WebConfig implements WebMvcConfigurer {
             .addPathPatterns(
                 API_PREFIX + "/rooms/*/folders/**",
                 API_PREFIX + "/rooms/*/media",
-                API_PREFIX + "/rooms/*/media/**");
+                API_PREFIX + "/rooms/*/media/**",
+                API_PREFIX + "/rooms/*/downloads",
+                API_PREFIX + "/rooms/*/downloads/**");
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/download/CreateDownloadJobRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/download/CreateDownloadJobRequest.java
@@ -1,0 +1,10 @@
+package com.sssok.presentation.api.download;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record CreateDownloadJobRequest(
+    @Schema(description = "압축할 미디어 ID 목록 (최대 1000개). folderId와 함께 쓸 수 없다") List<Long> mediaIds,
+    @Schema(description = "폴더 전체를 압축할 때 사용. mediaIds와 함께 쓸 수 없다") Long folderId
+) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/download/CreateDownloadJobResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/download/CreateDownloadJobResponse.java
@@ -1,0 +1,19 @@
+package com.sssok.presentation.api.download;
+
+import com.sssok.application.download.CreateDownloadJobResult;
+import com.sssok.domain.download.DownloadJobStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateDownloadJobResponse(
+    @Schema(description = "압축 작업 ID") Long jobId,
+    @Schema(description = "QUEUED / RUNNING / READY / FAILED / EXPIRED") DownloadJobStatus status,
+    @Schema(description = "압축 대상 개수") int mediaCount,
+    @Schema(description = "압축 대상 원본 총 바이트") long totalSize,
+    @Schema(description = "생성될 zip 파일명") String fileName
+) {
+
+    public static CreateDownloadJobResponse from(CreateDownloadJobResult result) {
+        return new CreateDownloadJobResponse(
+            result.jobId(), result.status(), result.mediaCount(), result.totalSize(), result.fileName());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/download/DownloadController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/download/DownloadController.java
@@ -1,0 +1,45 @@
+package com.sssok.presentation.api.download;
+
+import com.sssok.application.download.CreateDownloadJobResult;
+import com.sssok.application.download.CreateDownloadJobService;
+import com.sssok.presentation.api.common.ApiResponse;
+import com.sssok.presentation.auth.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "다운로드", description = "선택한 미디어를 zip으로 압축해 내려받는 비동기 작업")
+@RestController
+@RequestMapping("/rooms/{roomId}/downloads")
+@RequiredArgsConstructor
+public class DownloadController {
+
+    private final CreateDownloadJobService createDownloadJobService;
+
+    @Operation(
+        summary = "zip 다운로드 요청",
+        description = "선택한 미디어들을 하나의 zip으로 압축하는 작업을 생성한다. 즉시 완료되지 않고 jobId를 돌려준다. "
+            + "mediaIds와 folderId를 동시에 보내면 400, mediaIds가 1000개를 초과하면 400이 난다. "
+            + "둘 다 생략하면 방 전체 미디어가 대상이다. 처리 중인 미디어는 압축 대상과 mediaCount에서 제외되며, "
+            + "그 결과 대상이 하나도 없으면 404가 난다. 동시 진행 중인 압축 잡 수가 많으면 429가 난다."
+    )
+    @PostMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResponse<CreateDownloadJobResponse> create(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @RequestBody CreateDownloadJobRequest request
+    ) {
+        CreateDownloadJobResult result =
+            createDownloadJobService.create(roomId, memberId, request.mediaIds(), request.folderId());
+        return ApiResponse.of(CreateDownloadJobResponse.from(result));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaDownloadController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaDownloadController.java
@@ -1,0 +1,41 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.GetMediaDownloadUrlService;
+import com.sssok.presentation.auth.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "미디어 다운로드", description = "업로드 당시 파일명 그대로 원본을 내려받는다. 서버는 바이트를 프록시하지 않고 스토리지 서명 URL로 리다이렉트한다.")
+@RestController
+@RequestMapping("/rooms/{roomId}/media")
+@RequiredArgsConstructor
+public class MediaDownloadController {
+
+    private final GetMediaDownloadUrlService getMediaDownloadUrlService;
+
+    @Operation(
+        summary = "단건 다운로드",
+        description = "미디어 원본을 업로드 당시 파일명 그대로 내려받는다. 유효기간 5분짜리 스토리지 서명 URL로 302 "
+            + "리다이렉트하며, 바디는 없다. 서명 URL의 Content-Disposition에는 ASCII 폴백(filename)과 RFC 5987 "
+            + "UTF-8 인코딩(filename*)이 함께 실려 있어 한글 파일명도 깨지지 않는다. 없는 mediaId, 삭제됨, 다른 방의 "
+            + "미디어면 404가 나고, 아직 처리 중인 미디어면 409가 난다."
+    )
+    @GetMapping("/{mediaId}/download")
+    public ResponseEntity<Void> download(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "다운로드할 미디어 ID") @PathVariable Long mediaId
+    ) {
+        String url = getMediaDownloadUrlService.getUrl(roomId, mediaId);
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(url)).build();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -56,6 +56,12 @@ media:
   # GIF는 애니메이션이 깨지므로 리사이즈/압축 대상에서 제외한다
   skip-formats: gif
 
+download:
+  # 단건 다운로드 리다이렉트 대상 서명 URL의 유효기간
+  presigned-get-ttl: 5m
+  # 동일 멤버가 동시에 진행(QUEUED/RUNNING) 중일 수 있는 압축 잡의 최대 개수. 넘으면 429.
+  max-concurrent-jobs-per-requester: 3
+
 springdoc:
   swagger-ui:
     operations-sorter: method

--- a/backend/src/test/java/com/sssok/application/download/CreateDownloadJobServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/download/CreateDownloadJobServiceTest.java
@@ -1,0 +1,89 @@
+package com.sssok.application.download;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.download.exception.DownloadRateLimitedException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.infrastructure.config.DownloadProperties;
+import com.sssok.support.PostgresContainerSupport;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CreateDownloadJobServiceTest extends PostgresContainerSupport {
+
+    @Autowired
+    CreateDownloadJobService createDownloadJobService;
+
+    @Autowired
+    DownloadProperties downloadProperties;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    private void media(long id, long roomId, String status) {
+        jdbcTemplate.update("""
+            INSERT INTO stored_file
+                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes,
+                 storage_key, status, created_at, updated_at, reserved_at, retry_count)
+            VALUES (?, ?, 1, 'test.jpg', 'JPEG', 1024, ?, ?, now(), now(), now(), 0)
+            """, id, roomId, "test-key-" + id, status);
+    }
+
+    private List<Long> jobMediaIds(Long jobId) {
+        return jdbcTemplate.queryForList(
+            "select media_id from download_job_media where download_job_id = ?", Long.class, jobId);
+    }
+
+    @Test
+    void QUEUED_상태의_잡을_만들고_대상을_함께_저장한다() {
+        media(1L, 1L, "READY");
+        media(2L, 1L, "READY");
+
+        CreateDownloadJobResult result = createDownloadJobService.create(1L, 100L, List.of(1L, 2L), null);
+
+        assertThat(result.status()).isEqualTo(DownloadJobStatus.QUEUED);
+        assertThat(result.mediaCount()).isEqualTo(2);
+        assertThat(result.totalSize()).isEqualTo(2048L);
+        assertThat(result.fileName()).isEqualTo("sssOK_1.zip");
+        assertThat(jobMediaIds(result.jobId())).containsExactlyInAnyOrder(1L, 2L);
+    }
+
+    @Test
+    void 대상이_없으면_리졸버의_예외가_그대로_전파된다() {
+        assertThatThrownBy(() -> createDownloadJobService.create(1L, 100L, List.of(999L), null))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 동시_진행_중인_잡이_상한에_도달하면_429() {
+        media(1L, 1L, "READY");
+        int maxJobs = downloadProperties.maxConcurrentJobsPerRequester();
+        for (int i = 0; i < maxJobs; i++) {
+            createDownloadJobService.create(1L, 100L, List.of(1L), null);
+        }
+
+        assertThatThrownBy(() -> createDownloadJobService.create(1L, 100L, List.of(1L), null))
+            .isInstanceOf(DownloadRateLimitedException.class);
+    }
+
+    @Test
+    void 다른_요청자의_진행_중인_잡은_카운트에_영향을_주지_않는다() {
+        media(1L, 1L, "READY");
+        int maxJobs = downloadProperties.maxConcurrentJobsPerRequester();
+        for (int i = 0; i < maxJobs; i++) {
+            createDownloadJobService.create(1L, 100L, List.of(1L), null);
+        }
+
+        CreateDownloadJobResult result = createDownloadJobService.create(1L, 200L, List.of(1L), null);
+
+        assertThat(result.status()).isEqualTo(DownloadJobStatus.QUEUED);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/download/DownloadTargetResolverTest.java
+++ b/backend/src/test/java/com/sssok/application/download/DownloadTargetResolverTest.java
@@ -1,0 +1,160 @@
+package com.sssok.application.download;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.download.exception.InvalidDownloadParamException;
+import com.sssok.application.download.exception.TooManyFilesException;
+import com.sssok.application.folder.CreateFolderService;
+import com.sssok.application.folder.exception.FolderNotFoundException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.folder.Folder;
+import com.sssok.support.PostgresContainerSupport;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class DownloadTargetResolverTest extends PostgresContainerSupport {
+
+    @Autowired
+    DownloadTargetResolver downloadTargetResolver;
+
+    @Autowired
+    CreateFolderService createFolderService;
+
+    @Autowired
+    FolderMediaRepository folderMediaRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    private void media(long id, long roomId, String status) {
+        jdbcTemplate.update("""
+            INSERT INTO stored_file
+                (id, room_id, uploader_id, original_file_name, media_type, file_size_bytes,
+                 storage_key, status, created_at, updated_at, reserved_at, retry_count)
+            VALUES (?, ?, 1, 'test.jpg', 'JPEG', 1024, ?, ?, now(), now(), now(), 0)
+            """, id, roomId, "test-key-" + id, status);
+    }
+
+    @Nested
+    class mediaIds_모드 {
+
+        @Test
+        void 요청한_미디어를_그대로_돌려준다() {
+            media(1L, 1L, "READY");
+            media(2L, 1L, "READY");
+
+            List<StoredFile> resolved = downloadTargetResolver.resolve(1L, List.of(1L, 2L), null);
+
+            assertThat(resolved).extracting(StoredFile::getId).containsExactlyInAnyOrder(1L, 2L);
+        }
+
+        @Test
+        void 다른_방_미디어는_조용히_빠진다() {
+            media(1L, 1L, "READY");
+            media(2L, 2L, "READY");
+
+            List<StoredFile> resolved = downloadTargetResolver.resolve(1L, List.of(1L, 2L), null);
+
+            assertThat(resolved).extracting(StoredFile::getId).containsExactly(1L);
+        }
+
+        @Test
+        void READY가_아닌_미디어는_대상에서_빠진다() {
+            media(1L, 1L, "READY");
+            media(2L, 1L, "PROCESSING");
+
+            List<StoredFile> resolved = downloadTargetResolver.resolve(1L, List.of(1L, 2L), null);
+
+            assertThat(resolved).extracting(StoredFile::getId).containsExactly(1L);
+        }
+
+        @Test
+        void 요청한_id가_전부_존재하지만_전부_READY가_아니면_404() {
+            media(1L, 1L, "PROCESSING");
+
+            assertThatThrownBy(() -> downloadTargetResolver.resolve(1L, List.of(1L), null))
+                .isInstanceOf(MediaNotFoundException.class);
+        }
+
+        @Test
+        void 요청한_id가_전부_존재하지_않으면_404() {
+            assertThatThrownBy(() -> downloadTargetResolver.resolve(1L, List.of(999L), null))
+                .isInstanceOf(MediaNotFoundException.class);
+        }
+
+        @Test
+        void 개수가_상한을_초과하면_예외() {
+            List<Long> tooMany = LongStream.rangeClosed(1, 1001).boxed().toList();
+
+            assertThatThrownBy(() -> downloadTargetResolver.resolve(1L, tooMany, null))
+                .isInstanceOf(TooManyFilesException.class);
+        }
+    }
+
+    @Nested
+    class folderId_모드 {
+
+        @Test
+        void 폴더에_담긴_미디어_중_READY만_돌려준다() {
+            Folder folder = createFolderService.create(1L, "맛집");
+            media(1L, 1L, "READY");
+            media(2L, 1L, "PROCESSING");
+            folderMediaRepository.attachToFolder(folder.getId(), List.of(1L, 2L));
+
+            List<StoredFile> resolved = downloadTargetResolver.resolve(1L, null, folder.getId());
+
+            assertThat(resolved).extracting(StoredFile::getId).containsExactly(1L);
+        }
+
+        @Test
+        void 없는_폴더면_예외() {
+            assertThatThrownBy(() -> downloadTargetResolver.resolve(1L, null, -1L))
+                .isInstanceOf(FolderNotFoundException.class);
+        }
+
+        @Test
+        void 다른_방_소속_폴더는_없는_폴더로_취급한다() {
+            Folder folder = createFolderService.create(2L, "맛집");
+
+            assertThatThrownBy(() -> downloadTargetResolver.resolve(1L, null, folder.getId()))
+                .isInstanceOf(FolderNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class 둘_다_생략하면_방_전체 {
+
+        @Test
+        void 방의_READY_미디어_전체를_돌려준다() {
+            media(1L, 1L, "READY");
+            media(2L, 1L, "READY");
+            media(3L, 1L, "PROCESSING");
+            media(4L, 2L, "READY");
+
+            List<StoredFile> resolved = downloadTargetResolver.resolve(1L, null, null);
+
+            assertThat(resolved).extracting(StoredFile::getId).containsExactlyInAnyOrder(1L, 2L);
+        }
+    }
+
+    @Nested
+    class 잘못된_조합 {
+
+        @Test
+        void mediaIds와_folderId를_동시에_주면_예외() {
+            assertThatThrownBy(() -> downloadTargetResolver.resolve(1L, List.of(1L), 1L))
+                .isInstanceOf(InvalidDownloadParamException.class);
+        }
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/GetMediaDownloadUrlServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GetMediaDownloadUrlServiceTest.java
@@ -1,0 +1,126 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.MediaNotReadyException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// Repository + Service 통합 테스트 (H2). 스토리지 서명은 목으로 둔다.
+@SpringBootTest
+@ActiveProfiles("test")
+class GetMediaDownloadUrlServiceTest {
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long UPLOADER_ID = 100L;
+    private static final String PRESIGNED = "https://storage.example.com/signed";
+
+    @Autowired
+    GetMediaDownloadUrlService getMediaDownloadUrlService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    @BeforeEach
+    void setUp() {
+        given(fileStoragePort.presignGet(any(), anyString(), anyString(), any(Duration.class)))
+            .willReturn(PRESIGNED);
+    }
+
+    private StoredFile save(Long roomId, UploadStatus status) {
+        StoredFile file = StoredFile.reserve(
+            roomId, UPLOADER_ID, "사진.jpg", "image/jpeg", new FileSize(1024), Instant.now());
+        switch (status) {
+            case PROCESSING -> file.startProcessing();
+            case READY -> {
+                file.startProcessing();
+                file.markReady();
+            }
+            case FAILED -> file.failUpload();
+            default -> {
+            }
+        }
+        return fileRepository.save(file);
+    }
+
+    @Test
+    void READY_상태면_발급받은_서명_URL을_그대로_반환한다() {
+        StoredFile file = save(ROOM_ID, UploadStatus.READY);
+
+        String url = getMediaDownloadUrlService.getUrl(ROOM_ID, file.getId());
+
+        assertThat(url).isEqualTo(PRESIGNED);
+    }
+
+    @Test
+    void 원본_파일명과_MIME으로_서명을_요청한다() {
+        StoredFile file = save(ROOM_ID, UploadStatus.READY);
+
+        getMediaDownloadUrlService.getUrl(ROOM_ID, file.getId());
+
+        verify(fileStoragePort).presignGet(
+            eq(file.getStorageKey()),
+            eq("attachment; filename=\"download.jpg\"; filename*=UTF-8''%EC%82%AC%EC%A7%84.jpg"),
+            eq("image/jpeg"),
+            any(Duration.class));
+    }
+
+    @Test
+    void PROCESSING_상태면_409() {
+        StoredFile file = save(ROOM_ID, UploadStatus.PROCESSING);
+
+        assertThatThrownBy(() -> getMediaDownloadUrlService.getUrl(ROOM_ID, file.getId()))
+            .isInstanceOf(MediaNotReadyException.class);
+    }
+
+    @Test
+    void RESERVED_상태면_404() {
+        StoredFile file = save(ROOM_ID, UploadStatus.RESERVED);
+
+        assertThatThrownBy(() -> getMediaDownloadUrlService.getUrl(ROOM_ID, file.getId()))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void FAILED_상태면_404() {
+        StoredFile file = save(ROOM_ID, UploadStatus.FAILED);
+
+        assertThatThrownBy(() -> getMediaDownloadUrlService.getUrl(ROOM_ID, file.getId()))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 존재하지_않는_미디어면_404() {
+        assertThatThrownBy(() -> getMediaDownloadUrlService.getUrl(ROOM_ID, 999L))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 다른_방_소속_미디어면_404() {
+        StoredFile file = save(2L, UploadStatus.READY);
+
+        assertThatThrownBy(() -> getMediaDownloadUrlService.getUrl(ROOM_ID, file.getId()))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/download/DownloadControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/download/DownloadControllerTest.java
@@ -1,0 +1,145 @@
+package com.sssok.presentation.api.download;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.download.CreateDownloadJobResult;
+import com.sssok.application.download.CreateDownloadJobService;
+import com.sssok.application.download.exception.DownloadRateLimitedException;
+import com.sssok.application.download.exception.InvalidDownloadParamException;
+import com.sssok.application.download.exception.TooManyFilesException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.port.out.RoomMemberRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomMember;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(DownloadController.class)
+class DownloadControllerTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long MEMBER_ID = 2L;
+    private static final String BEARER = "Bearer valid-token";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    CreateDownloadJobService createDownloadJobService;
+
+    @MockitoBean
+    TokenProvider tokenProvider;
+
+    @MockitoBean
+    RoomRepository roomRepository;
+
+    @MockitoBean
+    RoomMemberRepository roomMemberRepository;
+
+    @BeforeEach
+    void setUp() {
+        given(tokenProvider.parse("valid-token")).willReturn(MEMBER_ID);
+        given(roomRepository.findById(ROOM_ID)).willReturn(Optional.of(activeRoom()));
+        given(roomMemberRepository.findByRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+            .willReturn(Optional.of(RoomMember.reconstruct(1L, ROOM_ID, MEMBER_ID, Instant.now())));
+    }
+
+    private Room activeRoom() {
+        return Room.reconstruct(ROOM_ID, null, RoomCode.generate(new SecureRandom()),
+            new RoomName("우테코 회식"), RoomStatus.initial(),
+            new RoomExpiration(Instant.now().plusSeconds(3600)), UploadPolicy.ANYONE,
+            1L, Instant.now(), null);
+    }
+
+    private ResultActions createJob(String body) throws Exception {
+        return mockMvc.perform(post("/api/v1/rooms/{roomId}/downloads", ROOM_ID)
+            .header("Authorization", BEARER)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body));
+    }
+
+    @Test
+    void 압축_요청하면_202와_잡_정보를_반환한다() throws Exception {
+        CreateDownloadJobResult result =
+            new CreateDownloadJobResult(1L, DownloadJobStatus.QUEUED, 3, 741843619L, "sssOK_10.zip");
+        given(createDownloadJobService.create(anyLong(), anyLong(), any(), any())).willReturn(result);
+
+        createJob("{\"mediaIds\":[5012,5011,5008]}")
+            .andExpect(status().isAccepted())
+            .andExpect(jsonPath("$.data.jobId").value(1))
+            .andExpect(jsonPath("$.data.status").value("QUEUED"))
+            .andExpect(jsonPath("$.data.mediaCount").value(3))
+            .andExpect(jsonPath("$.data.totalSize").value(741843619))
+            .andExpect(jsonPath("$.data.fileName").value("sssOK_10.zip"));
+    }
+
+    @Test
+    void mediaIds와_folderId를_함께_보내면_400() throws Exception {
+        given(createDownloadJobService.create(anyLong(), anyLong(), any(), any()))
+            .willThrow(new InvalidDownloadParamException());
+
+        createJob("{\"mediaIds\":[1],\"folderId\":2}")
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_PARAM"));
+    }
+
+    @Test
+    void 개수가_상한을_초과하면_400() throws Exception {
+        given(createDownloadJobService.create(anyLong(), anyLong(), any(), any()))
+            .willThrow(new TooManyFilesException(1000));
+
+        createJob("{\"mediaIds\":[1]}")
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("TOO_MANY_FILES"));
+    }
+
+    @Test
+    void 대상_미디어가_없으면_404() throws Exception {
+        given(createDownloadJobService.create(anyLong(), anyLong(), any(), any()))
+            .willThrow(new MediaNotFoundException());
+
+        createJob("{\"mediaIds\":[999]}")
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
+    }
+
+    @Test
+    void 동시_진행_중인_잡이_많으면_429() throws Exception {
+        given(createDownloadJobService.create(anyLong(), anyLong(), any(), any()))
+            .willThrow(new DownloadRateLimitedException());
+
+        createJob("{\"mediaIds\":[1]}")
+            .andExpect(status().isTooManyRequests())
+            .andExpect(jsonPath("$.code").value("RATE_LIMITED"));
+    }
+
+    @Test
+    void 인증_없이_요청하면_401() throws Exception {
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/downloads", ROOM_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[1]}"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaDownloadControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaDownloadControllerTest.java
@@ -1,0 +1,112 @@
+package com.sssok.presentation.api.media;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.media.GetMediaDownloadUrlService;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.MediaNotReadyException;
+import com.sssok.application.port.out.RoomMemberRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomMember;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MediaDownloadController.class)
+class MediaDownloadControllerTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long MEMBER_ID = 2L;
+    private static final Long MEDIA_ID = 5012L;
+    private static final String BEARER = "Bearer valid-token";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    GetMediaDownloadUrlService getMediaDownloadUrlService;
+
+    @MockitoBean
+    TokenProvider tokenProvider;
+
+    @MockitoBean
+    RoomRepository roomRepository;
+
+    @MockitoBean
+    RoomMemberRepository roomMemberRepository;
+
+    @BeforeEach
+    void setUp() {
+        given(tokenProvider.parse("valid-token")).willReturn(MEMBER_ID);
+        given(roomRepository.findById(ROOM_ID)).willReturn(Optional.of(activeRoom()));
+        given(roomMemberRepository.findByRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+            .willReturn(Optional.of(RoomMember.reconstruct(1L, ROOM_ID, MEMBER_ID, Instant.now())));
+    }
+
+    private Room activeRoom() {
+        return Room.reconstruct(ROOM_ID, null, RoomCode.generate(new SecureRandom()),
+            new RoomName("우테코 회식"), RoomStatus.initial(),
+            new RoomExpiration(Instant.now().plusSeconds(3600)), UploadPolicy.ANYONE,
+            1L, Instant.now(), null);
+    }
+
+    private ResultActions download() throws Exception {
+        return mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}/download", ROOM_ID, MEDIA_ID)
+            .header("Authorization", BEARER));
+    }
+
+    @Test
+    void 다운로드하면_302와_Location_헤더를_반환한다() throws Exception {
+        given(getMediaDownloadUrlService.getUrl(anyLong(), anyLong()))
+            .willReturn("https://storage.example.com/signed");
+
+        download()
+            .andExpect(status().isFound())
+            .andExpect(header().string("Location", "https://storage.example.com/signed"));
+    }
+
+    @Test
+    void 없는_미디어면_404() throws Exception {
+        given(getMediaDownloadUrlService.getUrl(anyLong(), anyLong()))
+            .willThrow(new MediaNotFoundException());
+
+        download()
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
+    }
+
+    @Test
+    void 처리중인_미디어면_409() throws Exception {
+        given(getMediaDownloadUrlService.getUrl(anyLong(), anyLong()))
+            .willThrow(new MediaNotReadyException());
+
+        download()
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("MEDIA_NOT_READY"));
+    }
+
+    @Test
+    void 인증_없이_요청하면_401() throws Exception {
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}/download", ROOM_ID, MEDIA_ID))
+            .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 작업 내용

이슈 #84의 3개 엔드포인트 중 2개 — **단건 미디어 다운로드**(302 리다이렉트)와 **zip 압축 다운로드 요청**(202, 잡 생성까지)을 구현했다. 앞선 인프라 PR 위에서 이어서 작업했다.

### 전체 흐름 — 단건 다운로드

```mermaid
sequenceDiagram
    participant Client
    participant Controller as MediaDownloadController
    participant Service as GetMediaDownloadUrlService
    participant FileRepo as FileRepository
    participant Storage as FileStoragePort (R2)

    Client->>Controller: GET /rooms/{roomId}/media/{mediaId}/download
    Controller->>Service: getUrl(roomId, mediaId)
    Service->>FileRepo: findById(mediaId)
    Note over Service: 다른 방 / RESERVED / FAILED → 404<br/>PROCESSING → 409
    Service->>Storage: presignGet(storageKey, Content-Disposition, ...)
    Storage-->>Service: 서명 URL (5분)
    Service-->>Controller: url
    Controller-->>Client: 302 Location: url
```

### 전체 흐름 — zip 압축 다운로드 요청

```mermaid
sequenceDiagram
    participant Client
    participant Controller as DownloadController
    participant Service as CreateDownloadJobService
    participant JobRepo as DownloadJobRepository
    participant Resolver as DownloadTargetResolver
    participant FileRepo as FileRepository / FolderMediaRepository

    Client->>Controller: POST /rooms/{roomId}/downloads
    Controller->>Service: create(roomId, memberId, mediaIds, folderId)
    Service->>JobRepo: countByRequesterIdAndStatusIn (동시 진행 잡 수)
    Note over Service: 상한 초과 → 429
    Service->>Resolver: resolve(roomId, mediaIds, folderId)
    Resolver->>FileRepo: findAllByIdIn / findAllByRoomId / findMediaIdsByFolderId
    Note over Resolver: PROCESSING 등 비-READY는 제외<br/>대상이 비면 404, 개수 초과 400
    Service->>JobRepo: save(QUEUED) + saveJobMedia(대상 id 확정)
    Service-->>Controller: jobId, status, mediaCount, totalSize, fileName
    Controller-->>Client: 202 Accepted
```

## 관련 이슈

이슈 #84의 일부. 비동기 압축 워커 + 상태 폴링(엔드포인트 3)은 다음 PR에서 이어서 하고, 거기서 `Closes #84`를 건다.

## 작업 영역

- [ ] Frontend
- [x] Backend

## 변경 사항

### 1. 압축 대상 리졸버 — `DownloadTargetResolver`
`mediaIds`/`folderId`/방 전체 중 어느 경로로 요청이 와도 결국 **READY 상태의 미디어만** 대상으로 남긴다.
- `mediaIds`와 `folderId`를 동시에 보내면 400, `mediaIds`가 1000개를 넘으면 400.
- `mediaIds` 모드에서는 다른 방 소속 미디어는 존재 자체를 드러내지 않고 조용히 제외한다.
- 최종적으로 READY가 아닌 것(PROCESSING·RESERVED·FAILED)은 전부 빠지고, 그 결과 대상이 하나도 없으면 404 — "요청한 id가 전부 없는 경우"와 "존재는 하지만 전부 READY가 아닌 경우"를 같은 경로로 처리한다.

### 2. zip 압축 다운로드 요청 서비스/API — `CreateDownloadJobService`, `DownloadController`
- 동일 요청자의 동시 진행 중(QUEUED/RUNNING) 잡 수가 설정값(`download.max-concurrent-jobs-per-requester`, 기본 3)을 넘으면 429.
- 리졸버로 확정한 대상의 `mediaCount`/`totalSize`를 계산해 **잡 생성 시점에 확정**하고, 대상 media id를 `download_job_media`에 그대로 저장한다.
- `POST /rooms/{roomId}/downloads`가 202로 `jobId`/`status`/`mediaCount`/`totalSize`/`fileName`을 반환한다.
- `WebConfig`에 `/rooms/*/downloads`, `/rooms/*/downloads/**` 경로를 `RoomMembershipInterceptor` 대상으로 추가해, 방 참여자 검증이 적용되도록 했다.

### 3. 단건 미디어 다운로드 서비스/API — `GetMediaDownloadUrlService`, `MediaDownloadController`
- 미디어가 없거나, 다른 방 소속이거나, RESERVED/FAILED 상태면(실물이 없는 상태) 404. PROCESSING이면 409.
- READY면 원본 파일명 기반 Content-Disposition과 원본 MIME 타입으로 5분짜리 다운로드 서명 URL을 발급해 302로 리다이렉트한다.
- `GET /rooms/{roomId}/media/{mediaId}/download`가 이 코드베이스에서 `ApiResponse<T>` 래퍼를 안 쓰는 첫 컨트롤러 메서드다 — 302 리다이렉트는 JSON 바디가 없어 `ResponseEntity<Void>`를 직접 썼다.

## 테스트

- [x] 단위 테스트 작성/통과
- [ ] 로컬 동작 확인

`DownloadTargetResolverTest`(11), `CreateDownloadJobServiceTest`(4), `DownloadControllerTest`(6), `GetMediaDownloadUrlServiceTest`(7), `MediaDownloadControllerTest`(4)를 추가했고 전부 통과했다. 전체 백엔드 테스트 스위트(712개)도 함께 돌려 기존 기능 회귀가 없는 것을 확인했다. Swagger UI로 두 엔드포인트를 직접 호출하는 수동 확인은 아직 안 했다.

## 리뷰 요청 사항 (선택)

- `mediaIds`가 전부 존재하지만 전부 비-READY인 경우(예: 전부 PROCESSING)를 `mediaCount: 0`인 빈 잡이 아니라 404로 처리했다 — 이슈 문서에 명시되지 않은 케이스라 이렇게 정했다.
- 이 PR도 base가 `main`이 아니라 앞선 인프라 PR 브랜치다(스택 구조).
