### PR TITLE
feat: 업로드 완료 등록 API 구현 - #76

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Backend CI
 
 on:
+  # GitHub 쪽 일시적 오류로 실행이 시작되지 못하면 수동으로 다시 돌린다.
+  workflow_dispatch:
   pull_request:
     branches: [ main, deploy ]
     paths:

--- a/backend/src/main/java/com/sssok/application/media/CompleteUploadResult.java
+++ b/backend/src/main/java/com/sssok/application/media/CompleteUploadResult.java
@@ -1,0 +1,6 @@
+package com.sssok.application.media;
+
+import java.util.List;
+
+public record CompleteUploadResult(List<MediaDetail> registered, List<FailedMedia> failed) {
+}

--- a/backend/src/main/java/com/sssok/application/media/CompleteUploadService.java
+++ b/backend/src/main/java/com/sssok/application/media/CompleteUploadService.java
@@ -1,0 +1,112 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.InvalidUploadParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.media.exception.UploadNotAllowedException;
+import com.sssok.application.port.out.EventPublisherPort;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FileStoragePort.UploadedObject;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadRejectionReason;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 스토리지에 실물이 있는지 서버가 직접 확인한다. 클라이언트 말만 믿으면 올리지 않은 파일이 목록에 뜬다.
+@Service
+@RequiredArgsConstructor
+public class CompleteUploadService {
+
+    private static final String MEDIA_CREATED = "media.created";
+
+    private final FileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+    private final FolderMediaRepository folderMediaRepository;
+    private final MemberRepository memberRepository;
+    private final RoomPermissionPort roomPermissionPort;
+    private final EventPublisherPort eventPublisherPort;
+
+    @Transactional
+    public CompleteUploadResult complete(Long roomId, Long uploaderId, List<Long> mediaIds) {
+        if (mediaIds == null || mediaIds.isEmpty()) {
+            throw new InvalidUploadParamException("등록할 미디어가 없습니다");
+        }
+        if (!roomPermissionPort.canUpload(roomId, uploaderId)) {
+            throw new UploadNotAllowedException();
+        }
+
+        List<StoredFile> found = fileRepository.findAllByIdIn(mediaIds);
+        rejectOthersReservation(found, uploaderId);
+
+        List<MediaDetail> registered = new ArrayList<>();
+        List<FailedMedia> failed = new ArrayList<>();
+        String uploaderName = uploaderName(uploaderId);
+
+        for (Long mediaId : mediaIds) {
+            StoredFile file = findIn(found, mediaId);
+            if (file == null) {
+                failed.add(FailedMedia.of(mediaId, UploadRejectionReason.MEDIA_NOT_FOUND));
+                continue;
+            }
+            UploadRejectionReason reason = verifyUploaded(file);
+            if (reason != null) {
+                failed.add(FailedMedia.of(mediaId, reason));
+                continue;
+            }
+            file.startProcessing();
+            StoredFile saved = fileRepository.save(file);
+            registered.add(MediaDetail.of(saved, uploaderName,
+                folderMediaRepository.findFolderIdsContainingMedia(List.of(mediaId))));
+        }
+
+        publishCreated(roomId, registered);
+        return new CompleteUploadResult(registered, failed);
+    }
+
+    // 남이 예약한 mediaId 가 하나라도 섞여 있으면 요청 전체를 막는다. 남의 업로드를 건드리는 시도다.
+    private void rejectOthersReservation(List<StoredFile> found, Long uploaderId) {
+        boolean hasOthers = found.stream().anyMatch(file -> !file.isUploadedBy(uploaderId));
+        if (hasOthers) {
+            throw new MediaForbiddenException();
+        }
+    }
+
+    // 발급 때 신고한 값과 실제로 올라온 것이 다르면 거부한다. 통과하면 null 이다.
+    private UploadRejectionReason verifyUploaded(StoredFile file) {
+        Optional<UploadedObject> uploaded = fileStoragePort.findUploaded(file.getStorageKey());
+        if (uploaded.isEmpty()) {
+            return UploadRejectionReason.UPLOAD_NOT_COMPLETED;
+        }
+        UploadedObject object = uploaded.get();
+        if (!file.matchesUploaded(object.sizeBytes(), object.contentType())) {
+            return object.sizeBytes() != file.getFileSize().bytes()
+                ? UploadRejectionReason.FILE_TOO_LARGE
+                : UploadRejectionReason.UNSUPPORTED_MEDIA_TYPE;
+        }
+        return null;
+    }
+
+    private StoredFile findIn(List<StoredFile> files, Long mediaId) {
+        return files.stream()
+            .filter(file -> file.getId().equals(mediaId))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private String uploaderName(Long uploaderId) {
+        return memberRepository.findById(uploaderId)
+            .map(member -> member.getDisplayName().value())
+            .orElse(null);
+    }
+
+    private void publishCreated(Long roomId, List<MediaDetail> registered) {
+        registered.forEach(media -> eventPublisherPort.publish(roomId, MEDIA_CREATED, media));
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/CompleteUploadService.java
+++ b/backend/src/main/java/com/sssok/application/media/CompleteUploadService.java
@@ -3,11 +3,9 @@ package com.sssok.application.media;
 import com.sssok.application.media.exception.InvalidUploadParamException;
 import com.sssok.application.media.exception.MediaForbiddenException;
 import com.sssok.application.media.exception.UploadNotAllowedException;
-import com.sssok.application.port.out.EventPublisherPort;
 import com.sssok.application.port.out.FileRepository;
 import com.sssok.application.port.out.FileStoragePort;
 import com.sssok.application.port.out.FileStoragePort.UploadedObject;
-import com.sssok.application.port.out.FolderMediaRepository;
 import com.sssok.application.port.out.MemberRepository;
 import com.sssok.application.port.out.RoomPermissionPort;
 import com.sssok.domain.file.StoredFile;
@@ -17,23 +15,21 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 // 스토리지에 실물이 있는지 서버가 직접 확인한다. 클라이언트 말만 믿으면 올리지 않은 파일이 목록에 뜬다.
+//
+// 트랜잭션을 열지 않는다. 스토리지 확인이 미디어 수만큼 네트워크를 왕복하는데 그동안 DB 커넥션을
+// 쥐고 있으면 등록 몇 건만으로 풀이 마른다. 실제 쓰기는 MediaRegistrar 가 짧게 연다.
 @Service
 @RequiredArgsConstructor
 public class CompleteUploadService {
 
-    private static final String MEDIA_CREATED = "media.created";
-
     private final FileRepository fileRepository;
     private final FileStoragePort fileStoragePort;
-    private final FolderMediaRepository folderMediaRepository;
     private final MemberRepository memberRepository;
     private final RoomPermissionPort roomPermissionPort;
-    private final EventPublisherPort eventPublisherPort;
+    private final MediaRegistrar mediaRegistrar;
 
-    @Transactional
     public CompleteUploadResult complete(Long roomId, Long uploaderId, List<Long> mediaIds) {
         if (mediaIds == null || mediaIds.isEmpty()) {
             throw new InvalidUploadParamException("등록할 미디어가 없습니다");
@@ -45,10 +41,8 @@ public class CompleteUploadService {
         List<StoredFile> found = fileRepository.findAllByIdIn(mediaIds);
         rejectOthersReservation(found, uploaderId);
 
-        List<MediaDetail> registered = new ArrayList<>();
+        List<StoredFile> verified = new ArrayList<>();
         List<FailedMedia> failed = new ArrayList<>();
-        String uploaderName = uploaderName(uploaderId);
-
         for (Long mediaId : mediaIds) {
             StoredFile file = findIn(found, mediaId);
             if (file == null) {
@@ -56,17 +50,15 @@ public class CompleteUploadService {
                 continue;
             }
             UploadRejectionReason reason = verifyUploaded(file);
-            if (reason != null) {
+            if (reason == null) {
+                verified.add(file);
+            } else {
                 failed.add(FailedMedia.of(mediaId, reason));
-                continue;
             }
-            file.startProcessing();
-            StoredFile saved = fileRepository.save(file);
-            registered.add(MediaDetail.of(saved, uploaderName,
-                folderMediaRepository.findFolderIdsContainingMedia(List.of(mediaId))));
         }
 
-        publishCreated(roomId, registered);
+        List<MediaDetail> registered =
+            mediaRegistrar.register(roomId, verified, uploaderName(uploaderId));
         return new CompleteUploadResult(registered, failed);
     }
 
@@ -104,9 +96,5 @@ public class CompleteUploadService {
         return memberRepository.findById(uploaderId)
             .map(member -> member.getDisplayName().value())
             .orElse(null);
-    }
-
-    private void publishCreated(Long roomId, List<MediaDetail> registered) {
-        registered.forEach(media -> eventPublisherPort.publish(roomId, MEDIA_CREATED, media));
     }
 }

--- a/backend/src/main/java/com/sssok/application/media/FailedMedia.java
+++ b/backend/src/main/java/com/sssok/application/media/FailedMedia.java
@@ -1,0 +1,10 @@
+package com.sssok.application.media;
+
+import com.sssok.domain.file.UploadRejectionReason;
+
+public record FailedMedia(Long mediaId, String code, String message) {
+
+    public static FailedMedia of(Long mediaId, UploadRejectionReason reason) {
+        return new FailedMedia(mediaId, reason.name(), reason.message());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaCreatedEvent.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.sssok.application.media;
+
+public record MediaCreatedEvent(Long roomId, MediaDetail media) {
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaDetail.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaDetail.java
@@ -1,0 +1,33 @@
+package com.sssok.application.media;
+
+import com.sssok.domain.file.StoredFile;
+import java.time.Instant;
+import java.util.List;
+
+// 미디어 목록 API 가 생기면 같은 형태를 쓰도록 응용 계층에 둔다.
+public record MediaDetail(Long mediaId, String type, String fileName, String mimeType, long size,
+                          String thumbnailUrl, String originalUrl, Integer width, Integer height,
+                          Integer duration, List<Long> folderIds, Long uploaderId,
+                          String uploaderName, String status, Instant uploadedAt) {
+
+    // 썸네일·크기·재생 시간은 워커가 채우기 전까지 비어 있다.
+    public static MediaDetail of(StoredFile file, String uploaderName, List<Long> folderIds) {
+        return new MediaDetail(
+            file.getId(),
+            file.getMediaType().isImage() ? "IMAGE" : "VIDEO",
+            file.getOriginalFileName(),
+            file.getMediaType().contentType(),
+            file.getFileSize().bytes(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            folderIds,
+            file.getUploaderId(),
+            uploaderName,
+            file.getStatus().name(),
+            file.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaEventListener.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaEventListener.java
@@ -1,0 +1,24 @@
+package com.sssok.application.media;
+
+import com.sssok.application.port.out.EventPublisherPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+// 등록 트랜잭션이 실제로 커밋된 뒤에만 SSE 로 내보낸다.
+// 커밋 전에 보내면 이후 롤백돼도 클라이언트는 이미 사진이 올라간 것으로 알고 목록에 그린다.
+@Component
+@RequiredArgsConstructor
+public class MediaEventListener {
+
+    private final EventPublisherPort eventPublisher;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MediaCreatedEvent event) {
+        eventPublisher.publish(event.roomId(), "media.created", event.media());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaRegistrar.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaRegistrar.java
@@ -1,0 +1,43 @@
+package com.sssok.application.media;
+
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.domain.file.StoredFile;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// 검증을 통과한 미디어만 받아 상태를 넘기고 저장한다.
+// 스토리지 확인은 이 트랜잭션 밖에서 끝나 있어야 한다 — 네트워크 왕복 동안 DB 커넥션을 쥐고 있으면
+// 등록 몇 건만으로 풀이 마르고 무관한 API 까지 함께 멈춘다.
+@Component
+@RequiredArgsConstructor
+public class MediaRegistrar {
+
+    private final FileRepository fileRepository;
+    private final FolderMediaRepository folderMediaRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public List<MediaDetail> register(Long roomId, List<StoredFile> verified, String uploaderName) {
+        if (verified.isEmpty()) {
+            return List.of();
+        }
+        List<Long> mediaIds = verified.stream().map(StoredFile::getId).toList();
+        Map<Long, List<Long>> folderIds = folderMediaRepository.findFolderIdsByMedia(mediaIds);
+
+        List<MediaDetail> registered = new ArrayList<>();
+        for (StoredFile file : verified) {
+            file.startProcessing();
+            StoredFile saved = fileRepository.save(file);
+            registered.add(MediaDetail.of(saved, uploaderName,
+                folderIds.getOrDefault(saved.getId(), List.of())));
+        }
+        registered.forEach(media -> eventPublisher.publishEvent(new MediaCreatedEvent(roomId, media)));
+        return registered;
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/exception/MediaForbiddenException.java
+++ b/backend/src/main/java/com/sssok/application/media/exception/MediaForbiddenException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.media.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class MediaForbiddenException extends SssOkException {
+
+    public MediaForbiddenException() {
+        super(ErrorCode.MEDIA_FORBIDDEN);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
@@ -13,6 +13,8 @@ public interface FileRepository {
 
     Optional<StoredFile> findById(Long id);
 
+    List<StoredFile> findAllByIdIn(List<Long> ids);
+
     // 담기/꺼내기에서 어떤 mediaId가 실제로 존재하는지 확인하는 용도.
     // 넘긴 id 중 존재하는 것만 골라 반환한다 — 나머지는 notFoundMediaIds로 취급하면 된다.
     List<Long> findExistingIds(List<Long> ids);

--- a/backend/src/main/java/com/sssok/application/port/out/FileStoragePort.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FileStoragePort.java
@@ -2,6 +2,7 @@ package com.sssok.application.port.out;
 
 import com.sssok.domain.file.StorageKey;
 import java.time.Duration;
+import java.util.Optional;
 
 // 오브젝트 스토리지 출력
 public interface FileStoragePort {
@@ -10,6 +11,12 @@ public interface FileStoragePort {
     // 업로드하는 쪽이 같은 값을 헤더에 실어야 한다 (docs/backend/R2_PRESIGNED_UPLOAD.md).
     String presignPut(StorageKey storageKey, String contentType, Duration ttl);
 
+    // 실제로 올라왔는지와 올라온 것이 무엇인지 확인한다. 없으면 비어 있다.
+    Optional<UploadedObject> findUploaded(StorageKey storageKey);
+
     // 없는 키를 지워도 성공으로 본다 — 배치가 다시 돌아도 안전해야 한다.
     void delete(StorageKey storageKey);
+
+    record UploadedObject(long sizeBytes, String contentType) {
+    }
 }

--- a/backend/src/main/java/com/sssok/application/port/out/FolderMediaRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FolderMediaRepository.java
@@ -37,4 +37,7 @@ public interface FolderMediaRepository {
     // 주어진 미디어들이 (호출 시점 기준) 속해 있는 폴더 id를 중복 없이 반환한다.
     // 폴더 미지정 꺼내기에서 "영향받은 폴더" 목록을 만드는 용도.
     List<Long> findFolderIdsContainingMedia(List<Long> mediaIds);
+
+    // 미디어별로 담긴 폴더 목록. 어느 폴더에도 없으면 결과에 없다.
+    Map<Long, List<Long>> findFolderIdsByMedia(List<Long> mediaIds);
 }

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     ROOM_MEMBERSHIP_REQUIRED(403, "입장한 방만 구독할 수 있습니다"),
     NOT_ROOM_MEMBER(403, "입장한 방에서만 이용할 수 있습니다"),
     UPLOAD_NOT_ALLOWED(403, "방장만 업로드할 수 있는 방입니다"),
+    MEDIA_FORBIDDEN(403, "본인이 요청한 업로드가 아닙니다"),
 
     // 404 Not Found
     ROOM_NOT_FOUND(404, "존재하지 않는 방입니다: %s"),

--- a/backend/src/main/java/com/sssok/domain/file/StoredFile.java
+++ b/backend/src/main/java/com/sssok/domain/file/StoredFile.java
@@ -72,6 +72,11 @@ public class StoredFile {
         transitionTo(UploadStatus.PROCESSING);
     }
 
+    // 스토리지에 실제로 올라온 것이 발급 때 신고한 값과 같은지 확인한다.
+    public boolean matchesUploaded(long uploadedBytes, String uploadedMimeType) {
+        return fileSize.bytes() == uploadedBytes && mediaType.contentType().equals(uploadedMimeType);
+    }
+
     public void markReady() {
         transitionTo(UploadStatus.READY);
     }

--- a/backend/src/main/java/com/sssok/domain/file/UploadRejectionReason.java
+++ b/backend/src/main/java/com/sssok/domain/file/UploadRejectionReason.java
@@ -6,7 +6,9 @@ public enum UploadRejectionReason {
 
     FILE_TOO_LARGE("파일 용량이 허용 크기를 초과했습니다"),
     UNSUPPORTED_MEDIA_TYPE("이미지와 영상만 업로드할 수 있습니다"),
-    INVALID_PARAM("파일 정보가 올바르지 않습니다");
+    INVALID_PARAM("파일 정보가 올바르지 않습니다"),
+    UPLOAD_NOT_COMPLETED("업로드가 완료되지 않았습니다. 다시 시도해 주세요"),
+    MEDIA_NOT_FOUND("업로드 요청을 찾을 수 없습니다");
 
     private final String message;
 

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
@@ -35,6 +35,14 @@ public class FileRepositoryAdapter implements FileRepository {
     }
 
     @Override
+    public List<StoredFile> findAllByIdIn(List<Long> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return jpaRepository.findAllById(ids).stream().map(this::toDomain).toList();
+    }
+
+    @Override
     public List<Long> findExistingIds(List<Long> ids) {
         return jpaRepository.findAllById(ids).stream()
             .map(StoredFileJpaEntity::getId)

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
@@ -54,6 +54,16 @@ public class StoredFileJpaEntity extends BaseEntity {
     @Column(name = "retry_count", nullable = false)
     private int retryCount;
 
+    // 썸네일·최적화 워커가 채운다. 그 전까지는 비어 있다.
+    @Column(name = "width")
+    private Integer width;
+
+    @Column(name = "height")
+    private Integer height;
+
+    @Column(name = "duration_seconds")
+    private Integer durationSeconds;
+
     public StoredFileJpaEntity(Long id, Long roomId, Long uploaderId, String originalFileName,
                                String mediaType, Long fileSizeBytes, String storageKey, Long folderId,
                                String status, Instant createdAt, Instant reservedAt, int retryCount) {

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaJpaRepository.java
@@ -24,6 +24,10 @@ public interface FolderMediaJpaRepository extends JpaRepository<FolderMediaJpaEn
     @Query("select distinct f.mediaId from FolderMediaJpaEntity f where f.mediaId in :mediaIds")
     List<Long> findDistinctMediaIdsByMediaIdIn(@Param("mediaIds") List<Long> mediaIds);
 
+    // 미디어별로 어떤 폴더에 담겼는지. 미디어마다 따로 조회하면 N+1 이 된다.
+    @Query("select f.mediaId, f.folderId from FolderMediaJpaEntity f where f.mediaId in :mediaIds")
+    List<Object[]> findMediaFolderPairs(@Param("mediaIds") List<Long> mediaIds);
+
     @Query("select distinct f.folderId from FolderMediaJpaEntity f where f.mediaId in :mediaIds")
     List<Long> findDistinctFolderIdsByMediaIdIn(@Param("mediaIds") List<Long> mediaIds);
 

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/folder/FolderMediaRepositoryAdapter.java
@@ -68,6 +68,17 @@ public class FolderMediaRepositoryAdapter implements FolderMediaRepository {
     }
 
     @Override
+    public Map<Long, List<Long>> findFolderIdsByMedia(List<Long> mediaIds) {
+        if (mediaIds.isEmpty()) {
+            return Map.of();
+        }
+        return jpaRepository.findMediaFolderPairs(mediaIds).stream()
+            .collect(Collectors.groupingBy(
+                pair -> (Long) pair[0],
+                Collectors.mapping(pair -> (Long) pair[1], Collectors.toList())));
+    }
+
+    @Override
     public List<Long> findFolderIdsContainingMedia(List<Long> mediaIds) {
         return jpaRepository.findDistinctFolderIdsByMediaIdIn(mediaIds);
     }

--- a/backend/src/main/java/com/sssok/infrastructure/realtime/RoomEventJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/realtime/RoomEventJpaEntity.java
@@ -30,7 +30,8 @@ public class RoomEventJpaEntity extends BaseEntity {
     @Column(name = "event_type", nullable = false, length = 50)
     private String eventType;
 
-    @Column(name = "payload", nullable = false)
+    // 마이그레이션은 TEXT 인데 명시하지 않으면 VARCHAR(255) 로 잡혀, 긴 payload 가 잘린다.
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
     private String payload;
 
     public RoomEventJpaEntity(Long roomId, String eventType, String payload, Instant createdAt) {

--- a/backend/src/main/java/com/sssok/infrastructure/storage/R2FileStorageAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/storage/R2FileStorageAdapter.java
@@ -6,6 +6,7 @@ import com.sssok.infrastructure.config.R2Properties;
 import jakarta.annotation.PreDestroy;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -14,6 +15,9 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -47,6 +51,19 @@ public class R2FileStorageAdapter implements FileStoragePort {
                 .build())
             .url()
             .toString();
+    }
+
+    @Override
+    public Optional<UploadedObject> findUploaded(StorageKey storageKey) {
+        try {
+            HeadObjectResponse head = client().headObject(HeadObjectRequest.builder()
+                .bucket(properties.bucket())
+                .key(storageKey.value())
+                .build());
+            return Optional.of(new UploadedObject(head.contentLength(), head.contentType()));
+        } catch (NoSuchKeyException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/backend/src/main/java/com/sssok/presentation/api/media/CompleteUploadRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/CompleteUploadRequest.java
@@ -1,0 +1,9 @@
+package com.sssok.presentation.api.media;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record CompleteUploadRequest(
+    @Schema(description = "스토리지 PUT 을 성공한 미디어 ID 목록") List<Long> mediaIds
+) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/CompleteUploadResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/CompleteUploadResponse.java
@@ -1,0 +1,27 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.CompleteUploadResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record CompleteUploadResponse(
+    @Schema(description = "등록에 성공한 미디어 목록") List<MediaResponse> registered,
+    @Schema(description = "등록에 실패한 항목") List<FailedResponse> failed
+) {
+    public static CompleteUploadResponse from(CompleteUploadResult result) {
+        return new CompleteUploadResponse(
+            result.registered().stream().map(MediaResponse::from).toList(),
+            result.failed().stream()
+                .map(media -> new FailedResponse(media.mediaId(), media.code(), media.message()))
+                .toList()
+        );
+    }
+
+    public record FailedResponse(
+        Long mediaId,
+        @Schema(description = "UPLOAD_NOT_COMPLETED / FILE_TOO_LARGE / UNSUPPORTED_MEDIA_TYPE / MEDIA_NOT_FOUND")
+        String code,
+        String message
+    ) {
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaResponse.java
@@ -1,0 +1,32 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.MediaDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+
+@Schema(description = "방 미디어 공통 표현")
+public record MediaResponse(
+    Long mediaId,
+    @Schema(description = "IMAGE 또는 VIDEO") String type,
+    String fileName,
+    String mimeType,
+    long size,
+    @Schema(description = "워커가 만들기 전까지 null") String thumbnailUrl,
+    @Schema(description = "워커가 만들기 전까지 null") String originalUrl,
+    Integer width,
+    Integer height,
+    @Schema(description = "영상 재생 시간(초)") Integer duration,
+    @Schema(description = "이 미디어가 담긴 폴더 목록") List<Long> folderIds,
+    Long uploaderId,
+    String uploaderName,
+    @Schema(description = "RESERVED / PROCESSING / READY / FAILED") String status,
+    Instant uploadedAt
+) {
+    public static MediaResponse from(MediaDetail detail) {
+        return new MediaResponse(detail.mediaId(), detail.type(), detail.fileName(),
+            detail.mimeType(), detail.size(), detail.thumbnailUrl(), detail.originalUrl(),
+            detail.width(), detail.height(), detail.duration(), detail.folderIds(),
+            detail.uploaderId(), detail.uploaderName(), detail.status(), detail.uploadedAt());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaUploadController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaUploadController.java
@@ -1,5 +1,7 @@
 package com.sssok.presentation.api.media;
 
+import com.sssok.application.media.CompleteUploadResult;
+import com.sssok.application.media.CompleteUploadService;
 import com.sssok.application.media.IssueUploadUrlsResult;
 import com.sssok.application.media.IssueUploadUrlsService;
 import com.sssok.application.media.UploadFileCommand;
@@ -10,10 +12,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "미디어 업로드", description = "서명 URL 발급 → 스토리지 직접 PUT → 완료 등록으로 이어지는 업로드 파이프라인")
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MediaUploadController {
 
     private final IssueUploadUrlsService issueUploadUrlsService;
+    private final CompleteUploadService completeUploadService;
 
     @Operation(
         summary = "업로드 URL 발급",
@@ -49,5 +54,24 @@ public class MediaUploadController {
         return ApiResponse.of(IssueUploadUrlsResponse.from(result));
     }
 
+    @Operation(
+        summary = "업로드 완료 등록",
+        description = "스토리지 PUT을 마친 미디어를 방 미디어로 등록한다. 서버가 스토리지에 실물이 있는지 "
+            + "직접 확인하고, 발급 때 신고한 크기·MIME과 다르면 거부한다. 통과한 미디어는 "
+            + "RESERVED에서 PROCESSING으로 넘어가고 SSE media.created 이벤트가 나간다. "
+            + "항목별 실패는 failed로 내려주고 요청 전체를 실패시키지 않는다. "
+            + "mediaIds가 비어 있으면 400, 남이 예약한 mediaId가 섞여 있으면 403이 난다."
+    )
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<CompleteUploadResponse> completeUpload(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @RequestBody CompleteUploadRequest request
+    ) {
+        CompleteUploadResult result =
+            completeUploadService.complete(roomId, memberId, request.mediaIds());
+        return ApiResponse.of(CompleteUploadResponse.from(result));
+    }
 
 }

--- a/backend/src/main/resources/db/migration/V15__add_media_dimension_columns.sql
+++ b/backend/src/main/resources/db/migration/V15__add_media_dimension_columns.sql
@@ -1,0 +1,5 @@
+-- #76 완료 등록: 썸네일·최적화 워커가 채울 자리를 미리 만든다.
+-- 등록 시점에는 알 수 없어 비어 있고, 워커가 처리한 뒤 채운다.
+ALTER TABLE stored_file ADD COLUMN width INT;
+ALTER TABLE stored_file ADD COLUMN height INT;
+ALTER TABLE stored_file ADD COLUMN duration_seconds INT;

--- a/backend/src/test/java/com/sssok/application/media/CompleteUploadServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/CompleteUploadServiceTest.java
@@ -1,0 +1,186 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.media.exception.InvalidUploadParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FileStoragePort.UploadedObject;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import com.sssok.domain.room.Room;
+import com.sssok.infrastructure.realtime.RoomEventJpaEntity;
+import com.sssok.infrastructure.realtime.RoomEventJpaRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// Repository + Service 통합 테스트 (H2). 스토리지에 무엇이 올라와 있는지는 목으로 정해두고,
+// 그 결과에 따라 등록이 갈리는지를 본다.
+@SpringBootTest
+@ActiveProfiles("test")
+class CompleteUploadServiceTest {
+
+    private static final long SIZE = 1024L;
+    private static final String MIME = "image/jpeg";
+
+    @Autowired
+    CompleteUploadService completeUploadService;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    @MockitoBean
+    RoomPermissionPort roomPermissionPort;
+
+    @Autowired
+    RoomEventJpaRepository roomEventJpaRepository;
+
+    private Long hostId;
+    private Long roomId;
+
+    @BeforeEach
+    void setUp() {
+        hostId = anonymousAuthService.authenticate("가현").userId();
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
+        roomId = room.getId();
+        given(roomPermissionPort.canUpload(any(), any())).willReturn(true);
+        given(fileStoragePort.presignPut(any(), anyString(), any(Duration.class))).willReturn("url");
+    }
+
+    private StoredFile reserved(Long uploaderId) {
+        return fileRepository.save(StoredFile.reserve(roomId, uploaderId, "a.jpg", MIME,
+            new FileSize(SIZE), Instant.now()));
+    }
+
+    private void uploadedAs(long size, String mimeType) {
+        given(fileStoragePort.findUploaded(any()))
+            .willReturn(Optional.of(new UploadedObject(size, mimeType)));
+    }
+
+    @Test
+    void 실물이_신고값과_같으면_등록되고_처리중이_된다() {
+        StoredFile file = reserved(hostId);
+        uploadedAs(SIZE, MIME);
+
+        CompleteUploadResult result = completeUploadService.complete(roomId, hostId, List.of(file.getId()));
+
+        assertThat(result.registered()).hasSize(1);
+        assertThat(result.registered().get(0).status()).isEqualTo("PROCESSING");
+        assertThat(fileRepository.findById(file.getId()).orElseThrow().getStatus())
+            .isEqualTo(UploadStatus.PROCESSING);
+    }
+
+    @Test
+    void 스토리지에_실물이_없으면_등록되지_않는다() {
+        StoredFile file = reserved(hostId);
+        given(fileStoragePort.findUploaded(any())).willReturn(Optional.empty());
+
+        CompleteUploadResult result = completeUploadService.complete(roomId, hostId, List.of(file.getId()));
+
+        // 올리지 않고 등록만 하는 위조를 막는다.
+        assertThat(result.registered()).isEmpty();
+        assertThat(result.failed().get(0).code()).isEqualTo("UPLOAD_NOT_COMPLETED");
+        assertThat(fileRepository.findById(file.getId()).orElseThrow().getStatus())
+            .isEqualTo(UploadStatus.RESERVED);
+    }
+
+    @Test
+    void 실제_크기가_신고값과_다르면_거부한다() {
+        StoredFile file = reserved(hostId);
+        uploadedAs(SIZE * 100, MIME);
+
+        CompleteUploadResult result = completeUploadService.complete(roomId, hostId, List.of(file.getId()));
+
+        assertThat(result.failed().get(0).code()).isEqualTo("FILE_TOO_LARGE");
+    }
+
+    @Test
+    void 실제_MIME_이_신고값과_다르면_거부한다() {
+        StoredFile file = reserved(hostId);
+        uploadedAs(SIZE, "video/mp4");
+
+        CompleteUploadResult result = completeUploadService.complete(roomId, hostId, List.of(file.getId()));
+
+        assertThat(result.failed().get(0).code()).isEqualTo("UNSUPPORTED_MEDIA_TYPE");
+    }
+
+    @Test
+    void 없는_미디어는_실패로_보고하고_나머지는_등록한다() {
+        StoredFile file = reserved(hostId);
+        uploadedAs(SIZE, MIME);
+
+        CompleteUploadResult result =
+            completeUploadService.complete(roomId, hostId, List.of(file.getId(), -1L));
+
+        assertThat(result.registered()).hasSize(1);
+        assertThat(result.failed().get(0).code()).isEqualTo("MEDIA_NOT_FOUND");
+    }
+
+    @Test
+    void 남이_예약한_미디어가_섞여있으면_요청_전체를_막는다() {
+        Long guestId = anonymousAuthService.authenticate("민수").userId();
+        StoredFile mine = reserved(hostId);
+        StoredFile others = reserved(guestId);
+        uploadedAs(SIZE, MIME);
+
+        assertThatThrownBy(() ->
+            completeUploadService.complete(roomId, hostId, List.of(mine.getId(), others.getId())))
+            .isInstanceOf(MediaForbiddenException.class);
+    }
+
+    @Test
+    void 등록에_성공하면_이벤트를_발행한다() {
+        StoredFile file = reserved(hostId);
+        uploadedAs(SIZE, MIME);
+
+        completeUploadService.complete(roomId, hostId, List.of(file.getId()));
+
+        List<RoomEventJpaEntity> events =
+            roomEventJpaRepository.findByRoomIdAndIdGreaterThanOrderById(roomId, 0L);
+        assertThat(events).extracting(RoomEventJpaEntity::getEventType).contains("media.created");
+    }
+
+    @Test
+    void 등록에_실패하면_이벤트를_발행하지_않는다() {
+        StoredFile file = reserved(hostId);
+        given(fileStoragePort.findUploaded(any())).willReturn(Optional.empty());
+
+        completeUploadService.complete(roomId, hostId, List.of(file.getId()));
+
+        assertThat(roomEventJpaRepository.findByRoomIdAndIdGreaterThanOrderById(roomId, 0L))
+            .extracting(RoomEventJpaEntity::getEventType)
+            .doesNotContain("media.created");
+    }
+
+    @Test
+    void 미디어_목록이_비어있으면_예외() {
+        assertThatThrownBy(() -> completeUploadService.complete(roomId, hostId, List.of()))
+            .isInstanceOf(InvalidUploadParamException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/MediaEventAfterCommitTest.java
+++ b/backend/src/test/java/com/sssok/application/media/MediaEventAfterCommitTest.java
@@ -1,0 +1,92 @@
+package com.sssok.application.media;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.given;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.port.out.EventPublisherPort;
+import com.sssok.application.port.out.EventSubscriberPort;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.room.Room;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+// 등록 트랜잭션이 롤백되면 SSE 도 나가면 안 된다.
+// 커밋 전에 보내면 클라이언트는 서버에 없는 사진을 목록에 그린다.
+@SpringBootTest
+@ActiveProfiles("test")
+class MediaEventAfterCommitTest {
+
+    @Autowired
+    MediaRegistrar mediaRegistrar;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @MockitoBean
+    FileRepository fileRepository;
+
+    @MockitoBean
+    RoomPermissionPort roomPermissionPort;
+
+    // 실제 발행 지점을 목으로 잡는다. room_events 행은 롤백되지만 이미 나간 SSE 는 되돌아가지 않으므로,
+    // "발행이 호출됐는가" 를 봐야 커밋 전 발행을 잡을 수 있다.
+    @MockitoBean
+    EventPublisherPort eventPublisherPort;
+
+    @MockitoBean
+    EventSubscriberPort eventSubscriberPort;
+
+    private Long roomId;
+    private StoredFile file;
+
+    @BeforeEach
+    void setUp() {
+        Long hostId = anonymousAuthService.authenticate("가현").userId();
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
+        roomId = room.getId();
+        file = StoredFile.reserve(roomId, hostId, "a.jpg", "image/jpeg",
+            new FileSize(1024L), Instant.now());
+    }
+
+    // 이 메서드는 스프링 테스트 기본값에 따라 끝에 롤백된다. register 는 그 트랜잭션에 참여하므로
+    // 커밋이 일어나지 않고, 따라서 발행도 일어나면 안 된다.
+    // 트랜잭션 안에서 직접 발행하면 이 단언이 깨진다.
+    @Test
+    @Transactional
+    void 커밋되지_않으면_이벤트가_나가지_않는다() {
+        given(fileRepository.save(any())).willAnswer(call -> call.getArgument(0));
+
+        mediaRegistrar.register(roomId, List.of(file), "가현");
+
+        verify(eventPublisherPort, never()).publish(any(), anyString(), any());
+    }
+
+    @Test
+    void 저장에_성공하면_커밋된_뒤에_이벤트가_나간다() {
+        given(fileRepository.save(any())).willAnswer(call -> call.getArgument(0));
+
+        mediaRegistrar.register(roomId, List.of(file), "가현");
+
+        verify(eventPublisherPort).publish(any(), eq("media.created"), any());
+    }
+
+}

--- a/backend/src/test/java/com/sssok/domain/file/UploadReservationTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/UploadReservationTest.java
@@ -57,4 +57,29 @@ class UploadReservationTest {
     }
 
 
+    @Nested
+    class 실제_업로드_대조 {
+
+        @Test
+        void 크기와_MIME_이_모두_같아야_통과한다() {
+            StoredFile file = reserved();
+
+            assertThat(file.matchesUploaded(FileSize.ofMegabytes(1).bytes(), "image/png")).isTrue();
+        }
+
+        @Test
+        void 크기가_다르면_거부한다() {
+            StoredFile file = reserved();
+
+            assertThat(file.matchesUploaded(FileSize.ofMegabytes(2).bytes(), "image/png")).isFalse();
+        }
+
+        @Test
+        void MIME_이_다르면_거부한다() {
+            StoredFile file = reserved();
+
+            // 신고는 png 로 하고 실제로는 다른 것을 올리는 위조를 막는다.
+            assertThat(file.matchesUploaded(FileSize.ofMegabytes(1).bytes(), "video/mp4")).isFalse();
+        }
+    }
 }

--- a/backend/src/test/java/com/sssok/infrastructure/storage/R2FileStorageAdapterTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/storage/R2FileStorageAdapterTest.java
@@ -2,6 +2,7 @@ package com.sssok.infrastructure.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sssok.application.port.out.FileStoragePort.UploadedObject;
 import com.sssok.domain.file.MediaType;
 import com.sssok.domain.file.StorageKey;
 import com.sssok.infrastructure.config.R2Properties;
@@ -17,6 +18,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -70,13 +72,18 @@ class R2FileStorageAdapterTest {
     }
 
     @Test
-    void 발급한_URL_로_실제_업로드가_된다() {
+    void 발급한_URL_로_올리고_올라온_것을_되읽는다() {
         R2FileStorageAdapter adapter = adapter();
         StorageKey key = StorageKey.generate(1L, MediaType.PNG);
         String url = adapter.presignPut(key, "image/png", Duration.ofMinutes(10));
 
         assertThat(put(url, "image/png")).isEqualTo(200);
         uploaded = key;
+
+        Optional<UploadedObject> found = adapter.findUploaded(key);
+        assertThat(found).isPresent();
+        assertThat(found.get().sizeBytes()).isEqualTo(BODY.length);
+        assertThat(found.get().contentType()).isEqualTo("image/png");
     }
 
     @Test
@@ -89,6 +96,14 @@ class R2FileStorageAdapterTest {
         assertThat(put(url, null)).isEqualTo(403);
     }
 
+    @Test
+    void 올리지_않은_키는_비어_있다() {
+        Optional<UploadedObject> found =
+            adapter().findUploaded(StorageKey.generate(1L, MediaType.PNG));
+
+        // 완료 등록이 이 결과로 위조를 걸러낸다.
+        assertThat(found).isEmpty();
+    }
 
     @Test
     void 없는_키를_지워도_실패하지_않는다() {

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadApiTest.java
@@ -14,12 +14,14 @@ import com.sssok.application.auth.AnonymousAuthService;
 import com.sssok.application.auth.AuthResult;
 import com.sssok.application.folder.CreateFolderService;
 import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FileStoragePort.UploadedObject;
 import com.sssok.application.room.CreateRoomService;
 import com.sssok.application.room.JoinRoomService;
 import com.sssok.domain.folder.Folder;
 import com.sssok.domain.room.Room;
 import com.sssok.support.PostgresContainerSupport;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +94,44 @@ class MediaUploadApiTest extends PostgresContainerSupport {
         return root.path("data").path("issued").get(0).path("mediaId").asLong();
     }
 
+    @Test
+    void 발급부터_완료_등록까지_이어진다() throws Exception {
+        String issued = issue(oneImage()).andExpect(status().isOk()).andReturn()
+            .getResponse().getContentAsString();
+        Long mediaId = issuedMediaId(issued);
+        given(fileStoragePort.findUploaded(any()))
+            .willReturn(Optional.of(new UploadedObject(SIZE, MIME)));
 
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media", roomId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[%d]}".formatted(mediaId)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.registered[0].mediaId").value(mediaId))
+            .andExpect(jsonPath("$.data.registered[0].status").value("PROCESSING"))
+            .andExpect(jsonPath("$.data.registered[0].type").value("IMAGE"))
+            .andExpect(jsonPath("$.data.registered[0].uploaderName").value("가현"));
+    }
+
+    @Test
+    void 폴더를_지정하면_발급과_동시에_담긴다() throws Exception {
+        Folder folder = createFolderService.create(roomId, "1일차");
+        String body = "{\"files\":[{\"fileName\":\"a.jpg\",\"mimeType\":\"%s\",\"size\":%d}],\"folderIds\":[%d]}"
+            .formatted(MIME, SIZE, folder.getId());
+
+        String issued = issue(body).andExpect(status().isOk()).andReturn()
+            .getResponse().getContentAsString();
+        Long mediaId = issuedMediaId(issued);
+        given(fileStoragePort.findUploaded(any()))
+            .willReturn(Optional.of(new UploadedObject(SIZE, MIME)));
+
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media", roomId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[%d]}".formatted(mediaId)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.registered[0].folderIds[0]").value(folder.getId()));
+    }
 
     @Test
     void 없는_폴더를_지정하면_404() throws Exception {
@@ -104,6 +143,20 @@ class MediaUploadApiTest extends PostgresContainerSupport {
             .andExpect(jsonPath("$.code").value("FOLDER_NOT_FOUND"));
     }
 
+    @Test
+    void 올리지_않고_등록하면_실패로_보고된다() throws Exception {
+        String issued = issue(oneImage()).andReturn().getResponse().getContentAsString();
+        Long mediaId = issuedMediaId(issued);
+        given(fileStoragePort.findUploaded(any())).willReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media", roomId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[%d]}".formatted(mediaId)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.registered").isEmpty())
+            .andExpect(jsonPath("$.data.failed[0].code").value("UPLOAD_NOT_COMPLETED"));
+    }
 
 
 

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadControllerTest.java
@@ -8,11 +8,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.sssok.application.media.CompleteUploadResult;
+import com.sssok.application.media.CompleteUploadService;
+import com.sssok.application.media.FailedMedia;
 import com.sssok.application.media.IssueUploadUrlsResult;
 import com.sssok.application.media.IssueUploadUrlsService;
+import com.sssok.application.media.MediaDetail;
 import com.sssok.application.media.RejectedFile;
 import com.sssok.application.media.UploadUrl;
 import com.sssok.application.media.exception.InvalidUploadParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
 import com.sssok.application.media.exception.UploadNotAllowedException;
 import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
@@ -54,6 +59,9 @@ class MediaUploadControllerTest {
     IssueUploadUrlsService issueUploadUrlsService;
 
     @MockitoBean
+    CompleteUploadService completeUploadService;
+
+    @MockitoBean
     TokenProvider tokenProvider;
 
     @MockitoBean
@@ -79,6 +87,13 @@ class MediaUploadControllerTest {
 
     private ResultActions issueUploadUrls(String body) throws Exception {
         return mockMvc.perform(post("/api/v1/rooms/{roomId}/media/upload-urls", ROOM_ID)
+            .header("Authorization", BEARER)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body));
+    }
+
+    private ResultActions completeUpload(String body) throws Exception {
+        return mockMvc.perform(post("/api/v1/rooms/{roomId}/media", ROOM_ID)
             .header("Authorization", BEARER)
             .contentType(MediaType.APPLICATION_JSON)
             .content(body));
@@ -121,7 +136,31 @@ class MediaUploadControllerTest {
             .andExpect(jsonPath("$.code").value("UPLOAD_NOT_ALLOWED"));
     }
 
+    @Test
+    void 완료_등록하면_201과_registered_failed_를_반환한다() throws Exception {
+        MediaDetail detail = new MediaDetail(MEDIA_ID, "IMAGE", "a.jpg", "image/jpeg", 1024L,
+            null, null, null, null, null, List.of(31L), MEMBER_ID, "로지", "PROCESSING", Instant.now());
+        CompleteUploadResult result = new CompleteUploadResult(List.of(detail),
+            List.of(FailedMedia.of(5013L, UploadRejectionReason.UPLOAD_NOT_COMPLETED)));
+        given(completeUploadService.complete(anyLong(), anyLong(), anyList())).willReturn(result);
 
+        completeUpload("{\"mediaIds\":[5012,5013]}")
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.registered[0].mediaId").value(MEDIA_ID))
+            .andExpect(jsonPath("$.data.registered[0].status").value("PROCESSING"))
+            .andExpect(jsonPath("$.data.registered[0].folderIds[0]").value(31))
+            .andExpect(jsonPath("$.data.failed[0].code").value("UPLOAD_NOT_COMPLETED"));
+    }
+
+    @Test
+    void 남의_예약을_등록하면_403과_MEDIA_FORBIDDEN() throws Exception {
+        given(completeUploadService.complete(anyLong(), anyLong(), anyList()))
+            .willThrow(new MediaForbiddenException());
+
+        completeUpload("{\"mediaIds\":[5012]}")
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("MEDIA_FORBIDDEN"));
+    }
 
 
 


### PR DESCRIPTION
## 작업 내용
- 업로드 완료 등록 API(POST /api/v1/rooms/{roomId}/media)를 main에 랜딩한다. 원래 PR #91/#92를 거쳐
  media-complete/media-reissue 브랜치에 이미 리뷰·머지되어 있었으나, 그 브랜치들이 main에 직접
  PR된 적이 없어 지금 처음 main 경로로 들어간다.
- 완료 등록 시 스토리지 왕복 동안 DB 커넥션을 잡고 있던 문제, 폴더 조회 N+1 문제에 대한 후속 수정
  (원 PR #92의 fix 커밋)도 함께 포함한다 — 완료 등록 로직 자체에 대한 수정이라 분리하지 않았다.
- CI가 GitHub 쪽 오류로 멈췄을 때 수동 재실행할 수 있도록 workflow_dispatch를 추가하는 작은 변경도
  포함되어 있다 (무관한 tooling 변경, 참고용).

## 관련 이슈
관련: #76 (이미 closed 상태. 이 PR은 해당 이슈 범위 중 완료 등록 API를 main에 최종 랜딩하는 것)

## 작업 영역
- [x] Backend

## 변경 사항
- [x] feat(backend): 업로드 완료 등록 API 구현
- [x] fix(backend): 완료 등록의 트랜잭션 범위와 이벤트 발행 시점 교정
- [x] ci(common): CI 수동 실행을 위한 workflow_dispatch 추가

## 테스트
- [x] 단위 테스트 작성/통과 (관련 테스트 클래스 로컬 실행 — BUILD SUCCESSFUL)
- [ ] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
- media-complete/media-reissue 브랜치는 서로 내용이 동일해져 있어(재발급 커밋이 완료 등록 브랜치에도
  합쳐짐), 재발급 API는 이 PR에서 제외하고 cherry-pick으로 새 브랜치를 만들어 분리했다. 재발급 API는
  이 PR 위에 쌓인 후속 PR로 별도 진행한다.
- 커밋 해시는 cherry-pick으로 바뀌었지만 작성자(gahyeonnni)는 원본 그대로 유지했다.
