### PR TITLE
feat: zip 다운로드 상태 조회 API 구현 - #84

### DIFF
--- a/backend/src/main/java/com/sssok/application/download/GetDownloadJobStatusResult.java
+++ b/backend/src/main/java/com/sssok/application/download/GetDownloadJobStatusResult.java
@@ -1,0 +1,16 @@
+package com.sssok.application.download;
+
+import com.sssok.domain.download.DownloadJobStatus;
+import java.time.Instant;
+
+public record GetDownloadJobStatusResult(
+    Long jobId,
+    DownloadJobStatus status,
+    int progress,
+    int mediaCount,
+    String fileName,
+    String downloadUrl,
+    Instant expiresAt,
+    String failureReason
+) {
+}

--- a/backend/src/main/java/com/sssok/application/download/GetDownloadJobStatusService.java
+++ b/backend/src/main/java/com/sssok/application/download/GetDownloadJobStatusService.java
@@ -1,0 +1,57 @@
+package com.sssok.application.download;
+
+import com.sssok.application.download.exception.DownloadExpiredException;
+import com.sssok.application.download.exception.DownloadForbiddenException;
+import com.sssok.application.download.exception.DownloadNotFoundException;
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.domain.file.DownloadFileNames;
+import com.sssok.infrastructure.config.DownloadProperties;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class GetDownloadJobStatusService {
+
+    private static final String ZIP_CONTENT_TYPE = "application/zip";
+
+    private final DownloadJobRepository downloadJobRepository;
+    private final FileStoragePort fileStoragePort;
+    private final DownloadProperties downloadProperties;
+
+    public GetDownloadJobStatusResult getStatus(Long jobId, Long requesterId) {
+        DownloadJob job = downloadJobRepository.findById(jobId)
+            .orElseThrow(DownloadNotFoundException::new);
+
+        if (!job.isRequestedBy(requesterId)) {
+            throw new DownloadForbiddenException();
+        }
+        if (job.isExpired(downloadProperties.retention(), Instant.now())) {
+            throw new DownloadExpiredException();
+        }
+
+        String downloadUrl = null;
+        Instant expiresAt = null;
+        if (job.getStatus() == DownloadJobStatus.READY) {
+            expiresAt = job.getReadyAt().plus(downloadProperties.retention());
+            downloadUrl = presignZipUrl(job, expiresAt);
+        }
+
+        return new GetDownloadJobStatusResult(job.getId(), job.getStatus(), job.getProgress(),
+            job.getMediaCount(), job.getFileName(), downloadUrl, expiresAt, job.getFailureReason());
+    }
+
+    // 저장된 URL을 재사용하지 않고 조회할 때마다 다시 서명한다 — presign 자체의 유효기간이
+    // 보관 기간(retention)보다 먼저 끝나버리는 상황을 막기 위해, 남은 보관 시간만큼만 서명한다.
+    private String presignZipUrl(DownloadJob job, Instant expiresAt) {
+        String contentDisposition = DownloadFileNames.contentDispositionOf(job.getFileName());
+        Duration remaining = Duration.between(Instant.now(), expiresAt);
+        return fileStoragePort.presignGet(job.getZipStorageKey(), contentDisposition, ZIP_CONTENT_TYPE, remaining);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/exception/DownloadExpiredException.java
+++ b/backend/src/main/java/com/sssok/application/download/exception/DownloadExpiredException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.download.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class DownloadExpiredException extends SssOkException {
+
+    public DownloadExpiredException() {
+        super(ErrorCode.DOWNLOAD_EXPIRED);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/exception/DownloadForbiddenException.java
+++ b/backend/src/main/java/com/sssok/application/download/exception/DownloadForbiddenException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.download.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class DownloadForbiddenException extends SssOkException {
+
+    public DownloadForbiddenException() {
+        super(ErrorCode.DOWNLOAD_FORBIDDEN);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/exception/DownloadNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/download/exception/DownloadNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.download.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class DownloadNotFoundException extends SssOkException {
+
+    public DownloadNotFoundException() {
+        super(ErrorCode.DOWNLOAD_NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -35,12 +35,14 @@ public enum ErrorCode {
     NOT_ROOM_MEMBER(403, "입장한 방에서만 이용할 수 있습니다"),
     UPLOAD_NOT_ALLOWED(403, "방장만 업로드할 수 있는 방입니다"),
     MEDIA_FORBIDDEN(403, "본인이 요청한 업로드가 아닙니다"),
+    DOWNLOAD_FORBIDDEN(403, "본인이 요청한 다운로드가 아닙니다"),
 
     // 404 Not Found
     ROOM_NOT_FOUND(404, "존재하지 않는 방입니다: %s"),
     LINK_CODE_NOT_FOUND(404, "유효하지 않은 코드입니다"),
     FOLDER_NOT_FOUND(404, "존재하지 않는 폴더입니다: %s"),
     MEDIA_NOT_FOUND(404, "업로드 요청을 찾을 수 없습니다"),
+    DOWNLOAD_NOT_FOUND(404, "다운로드 요청을 찾을 수 없습니다"),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(405, "지원하지 않는 요청 방식입니다"),
@@ -55,6 +57,7 @@ public enum ErrorCode {
     ROOM_EXPIRED(410, "이미 사라진 방입니다"),
     ROOM_ALREADY_DELETED(410, "이미 삭제되었거나 만료된 방입니다"),
     LINK_CODE_EXPIRED(410, "만료된 코드입니다"),
+    DOWNLOAD_EXPIRED(410, "다운로드 기한이 지났습니다"),
 
     // 413 Payload Too Large
     FILE_SIZE_EXCEEDED(413, "%s 파일은 최대 %d바이트까지 업로드할 수 있습니다. (요청: %d바이트)"),

--- a/backend/src/main/java/com/sssok/infrastructure/config/DownloadProperties.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/DownloadProperties.java
@@ -4,5 +4,5 @@ import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "download")
-public record DownloadProperties(Duration presignedGetTtl, int maxConcurrentJobsPerRequester) {
+public record DownloadProperties(Duration presignedGetTtl, int maxConcurrentJobsPerRequester, Duration retention) {
 }

--- a/backend/src/main/java/com/sssok/presentation/api/download/DownloadController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/download/DownloadController.java
@@ -2,6 +2,8 @@ package com.sssok.presentation.api.download;
 
 import com.sssok.application.download.CreateDownloadJobResult;
 import com.sssok.application.download.CreateDownloadJobService;
+import com.sssok.application.download.GetDownloadJobStatusResult;
+import com.sssok.application.download.GetDownloadJobStatusService;
 import com.sssok.presentation.api.common.ApiResponse;
 import com.sssok.presentation.auth.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DownloadController {
 
     private final CreateDownloadJobService createDownloadJobService;
+    private final GetDownloadJobStatusService getDownloadJobStatusService;
 
     @Operation(
         summary = "zip 다운로드 요청",
@@ -41,5 +45,21 @@ public class DownloadController {
         CreateDownloadJobResult result =
             createDownloadJobService.create(roomId, memberId, request.mediaIds(), request.folderId());
         return ApiResponse.of(CreateDownloadJobResponse.from(result));
+    }
+
+    @Operation(
+        summary = "zip 다운로드 상태 조회",
+        description = "압축 작업의 진행 상태를 조회하고, 완료되면 다운로드 URL을 받는다. 본인이 요청한 잡만 조회할 수 "
+            + "있고, 아니면 403이 난다. 없는 jobId는 404, 보관 기간(기본 1시간, READY 시점부터 계산)이 지났으면 "
+            + "410이 난다. downloadUrl/expiresAt은 READY일 때만 채워지며, 조회할 때마다 새로 서명한다."
+    )
+    @GetMapping("/{jobId}")
+    public ApiResponse<GetDownloadJobStatusResponse> status(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "B-7-1에서 받은 압축 작업 ID") @PathVariable Long jobId
+    ) {
+        GetDownloadJobStatusResult result = getDownloadJobStatusService.getStatus(jobId, memberId);
+        return ApiResponse.of(GetDownloadJobStatusResponse.from(result));
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/download/GetDownloadJobStatusResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/download/GetDownloadJobStatusResponse.java
@@ -1,0 +1,24 @@
+package com.sssok.presentation.api.download;
+
+import com.sssok.application.download.GetDownloadJobStatusResult;
+import com.sssok.domain.download.DownloadJobStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+public record GetDownloadJobStatusResponse(
+    @Schema(description = "압축 작업 ID") Long jobId,
+    @Schema(description = "QUEUED / RUNNING / READY / FAILED / EXPIRED") DownloadJobStatus status,
+    @Schema(description = "진행률 0~100") int progress,
+    @Schema(description = "압축 대상 개수") int mediaCount,
+    @Schema(description = "zip 파일명") String fileName,
+    @Schema(description = "완료 시 다운로드 서명 URL. READY가 아니면 null") String downloadUrl,
+    @Schema(description = "다운로드 URL 만료 일시. READY가 아니면 null") Instant expiresAt,
+    @Schema(description = "실패 사유. FAILED가 아니면 null") String failureReason
+) {
+
+    public static GetDownloadJobStatusResponse from(GetDownloadJobStatusResult result) {
+        return new GetDownloadJobStatusResponse(
+            result.jobId(), result.status(), result.progress(), result.mediaCount(),
+            result.fileName(), result.downloadUrl(), result.expiresAt(), result.failureReason());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -61,6 +61,8 @@ download:
   presigned-get-ttl: 5m
   # 동일 멤버가 동시에 진행(QUEUED/RUNNING) 중일 수 있는 압축 잡의 최대 개수. 넘으면 429.
   max-concurrent-jobs-per-requester: 3
+  # zip 압축 잡의 보관 기간. READY(압축 완료) 시점부터 센다. 지나면 410, 배치가 실물을 정리한다.
+  retention: 1h
 
 springdoc:
   swagger-ui:

--- a/backend/src/test/java/com/sssok/application/download/GetDownloadJobStatusServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/download/GetDownloadJobStatusServiceTest.java
@@ -1,0 +1,126 @@
+package com.sssok.application.download;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.sssok.application.download.exception.DownloadExpiredException;
+import com.sssok.application.download.exception.DownloadForbiddenException;
+import com.sssok.application.download.exception.DownloadNotFoundException;
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.domain.file.StorageKey;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// Repository + Service 통합 테스트 (H2). 스토리지 서명은 목으로 둔다.
+@SpringBootTest
+@ActiveProfiles("test")
+class GetDownloadJobStatusServiceTest {
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long REQUESTER_ID = 100L;
+    private static final String PRESIGNED = "https://storage.example.com/zip-signed";
+
+    @Autowired
+    GetDownloadJobStatusService getDownloadJobStatusService;
+
+    @Autowired
+    DownloadJobRepository downloadJobRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    @BeforeEach
+    void setUp() {
+        given(fileStoragePort.presignGet(any(), anyString(), anyString(), any(Duration.class)))
+            .willReturn(PRESIGNED);
+    }
+
+    private DownloadJob queuedJob() {
+        return downloadJobRepository.save(
+            DownloadJob.create(ROOM_ID, REQUESTER_ID, 3, 1000L, "sssOK_1.zip", Instant.now()));
+    }
+
+    private DownloadJob readyJob(Instant readyAt) {
+        DownloadJob job = DownloadJob.create(ROOM_ID, REQUESTER_ID, 3, 1000L, "sssOK_1.zip", Instant.now());
+        job.markRunning();
+        job.markReady(new StorageKey("rooms/1/downloads/job-1.zip"), readyAt);
+        return downloadJobRepository.save(job);
+    }
+
+    private DownloadJob failedJob() {
+        DownloadJob job = DownloadJob.create(ROOM_ID, REQUESTER_ID, 3, 1000L, "sssOK_1.zip", Instant.now());
+        job.markRunning();
+        job.markFailed("스토리지 업로드 실패");
+        return downloadJobRepository.save(job);
+    }
+
+    @Test
+    void QUEUED_잡은_downloadUrl_없이_상태만_돌려준다() {
+        DownloadJob job = queuedJob();
+
+        GetDownloadJobStatusResult result = getDownloadJobStatusService.getStatus(job.getId(), REQUESTER_ID);
+
+        assertThat(result.status()).isEqualTo(DownloadJobStatus.QUEUED);
+        assertThat(result.downloadUrl()).isNull();
+        assertThat(result.expiresAt()).isNull();
+        assertThat(result.failureReason()).isNull();
+    }
+
+    @Test
+    void READY_잡은_다운로드_URL과_만료_시각을_돌려준다() {
+        Instant readyAt = Instant.now();
+        DownloadJob job = readyJob(readyAt);
+
+        GetDownloadJobStatusResult result = getDownloadJobStatusService.getStatus(job.getId(), REQUESTER_ID);
+
+        assertThat(result.status()).isEqualTo(DownloadJobStatus.READY);
+        assertThat(result.downloadUrl()).isEqualTo(PRESIGNED);
+        assertThat(result.expiresAt()).isEqualTo(readyAt.plus(Duration.ofHours(1)));
+        assertThat(result.progress()).isEqualTo(100);
+    }
+
+    @Test
+    void FAILED_잡은_실패_사유를_돌려준다() {
+        DownloadJob job = failedJob();
+
+        GetDownloadJobStatusResult result = getDownloadJobStatusService.getStatus(job.getId(), REQUESTER_ID);
+
+        assertThat(result.status()).isEqualTo(DownloadJobStatus.FAILED);
+        assertThat(result.failureReason()).isEqualTo("스토리지 업로드 실패");
+        assertThat(result.downloadUrl()).isNull();
+    }
+
+    @Test
+    void 본인이_아니면_403() {
+        DownloadJob job = queuedJob();
+
+        assertThatThrownBy(() -> getDownloadJobStatusService.getStatus(job.getId(), 999L))
+            .isInstanceOf(DownloadForbiddenException.class);
+    }
+
+    @Test
+    void 없는_잡이면_404() {
+        assertThatThrownBy(() -> getDownloadJobStatusService.getStatus(999L, REQUESTER_ID))
+            .isInstanceOf(DownloadNotFoundException.class);
+    }
+
+    @Test
+    void 보관_기간이_지난_READY_잡은_410() {
+        DownloadJob job = readyJob(Instant.now().minus(Duration.ofHours(2)));
+
+        assertThatThrownBy(() -> getDownloadJobStatusService.getStatus(job.getId(), REQUESTER_ID))
+            .isInstanceOf(DownloadExpiredException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/download/DownloadControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/download/DownloadControllerTest.java
@@ -3,12 +3,18 @@ package com.sssok.presentation.api.download;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sssok.application.download.CreateDownloadJobResult;
 import com.sssok.application.download.CreateDownloadJobService;
+import com.sssok.application.download.GetDownloadJobStatusResult;
+import com.sssok.application.download.GetDownloadJobStatusService;
+import com.sssok.application.download.exception.DownloadExpiredException;
+import com.sssok.application.download.exception.DownloadForbiddenException;
+import com.sssok.application.download.exception.DownloadNotFoundException;
 import com.sssok.application.download.exception.DownloadRateLimitedException;
 import com.sssok.application.download.exception.InvalidDownloadParamException;
 import com.sssok.application.download.exception.TooManyFilesException;
@@ -48,6 +54,9 @@ class DownloadControllerTest {
 
     @MockitoBean
     CreateDownloadJobService createDownloadJobService;
+
+    @MockitoBean
+    GetDownloadJobStatusService getDownloadJobStatusService;
 
     @MockitoBean
     TokenProvider tokenProvider;
@@ -140,6 +149,63 @@ class DownloadControllerTest {
         mockMvc.perform(post("/api/v1/rooms/{roomId}/downloads", ROOM_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"mediaIds\":[1]}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    private ResultActions getJobStatus(Long jobId) throws Exception {
+        return mockMvc.perform(get("/api/v1/rooms/{roomId}/downloads/{jobId}", ROOM_ID, jobId)
+            .header("Authorization", BEARER));
+    }
+
+    @Test
+    void 상태_조회하면_200과_잡_상태를_반환한다() throws Exception {
+        Instant expiresAt = Instant.parse("2026-08-27T12:00:00Z");
+        GetDownloadJobStatusResult result = new GetDownloadJobStatusResult(
+            1L, DownloadJobStatus.READY, 100, 3, "sssOK_10.zip",
+            "https://storage.example.com/zip-signed", expiresAt, null);
+        given(getDownloadJobStatusService.getStatus(anyLong(), anyLong())).willReturn(result);
+
+        getJobStatus(1L)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.jobId").value(1))
+            .andExpect(jsonPath("$.data.status").value("READY"))
+            .andExpect(jsonPath("$.data.progress").value(100))
+            .andExpect(jsonPath("$.data.downloadUrl").value("https://storage.example.com/zip-signed"));
+    }
+
+    @Test
+    void 본인이_아닌_잡을_조회하면_403() throws Exception {
+        given(getDownloadJobStatusService.getStatus(anyLong(), anyLong()))
+            .willThrow(new DownloadForbiddenException());
+
+        getJobStatus(1L)
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("DOWNLOAD_FORBIDDEN"));
+    }
+
+    @Test
+    void 없는_잡을_조회하면_404() throws Exception {
+        given(getDownloadJobStatusService.getStatus(anyLong(), anyLong()))
+            .willThrow(new DownloadNotFoundException());
+
+        getJobStatus(999L)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("DOWNLOAD_NOT_FOUND"));
+    }
+
+    @Test
+    void 보관_기간이_지난_잡을_조회하면_410() throws Exception {
+        given(getDownloadJobStatusService.getStatus(anyLong(), anyLong()))
+            .willThrow(new DownloadExpiredException());
+
+        getJobStatus(1L)
+            .andExpect(status().isGone())
+            .andExpect(jsonPath("$.code").value("DOWNLOAD_EXPIRED"));
+    }
+
+    @Test
+    void 상태_조회도_인증_없이_요청하면_401() throws Exception {
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/downloads/{jobId}", ROOM_ID, 1L))
             .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## 작업 내용

이슈 #84의 세 번째 엔드포인트 — **zip 다운로드 상태 조회**를 구현했다. 압축 잡의 진행 상태를 폴링하고, 완료됐으면 다운로드 서명 URL을 받는다. 앞선 API PR(#98) 위에서 이어서 작업했다.

### 전체 흐름

```mermaid
sequenceDiagram
    autonumber
    participant Client as 클라이언트
    participant Svc as GetDownloadJobStatusService
    participant DB
    participant R2

    Client->>Svc: GET /downloads/{jobId} (1~2초 간격)
    Svc->>DB: findById(jobId)
    DB-->>Svc: DownloadJob
    Note over Svc: isRequestedBy? isExpired?<br/>본인 아니면 403 · 기한 지났으면 410
    Svc->>R2: READY일 때만 presignGet(zipKey, 남은 시간)
    R2-->>Svc: 서명 URL
    Svc-->>Client: 200 { status, progress, downloadUrl, expiresAt, failureReason }
    Note over Client: READY가 아니면 downloadUrl · expiresAt은 null
```

## 관련 이슈

이슈 #84의 일부. 아직 압축 자체를 실행하는 워커가 없어(다음 PR) 잡이 QUEUED에서 더 진행되지 않는다 — `Closes`는 워커가 붙는 PR에서 건다.

## 작업 영역

- [ ] Frontend
- [x] Backend

## 변경 사항

### 1. 에러코드·설정 추가
`DOWNLOAD_FORBIDDEN`(403), `DOWNLOAD_NOT_FOUND`(404), `DOWNLOAD_EXPIRED`(410)와 대응 예외 3개를 추가했다. `DownloadProperties`에 `retention`(보관 기간, 기본 1시간)도 추가했다 — 이 조회 서비스가 만료 판정에 바로 필요하다.

### 2. `GetDownloadJobStatusService`
- 잡을 조회한 뒤 **본인 확인 → 만료 판정** 순서로 검증한다. 만료 판정은 배치가 `EXPIRED`를 찍었는지와 무관하게, 조회 시점에 `readyAt + retention < now`를 직접 계산한다 — 배치는 10분에 한 번만 돌기 때문에, 그 사이 구간은 조회 자신이 막아야 한다.
- READY일 때만 다운로드 URL을 만드는데, **저장해 둔 URL을 재사용하지 않고 매번 새로 서명한다.** 서명 자체의 유효기간이 잡의 보관 기간보다 먼저 끝나버리는 걸 막기 위해, `expiresAt`(= `readyAt + retention`)까지 남은 시간만큼만 서명한다.

### 3. API 노출
`DownloadController`에 `GET /rooms/{roomId}/downloads/{jobId}`를 추가했다.

## 테스트

- [x] 단위 테스트 작성/통과
- [ ] 로컬 동작 확인

`GetDownloadJobStatusServiceTest`(6: QUEUED/READY/FAILED 상태별, 본인 아님, 없음, 만료) + `DownloadControllerTest`에 상태 조회 케이스 5개(200, 403, 404, 410, 401) 추가. 전부 통과했다.

## 리뷰 요청 사항 (선택)

- 이 PR만으로는 잡이 QUEUED에서 멈춰 있어 READY/FAILED 응답을 실제 흐름으로는 볼 수 없다. 다음 PR(비동기 압축 파이프라인)이 이어 붙는다.
- 이 PR도 base가 `main`이 아니라 스택의 이전 브랜치(`feature/be-#84-media-download-api`, PR #98)다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - ZIP 다운로드 작업의 상태를 조회할 수 있습니다.
  - 대기, 진행률, 완료, 실패 상태와 대상 파일 수를 확인할 수 있습니다.
  - 완료된 다운로드의 파일명, 다운로드 URL, 만료 시각을 제공합니다.
- **오류 개선**
  - 존재하지 않는 다운로드, 권한이 없는 요청, 보관 기간이 지난 다운로드를 구분해 안내합니다.
  - 다운로드 보관 기간을 1시간으로 설정했습니다.
- **안정성**
  - 다운로드 상태 조회와 주요 오류 상황에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->