### PR TITLE
feat: 다운로드 zip 만료 정리 배치 구현 - #84

### DIFF
--- a/backend/src/main/java/com/sssok/application/download/DownloadJobExpirer.java
+++ b/backend/src/main/java/com/sssok/application/download/DownloadJobExpirer.java
@@ -1,0 +1,25 @@
+package com.sssok.application.download;
+
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.download.DownloadJob;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// 실물을 먼저 지운다. DB 행이 남아 있어야 중간에 실패해도 다음 회차에 다시 찾아 시도할 수 있다
+// (RoomPurger와 같은 이유).
+@Component
+@RequiredArgsConstructor
+public class DownloadJobExpirer {
+
+    private final DownloadJobRepository downloadJobRepository;
+    private final FileStoragePort fileStoragePort;
+
+    @Transactional
+    public void expire(DownloadJob job) {
+        fileStoragePort.delete(job.getZipStorageKey());
+        job.markExpired();
+        downloadJobRepository.save(job);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/download/SweepDownloadJobsService.java
+++ b/backend/src/main/java/com/sssok/application/download/SweepDownloadJobsService.java
@@ -1,0 +1,38 @@
+package com.sssok.application.download;
+
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.infrastructure.config.DownloadProperties;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+// 보관 기간이 지난 READY 잡의 zip 실물을 지우고 EXPIRED로 넘긴다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SweepDownloadJobsService {
+
+    private final DownloadJobRepository downloadJobRepository;
+    private final DownloadJobExpirer downloadJobExpirer;
+    private final DownloadProperties downloadProperties;
+
+    public int sweepExpired(Instant now) {
+        Instant threshold = now.minus(downloadProperties.retention());
+        List<DownloadJob> targets = downloadJobRepository.findAllExpiredReady(threshold);
+
+        int swept = 0;
+        for (DownloadJob job : targets) {
+            // 한 잡이 실패해도 나머지는 계속 정리한다. 실패한 잡은 다음 회차에 다시 대상으로 잡힌다.
+            try {
+                downloadJobExpirer.expire(job);
+                swept++;
+            } catch (RuntimeException e) {
+                log.warn("다운로드 잡 {} 정리에 실패했습니다. 다음 회차에 다시 시도합니다", job.getId(), e);
+            }
+        }
+        return swept;
+    }
+}

--- a/backend/src/main/java/com/sssok/application/port/out/DownloadJobRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/DownloadJobRepository.java
@@ -2,6 +2,7 @@ package com.sssok.application.port.out;
 
 import com.sssok.domain.download.DownloadJob;
 import com.sssok.domain.download.DownloadJobStatus;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +22,7 @@ public interface DownloadJobRepository {
 
     // 이 잡이 압축해야 할 media id 목록. 워커가 실제로 무엇을 zip에 담을지 결정할 때 쓴다.
     List<Long> findMediaIdsByJobId(Long jobId);
+
+    // READY인 채로 threshold(now - retention) 이전에 완료된 잡. 만료 정리 배치가 쓴다.
+    List<DownloadJob> findAllExpiredReady(Instant threshold);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/download/DownloadJobJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/download/DownloadJobJpaRepository.java
@@ -1,9 +1,12 @@
 package com.sssok.infrastructure.persistence.download;
 
+import java.time.Instant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DownloadJobJpaRepository extends JpaRepository<DownloadJobJpaEntity, Long> {
 
     long countByRequesterIdAndStatusIn(Long requesterId, List<String> statuses);
+
+    List<DownloadJobJpaEntity> findAllByStatusAndReadyAtBefore(String status, Instant threshold);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/download/DownloadJobRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/download/DownloadJobRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.sssok.application.port.out.DownloadJobRepository;
 import com.sssok.domain.download.DownloadJob;
 import com.sssok.domain.download.DownloadJobStatus;
 import com.sssok.domain.file.StorageKey;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +45,13 @@ public class DownloadJobRepositoryAdapter implements DownloadJobRepository {
     public List<Long> findMediaIdsByJobId(Long jobId) {
         return jobMediaJpaRepository.findAllByDownloadJobId(jobId).stream()
             .map(DownloadJobMediaJpaEntity::getMediaId)
+            .toList();
+    }
+
+    @Override
+    public List<DownloadJob> findAllExpiredReady(Instant threshold) {
+        return jpaRepository.findAllByStatusAndReadyAtBefore(DownloadJobStatus.READY.name(), threshold).stream()
+            .map(this::toDomain)
             .toList();
     }
 

--- a/backend/src/main/java/com/sssok/infrastructure/scheduler/DownloadJobSweepBatch.java
+++ b/backend/src/main/java/com/sssok/infrastructure/scheduler/DownloadJobSweepBatch.java
@@ -1,0 +1,26 @@
+package com.sssok.infrastructure.scheduler;
+
+import com.sssok.application.download.SweepDownloadJobsService;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+// 보관 기간이 지난 다운로드 zip을 영구 삭제하는 스케줄 배치.
+// 단일 인스턴스 전제로 분산 락이 없다 (PurgeBatch와 같은 전제).
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DownloadJobSweepBatch {
+
+    private final SweepDownloadJobsService sweepDownloadJobsService;
+
+    @Scheduled(cron = "${download.sweep-cron:0 */10 * * * *}")
+    public void sweep() {
+        int swept = sweepDownloadJobsService.sweepExpired(Instant.now());
+        if (swept > 0) {
+            log.info("보관 기간이 지난 다운로드 zip {}개를 정리했습니다", swept);
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -63,6 +63,8 @@ download:
   max-concurrent-jobs-per-requester: 3
   # zip 압축 잡의 보관 기간. READY(압축 완료) 시점부터 센다. 지나면 410, 배치가 실물을 정리한다.
   retention: 1h
+  # 보관 기간이 지난 zip을 정리하는 시각(10분마다).
+  sweep-cron: "0 */10 * * * *"
 
 springdoc:
   swagger-ui:

--- a/backend/src/test/java/com/sssok/application/download/GetDownloadJobStatusServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/download/GetDownloadJobStatusServiceTest.java
@@ -22,10 +22,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
 
 // Repository + Service 통합 테스트 (H2). 스토리지 서명은 목으로 둔다.
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class GetDownloadJobStatusServiceTest {
 
     private static final Long ROOM_ID = 1L;

--- a/backend/src/test/java/com/sssok/application/download/SweepDownloadJobsServiceFailureTest.java
+++ b/backend/src/test/java/com/sssok/application/download/SweepDownloadJobsServiceFailureTest.java
@@ -1,0 +1,61 @@
+package com.sssok.application.download;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.domain.file.StorageKey;
+import com.sssok.infrastructure.config.DownloadProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+// 잡 하나가 실패해도 나머지 정리가 멈추지 않아야 한다.
+class SweepDownloadJobsServiceFailureTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-27T00:00:00Z");
+
+    private final DownloadJobRepository downloadJobRepository = mock(DownloadJobRepository.class);
+    private final DownloadJobExpirer downloadJobExpirer = mock(DownloadJobExpirer.class);
+    private final DownloadProperties downloadProperties =
+        new DownloadProperties(Duration.ofMinutes(5), 3, Duration.ofHours(1));
+
+    private final SweepDownloadJobsService sweepDownloadJobsService =
+        new SweepDownloadJobsService(downloadJobRepository, downloadJobExpirer, downloadProperties);
+
+    @Test
+    void 한_잡이_실패해도_나머지는_계속_정리한다() {
+        DownloadJob failing = job(1L);
+        DownloadJob healthy = job(2L);
+        given(downloadJobRepository.findAllExpiredReady(any())).willReturn(List.of(failing, healthy));
+        willThrow(new IllegalStateException("스토리지 오류")).given(downloadJobExpirer).expire(failing);
+
+        int swept = sweepDownloadJobsService.sweepExpired(NOW);
+
+        assertThat(swept).isEqualTo(1);
+        verify(downloadJobExpirer, times(1)).expire(healthy);
+    }
+
+    @Test
+    void 전부_실패해도_예외를_밖으로_던지지_않는다() {
+        given(downloadJobRepository.findAllExpiredReady(any())).willReturn(List.of(job(1L)));
+        willThrow(new IllegalStateException("스토리지 오류")).given(downloadJobExpirer).expire(any());
+
+        // 배치가 죽으면 다음 회차까지 아무것도 정리되지 않는다.
+        assertThat(sweepDownloadJobsService.sweepExpired(NOW)).isZero();
+    }
+
+    private DownloadJob job(Long id) {
+        return DownloadJob.reconstruct(id, 1L, 100L, DownloadJobStatus.READY, 1, 1024L,
+            "sssOK_1.zip", new StorageKey("rooms/1/downloads/" + id + ".zip"), 100,
+            NOW.minus(Duration.ofHours(3)), NOW.minus(Duration.ofHours(2)), null);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/download/SweepDownloadJobsServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/download/SweepDownloadJobsServiceTest.java
@@ -1,0 +1,86 @@
+package com.sssok.application.download;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.sssok.application.port.out.DownloadJobRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.download.DownloadJob;
+import com.sssok.domain.download.DownloadJobStatus;
+import com.sssok.domain.file.StorageKey;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+// Repository + Service 통합 테스트 (H2). 스토리지 삭제는 목으로 둔다.
+// @Transactional로 테스트마다 롤백한다 — 이 서비스는 status/ready_at만으로 대상을 고르기 때문에,
+// 다른 테스트가 남긴 READY 잡이 격리 없이 섞이면 (특히 "미래" now를 넣는 테스트에서) 서로 오염된다.
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class SweepDownloadJobsServiceTest {
+
+    @Autowired
+    SweepDownloadJobsService sweepDownloadJobsService;
+
+    @Autowired
+    DownloadJobRepository downloadJobRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    private DownloadJob readyJobAt(Instant readyAt) {
+        DownloadJob job = DownloadJob.create(1L, 100L, 1, 1024L, "sssOK_1.zip", Instant.now());
+        job.markRunning();
+        job.markReady(new StorageKey("rooms/1/downloads/" + System.nanoTime() + ".zip"), readyAt);
+        return downloadJobRepository.save(job);
+    }
+
+    @Test
+    void 보관_기간이_지난_READY_잡을_정리하고_실물을_지운다() {
+        DownloadJob job = readyJobAt(Instant.now().minus(Duration.ofHours(2)));
+
+        int swept = sweepDownloadJobsService.sweepExpired(Instant.now());
+
+        assertThat(swept).isEqualTo(1);
+        assertThat(downloadJobRepository.findById(job.getId()).orElseThrow().getStatus())
+            .isEqualTo(DownloadJobStatus.EXPIRED);
+        verify(fileStoragePort).delete(job.getZipStorageKey());
+    }
+
+    @Test
+    void 보관_기간이_안_지난_READY_잡은_대상이_아니다() {
+        DownloadJob job = readyJobAt(Instant.now());
+
+        int swept = sweepDownloadJobsService.sweepExpired(Instant.now());
+
+        assertThat(swept).isZero();
+        assertThat(downloadJobRepository.findById(job.getId()).orElseThrow().getStatus())
+            .isEqualTo(DownloadJobStatus.READY);
+    }
+
+    @Test
+    void READY가_아니면_대상이_아니다() {
+        DownloadJob job = downloadJobRepository.save(
+            DownloadJob.create(1L, 100L, 1, 1024L, "sssOK_1.zip", Instant.now()));
+
+        int swept = sweepDownloadJobsService.sweepExpired(Instant.now().plus(Duration.ofDays(1)));
+
+        assertThat(swept).isZero();
+        assertThat(downloadJobRepository.findById(job.getId()).orElseThrow().getStatus())
+            .isEqualTo(DownloadJobStatus.QUEUED);
+    }
+
+    @Test
+    void 다시_돌려도_같은_결과다() {
+        readyJobAt(Instant.now().minus(Duration.ofHours(2)));
+
+        assertThat(sweepDownloadJobsService.sweepExpired(Instant.now())).isEqualTo(1);
+        assertThat(sweepDownloadJobsService.sweepExpired(Instant.now())).isZero();
+    }
+}

--- a/backend/src/test/java/com/sssok/infrastructure/scheduler/DownloadJobSweepBatchSchedulingTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/scheduler/DownloadJobSweepBatchSchedulingTest.java
@@ -1,0 +1,34 @@
+package com.sssok.infrastructure.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+// 배치가 실제로 스케줄에 등록되는지 확인한다. @EnableScheduling 이 빠지면 여기서 걸린다.
+@SpringBootTest
+@ActiveProfiles("test")
+class DownloadJobSweepBatchSchedulingTest {
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void 정리_배치가_스케줄에_등록된다() {
+        assertThat(scheduledTaskNames())
+            .anyMatch(name -> name.contains(DownloadJobSweepBatch.class.getName() + ".sweep"));
+    }
+
+    // 스프링이 러너블을 감싸는 방식은 버전마다 달라서, 타입 대신 표기로 확인한다.
+    private List<String> scheduledTaskNames() {
+        return applicationContext.getBeansOfType(ScheduledTaskHolder.class).values().stream()
+            .flatMap(holder -> holder.getScheduledTasks().stream())
+            .map(task -> task.getTask().getRunnable().toString())
+            .toList();
+    }
+}

--- a/backend/src/test/java/com/sssok/infrastructure/scheduler/DownloadJobSweepBatchTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/scheduler/DownloadJobSweepBatchTest.java
@@ -1,0 +1,31 @@
+package com.sssok.infrastructure.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+import com.sssok.application.download.SweepDownloadJobsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// 배치가 정리 작업을 서비스에 위임하는지 확인한다. 스케줄 등록 여부는
+// DownloadJobSweepBatchSchedulingTest 가 본다.
+@SpringBootTest
+@ActiveProfiles("test")
+class DownloadJobSweepBatchTest {
+
+    @Autowired
+    DownloadJobSweepBatch downloadJobSweepBatch;
+
+    @MockitoBean
+    SweepDownloadJobsService sweepDownloadJobsService;
+
+    @Test
+    void 배치가_돌면_정리를_위임한다() {
+        downloadJobSweepBatch.sweep();
+
+        then(sweepDownloadJobsService).should().sweepExpired(any());
+    }
+}


### PR DESCRIPTION
## 작업 내용

보관 기간이 지난 압축 zip을 정리하는 스케줄 배치를 구현했다. 이걸로 이슈 #84의 3개 엔드포인트(단건 다운로드 · zip 압축 요청 · 상태 조회)와 뒷정리까지 전체가 끝난다.

### 전체 흐름

```mermaid
flowchart TD
    A["DownloadJobSweepBatch<br/>@Scheduled 10분마다"] --> B["SweepDownloadJobsService<br/>findAllExpiredReady(now − 1h)"]
    B --> C{"대상마다"}
    C --> D["DownloadJobExpirer (@Transactional)<br/>① zip 실물 삭제 → R2<br/>② markExpired() 저장 → DB"]
    D -->|실패| E["catch 후 다음 잡으로<br/>배치는 죽지 않는다"]
    E -.-> C
    D -->|성공| C
```

## 관련 이슈

Closes #84

## 작업 영역

- [ ] Frontend
- [x] Backend

## 변경 사항

### 1. 만료 정리 배치
- `DownloadJobRepository.findAllExpiredReady`를 추가했다 — status=READY이고 ready_at이 보관 기간을 넘긴 잡을 조회.
- `DownloadJobExpirer`(`@Transactional`)를 추가했다 — **zip 실물을 먼저 지우고** 그다음 `markExpired()`로 저장한다. 순서가 중요하다: 실물 삭제가 실패해도 DB 행은 READY로 남아 다음 회차에 다시 대상이 되지만, 순서를 바꾸면 DB만 EXPIRED가 되고 실물이 영원히 안 지워지는 조합이 생긴다. `RoomPurger`와 같은 이유다.
- `SweepDownloadJobsService`가 대상을 순회하며 하나씩 정리한다. `PurgeRoomService`와 같은 패턴으로, 한 건이 실패해도 나머지는 계속 정리한다.
- `DownloadJobSweepBatch`를 추가했다 — `@Scheduled(cron = "${download.sweep-cron:0 */10 * * * *}")`, 기본 10분마다.

### 2. 테스트 격리 버그 수정
`GetDownloadJobStatusServiceTest`(앞선 PR에서 추가)에 `@Transactional`이 빠져 있어, 거기서 만든 READY 잡이 H2 DB에 영구로 남아 있었다. status/ready_at만으로 대상을 고르는 이번 PR의 `SweepDownloadJobsServiceTest`가 그 leftover를 주워버려, **전체 테스트 스위트를 돌릴 때만** 실패가 재현됐다(개별 클래스 실행은 통과). 근본 원인에 `@Transactional`을 추가해 고쳤다.

## 테스트

- [x] 단위 테스트 작성/통과
- [ ] 로컬 동작 확인

`SweepDownloadJobsServiceTest`(4: 정리 성공/기간 미도달/READY 아님/재실행 안전성), `SweepDownloadJobsServiceFailureTest`(2: 한 건 실패해도 나머지 정리/전부 실패해도 예외 안 던짐), `DownloadJobSweepBatchTest`(배치가 서비스에 위임하는지), `DownloadJobSweepBatchSchedulingTest`(`@EnableScheduling` 없으면 걸리는 스케줄 등록 확인). 전체 스위트를 3번 다시 돌려 격리 문제가 재발하지 않는 것도 확인했다.

## 리뷰 요청 사항 (선택)

- 이 배치는 단일 인스턴스 전제로 분산 락이 없다 (기존 `PurgeBatch`와 같은 전제). 스케일 아웃하면 여러 인스턴스가 같은 잡을 동시에 정리하려 들 수 있다.
- 이슈 #84 전체 스코프가 이 PR로 끝나 `Closes #84`를 넣었다 — 병합되면 이슈가 자동으로 닫힌다.
