### PR TITLE
feat: 업로드 URL 재발급 API 구현 - #76

### DIFF
--- a/backend/src/main/java/com/sssok/application/media/ReissueUploadUrlService.java
+++ b/backend/src/main/java/com/sssok/application/media/ReissueUploadUrlService.java
@@ -1,0 +1,70 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.InvalidUploadParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.UploadNotAllowedException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.exception.InvalidFileSizeException;
+import com.sssok.infrastructure.config.UploadProperties;
+import java.time.Instant;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 최초 발급 이후 방 권한이 바뀌었을 수 있어 여기서 다시 검사한다.
+@Service
+@RequiredArgsConstructor
+public class ReissueUploadUrlService {
+
+    private static final String PUT = "PUT";
+
+    private final FileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+    private final RoomPermissionPort roomPermissionPort;
+    private final UploadProperties uploadProperties;
+
+    @Transactional
+    public ReissuedUploadUrl reissue(Long roomId, Long mediaId, Long requesterId, Long newSize) {
+        StoredFile file = fileRepository.findById(mediaId)
+            .filter(found -> found.getRoomId().equals(roomId))
+            .orElseThrow(MediaNotFoundException::new);
+
+        // 방장이라도 남의 예약은 재발급하지 못한다.
+        if (!file.isUploadedBy(requesterId)) {
+            throw new MediaForbiddenException();
+        }
+        if (!roomPermissionPort.canUpload(roomId, requesterId)) {
+            throw new UploadNotAllowedException();
+        }
+        if (newSize != null) {
+            changeSize(file, newSize);
+        }
+
+        file.reissueUploadUrl(uploadProperties.maxRetryCount(), Instant.now());
+        StoredFile saved = fileRepository.save(file);
+
+        String contentType = saved.getMediaType().contentType();
+        String url = fileStoragePort.presignPut(
+            saved.getStorageKey(), contentType, uploadProperties.presignedUrlTtl());
+
+        return new ReissuedUploadUrl(saved.getId(), saved.getOriginalFileName(), url, PUT,
+            Map.of("Content-Type", contentType),
+            (int) uploadProperties.presignedUrlTtl().toSeconds(),
+            saved.getRetryCount(), uploadProperties.maxRetryCount());
+    }
+
+    // 재압축해서 다시 올리는 경우. 0 이하는 400, 한도 초과는 413 으로 갈린다.
+    private void changeSize(StoredFile file, Long newSize) {
+        try {
+            file.changeFileSize(new FileSize(newSize));
+        } catch (InvalidFileSizeException e) {
+            throw new InvalidUploadParamException("파일 크기가 올바르지 않습니다");
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/ReissuedUploadUrl.java
+++ b/backend/src/main/java/com/sssok/application/media/ReissuedUploadUrl.java
@@ -1,0 +1,8 @@
+package com.sssok.application.media;
+
+import java.util.Map;
+
+public record ReissuedUploadUrl(Long mediaId, String fileName, String uploadUrl, String method,
+                                Map<String, String> headers, int expiresIn,
+                                int retryCount, int maxRetryCount) {
+}

--- a/backend/src/main/java/com/sssok/application/media/exception/MediaNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/media/exception/MediaNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.media.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class MediaNotFoundException extends SssOkException {
+
+    public MediaNotFoundException() {
+        super(ErrorCode.MEDIA_NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     ROOM_NOT_FOUND(404, "존재하지 않는 방입니다: %s"),
     LINK_CODE_NOT_FOUND(404, "유효하지 않은 코드입니다"),
     FOLDER_NOT_FOUND(404, "존재하지 않는 폴더입니다: %s"),
+    MEDIA_NOT_FOUND(404, "업로드 요청을 찾을 수 없습니다"),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(405, "지원하지 않는 요청 방식입니다"),
@@ -45,6 +46,7 @@ public enum ErrorCode {
     // 409 Conflict
     ROOM_MODIFIED(409, "방 정보가 방금 변경되었습니다. 다시 시도해주세요"),
     DUPLICATE_FOLDER_NAME(409, "이미 같은 이름의 폴더가 있습니다"),
+    UPLOAD_ALREADY_COMPLETED(409, "이미 업로드가 완료된 파일입니다"),
 
     // 410 Gone
     ROOM_EXPIRED(410, "이미 사라진 방입니다"),
@@ -54,6 +56,9 @@ public enum ErrorCode {
     // 413 Payload Too Large
     FILE_SIZE_EXCEEDED(413, "%s 파일은 최대 %d바이트까지 업로드할 수 있습니다. (요청: %d바이트)"),
     FILE_TOO_LARGE(413, "파일 용량이 허용 크기를 초과했습니다"),
+
+    // 429 Too Many Requests
+    UPLOAD_RETRY_EXCEEDED(429, "재시도 횟수를 초과했습니다. 처음부터 다시 올려주세요"),
 
     // 415 Unsupported Media Type
     UNSUPPORTED_MEDIA_TYPE(415, "지원하지 않는 요청 형식입니다"),

--- a/backend/src/main/java/com/sssok/domain/file/StoredFile.java
+++ b/backend/src/main/java/com/sssok/domain/file/StoredFile.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 
 import com.sssok.domain.file.exception.FileSizeExceededException;
 import com.sssok.domain.file.exception.IllegalUploadStatusException;
+import com.sssok.domain.file.exception.UploadAlreadyCompletedException;
+import com.sssok.domain.file.exception.UploadRetryExceededException;
 import lombok.Getter;
 
 @Getter
@@ -14,7 +16,7 @@ public class StoredFile {
     private final Long uploaderId;
     private final String originalFileName;
     private final MediaType mediaType;
-    private final FileSize fileSize;
+    private FileSize fileSize;
     private final StorageKey storageKey;
     private final Instant createdAt;
 
@@ -70,6 +72,25 @@ public class StoredFile {
 
     public void startProcessing() {
         transitionTo(UploadStatus.PROCESSING);
+    }
+
+    // 이미 올라간 파일을 덮어쓰지 못하게 RESERVED·FAILED 에서만 허용한다.
+    // 정리 배치 기준 시각을 지금으로 미뤄, 재시도 중인 파일이 회수되지 않게 한다.
+    public void reissueUploadUrl(int maxRetryCount, Instant now) {
+        if (!status.canReissueUploadUrl()) {
+            throw new UploadAlreadyCompletedException();
+        }
+        if (retryCount >= maxRetryCount) {
+            throw new UploadRetryExceededException(maxRetryCount);
+        }
+        retryCount++;
+        reservedAt = now;
+    }
+
+    // 재압축해서 다시 올리는 경우에만 크기가 바뀐다.
+    public void changeFileSize(FileSize newFileSize) {
+        validateSize(mediaType, newFileSize);
+        this.fileSize = newFileSize;
     }
 
     // 스토리지에 실제로 올라온 것이 발급 때 신고한 값과 같은지 확인한다.

--- a/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
+++ b/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
@@ -14,6 +14,11 @@ public enum UploadStatus {
     private static final Set<UploadStatus> FROM_PROCESSING = Set.of(READY, FAILED);
     private static final Set<UploadStatus> FROM_FAILED = Set.of(PROCESSING);
 
+    // 서명 URL 을 다시 발급해도 되는 상태. 이미 올라간 파일을 덮어쓰지 못하게 막는 기준이다.
+    public boolean canReissueUploadUrl() {
+        return this == RESERVED || this == FAILED;
+    }
+
     public boolean canTransitionTo(UploadStatus next) {
         return switch (this) {
             case RESERVED -> FROM_RESERVED.contains(next);

--- a/backend/src/main/java/com/sssok/domain/file/exception/UploadAlreadyCompletedException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/UploadAlreadyCompletedException.java
@@ -1,0 +1,11 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class UploadAlreadyCompletedException extends SssOkException {
+
+    public UploadAlreadyCompletedException() {
+        super(ErrorCode.UPLOAD_ALREADY_COMPLETED);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/exception/UploadRetryExceededException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/UploadRetryExceededException.java
@@ -1,0 +1,11 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class UploadRetryExceededException extends SssOkException {
+
+    public UploadRetryExceededException(int maxRetryCount) {
+        super(ErrorCode.UPLOAD_RETRY_EXCEEDED);
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/UploadProperties.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/UploadProperties.java
@@ -4,5 +4,5 @@ import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "upload")
-public record UploadProperties(Duration presignedUrlTtl) {
+public record UploadProperties(Duration presignedUrlTtl, int maxRetryCount) {
 }

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaUploadController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaUploadController.java
@@ -4,6 +4,8 @@ import com.sssok.application.media.CompleteUploadResult;
 import com.sssok.application.media.CompleteUploadService;
 import com.sssok.application.media.IssueUploadUrlsResult;
 import com.sssok.application.media.IssueUploadUrlsService;
+import com.sssok.application.media.ReissueUploadUrlService;
+import com.sssok.application.media.ReissuedUploadUrl;
 import com.sssok.application.media.UploadFileCommand;
 import com.sssok.presentation.api.common.ApiResponse;
 import com.sssok.presentation.auth.AuthMember;
@@ -28,6 +30,7 @@ public class MediaUploadController {
 
     private final IssueUploadUrlsService issueUploadUrlsService;
     private final CompleteUploadService completeUploadService;
+    private final ReissueUploadUrlService reissueUploadUrlService;
 
     @Operation(
         summary = "업로드 URL 발급",
@@ -74,4 +77,25 @@ public class MediaUploadController {
         return ApiResponse.of(CompleteUploadResponse.from(result));
     }
 
+    @Operation(
+        summary = "업로드 URL 재발급",
+        description = "서명 URL이 만료됐거나 전송이 실패했을 때 같은 미디어 ID로 새 URL을 받는다. "
+            + "업로더 본인만 가능하며 방장도 남의 예약은 재발급하지 못한다. "
+            + "재발급 시점에 방 만료와 업로드 권한을 다시 검사한다. "
+            + "이미 올라간 파일을 덮어쓰지 못하도록 RESERVED·FAILED 상태에서만 허용하고, "
+            + "PROCESSING·READY면 409가 난다. 재시도 횟수가 한도를 넘으면 429가 나며 "
+            + "이때는 처음부터 다시 올려야 한다. 바디는 파일 크기가 바뀐 경우에만 보낸다."
+    )
+    @PostMapping("/{mediaId}/upload-url")
+    public ApiResponse<ReissueUploadUrlResponse> reissueUploadUrl(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "발급 응답의 mediaId") @PathVariable Long mediaId,
+        @RequestBody(required = false) ReissueUploadUrlRequest request
+    ) {
+        Long newSize = request == null ? null : request.size();
+        ReissuedUploadUrl url =
+            reissueUploadUrlService.reissue(roomId, mediaId, memberId, newSize);
+        return ApiResponse.of(ReissueUploadUrlResponse.from(url));
+    }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/media/ReissueUploadUrlRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/ReissueUploadUrlRequest.java
@@ -1,0 +1,9 @@
+package com.sssok.presentation.api.media;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReissueUploadUrlRequest(
+    @Schema(description = "재압축해서 크기가 바뀐 경우에만 보낸다. 생략하면 최초 발급 값을 그대로 쓴다")
+    Long size
+) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/ReissueUploadUrlResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/ReissueUploadUrlResponse.java
@@ -1,0 +1,21 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.ReissuedUploadUrl;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+public record ReissueUploadUrlResponse(
+    @Schema(description = "미디어 ID. 재발급해도 바뀌지 않는다") Long mediaId,
+    String fileName,
+    @Schema(description = "새로 발급된 서명 URL") String uploadUrl,
+    String method,
+    Map<String, String> headers,
+    @Schema(description = "서명 URL 유효 시간(초)") int expiresIn,
+    @Schema(description = "이번 호출을 포함한 누적 재발급 횟수") int retryCount,
+    @Schema(description = "허용 최대 재발급 횟수") int maxRetryCount
+) {
+    public static ReissueUploadUrlResponse from(ReissuedUploadUrl url) {
+        return new ReissueUploadUrlResponse(url.mediaId(), url.fileName(), url.uploadUrl(),
+            url.method(), url.headers(), url.expiresIn(), url.retryCount(), url.maxRetryCount());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,6 +48,8 @@ upload:
   image-max-size: 10MB
   video-max-size: 1GB
   presigned-url-ttl: 10m
+  # 서명 URL 무한 발급을 막는 상한. 넘으면 처음부터 다시 올려야 한다.
+  max-retry-count: 5
 
 media:
   resize-target-width: 1600

--- a/backend/src/test/java/com/sssok/application/media/ReissueUploadUrlServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/ReissueUploadUrlServiceTest.java
@@ -1,0 +1,197 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.media.exception.InvalidUploadParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.UploadNotAllowedException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.exception.FileSizeExceededException;
+import com.sssok.domain.file.exception.UploadAlreadyCompletedException;
+import com.sssok.domain.file.exception.UploadRetryExceededException;
+import com.sssok.domain.room.Room;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// Repository + Service 통합 테스트 (H2).
+@SpringBootTest
+@ActiveProfiles("test")
+class ReissueUploadUrlServiceTest {
+
+    private static final long SIZE = 1024L;
+    private static final String MIME = "image/jpeg";
+    private static final int MAX_RETRY = 5;
+
+    @Autowired
+    ReissueUploadUrlService reissueUploadUrlService;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    @MockitoBean
+    RoomPermissionPort roomPermissionPort;
+
+    private Long hostId;
+    private Long roomId;
+
+    @BeforeEach
+    void setUp() {
+        hostId = anonymousAuthService.authenticate("가현").userId();
+        Room room = createRoomService.create(hostId, "우테코 회식", null, null).room();
+        roomId = room.getId();
+        given(roomPermissionPort.canUpload(any(), any())).willReturn(true);
+        given(fileStoragePort.presignPut(any(), anyString(), any(Duration.class))).willReturn("new-url");
+    }
+
+    private StoredFile reserved(Long uploaderId) {
+        return fileRepository.save(StoredFile.reserve(roomId, uploaderId, "a.jpg", MIME,
+            new FileSize(SIZE), Instant.now()));
+    }
+
+    @Test
+    void 같은_미디어_ID로_새_URL을_받는다() {
+        StoredFile file = reserved(hostId);
+
+        ReissuedUploadUrl result =
+            reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null);
+
+        assertThat(result.mediaId()).isEqualTo(file.getId());
+        assertThat(result.fileName()).isEqualTo("a.jpg");
+        assertThat(result.uploadUrl()).isEqualTo("new-url");
+        assertThat(result.headers()).containsEntry("Content-Type", MIME);
+    }
+
+    @Test
+    void 재시도_횟수가_오르고_한도를_함께_알려준다() {
+        StoredFile file = reserved(hostId);
+
+        ReissuedUploadUrl first = reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null);
+        ReissuedUploadUrl second = reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null);
+
+        assertThat(first.retryCount()).isEqualTo(1);
+        assertThat(second.retryCount()).isEqualTo(2);
+        assertThat(second.maxRetryCount()).isEqualTo(MAX_RETRY);
+    }
+
+    @Test
+    void 정리_배치_기준_시각이_재발급_시각으로_밀린다() {
+        StoredFile file = reserved(hostId);
+        Instant before = file.getReservedAt();
+
+        reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null);
+
+        // 재시도 중인 파일이 1시간 룰에 걸려 회수되면 안 된다.
+        assertThat(fileRepository.findById(file.getId()).orElseThrow().getReservedAt())
+            .isAfterOrEqualTo(before);
+    }
+
+    @Test
+    void 한도를_넘기면_예외() {
+        StoredFile file = reserved(hostId);
+        for (int i = 0; i < MAX_RETRY; i++) {
+            reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null);
+        }
+
+        assertThatThrownBy(() -> reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null))
+            .isInstanceOf(UploadRetryExceededException.class);
+    }
+
+    @Test
+    void 이미_등록된_업로드는_재발급할_수_없다() {
+        StoredFile file = reserved(hostId);
+        file.startProcessing();
+        fileRepository.save(file);
+
+        assertThatThrownBy(() -> reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null))
+            .isInstanceOf(UploadAlreadyCompletedException.class);
+    }
+
+    @Test
+    void 업로더_본인이_아니면_예외() {
+        Long guestId = anonymousAuthService.authenticate("민수").userId();
+        StoredFile file = reserved(guestId);
+
+        // 방장이라도 남의 예약은 재발급하지 못한다.
+        assertThatThrownBy(() -> reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null))
+            .isInstanceOf(MediaForbiddenException.class);
+    }
+
+    @Test
+    void 재발급_시점에_업로드_권한을_다시_본다() {
+        StoredFile file = reserved(hostId);
+        given(roomPermissionPort.canUpload(any(), any())).willReturn(false);
+
+        // 최초 발급 뒤 방장이 권한을 바꿨을 수 있다.
+        assertThatThrownBy(() -> reissueUploadUrlService.reissue(roomId, file.getId(), hostId, null))
+            .isInstanceOf(UploadNotAllowedException.class);
+    }
+
+    @Test
+    void 없는_미디어면_예외() {
+        assertThatThrownBy(() -> reissueUploadUrlService.reissue(roomId, -1L, hostId, null))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 다른_방의_미디어면_예외() {
+        StoredFile file = reserved(hostId);
+        Long otherRoomId = createRoomService.create(hostId, "다른 회식", null, null).room().getId();
+
+        assertThatThrownBy(() ->
+            reissueUploadUrlService.reissue(otherRoomId, file.getId(), hostId, null))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 바뀐_크기를_반영한다() {
+        StoredFile file = reserved(hostId);
+
+        reissueUploadUrlService.reissue(roomId, file.getId(), hostId, 512L);
+
+        assertThat(fileRepository.findById(file.getId()).orElseThrow().getFileSize().bytes())
+            .isEqualTo(512L);
+    }
+
+    @Test
+    void 바뀐_크기가_0이하면_예외() {
+        StoredFile file = reserved(hostId);
+
+        assertThatThrownBy(() -> reissueUploadUrlService.reissue(roomId, file.getId(), hostId, 0L))
+            .isInstanceOf(InvalidUploadParamException.class);
+    }
+
+    @Test
+    void 바뀐_크기가_한도를_넘으면_예외() {
+        StoredFile file = reserved(hostId);
+
+        assertThatThrownBy(() ->
+            reissueUploadUrlService.reissue(roomId, file.getId(), hostId, 11L * 1024 * 1024))
+            .isInstanceOf(FileSizeExceededException.class);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/UploadReservationTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/UploadReservationTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sssok.domain.file.exception.FileSizeExceededException;
 import com.sssok.domain.file.exception.UnsupportedMediaTypeException;
+import com.sssok.domain.file.exception.UploadAlreadyCompletedException;
+import com.sssok.domain.file.exception.UploadRetryExceededException;
+import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,6 +17,7 @@ class UploadReservationTest {
     private static final Instant NOW = Instant.parse("2026-08-26T10:00:00Z");
     private static final Long ROOM_ID = 1L;
     private static final Long UPLOADER_ID = 100L;
+    private static final int MAX_RETRY = 5;
 
     private static StoredFile reserved() {
         return StoredFile.reserve(ROOM_ID, UPLOADER_ID, "cat.png", "image/png",
@@ -56,6 +60,80 @@ class UploadReservationTest {
         }
     }
 
+    @Nested
+    class 재발급 {
+
+        @Test
+        void 재발급하면_횟수가_오르고_기준_시각이_갱신된다() {
+            StoredFile file = reserved();
+            Instant later = NOW.plus(Duration.ofMinutes(20));
+
+            file.reissueUploadUrl(MAX_RETRY, later);
+
+            assertThat(file.getRetryCount()).isEqualTo(1);
+            // 정리 배치가 이 값을 보므로, 재시도 중인 파일이 회수되지 않으려면 미뤄져야 한다.
+            assertThat(file.getReservedAt()).isEqualTo(later);
+        }
+
+        @Test
+        void 실패한_업로드도_재발급할_수_있다() {
+            StoredFile file = reserved();
+            file.failUpload();
+
+            file.reissueUploadUrl(MAX_RETRY, NOW);
+
+            assertThat(file.getRetryCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 이미_등록된_업로드는_재발급할_수_없다() {
+            StoredFile file = reserved();
+            file.startProcessing();
+
+            // 이미 올라간 파일을 덮어쓰지 못하게 막는다.
+            assertThatThrownBy(() -> file.reissueUploadUrl(MAX_RETRY, NOW))
+                .isInstanceOf(UploadAlreadyCompletedException.class);
+        }
+
+        @Test
+        void 완료된_업로드도_재발급할_수_없다() {
+            StoredFile file = reserved();
+            file.startProcessing();
+            file.markReady();
+
+            assertThatThrownBy(() -> file.reissueUploadUrl(MAX_RETRY, NOW))
+                .isInstanceOf(UploadAlreadyCompletedException.class);
+        }
+
+        @Test
+        void 한도만큼_쓰면_더_재발급할_수_없다() {
+            StoredFile file = reserved();
+            for (int i = 0; i < MAX_RETRY; i++) {
+                file.reissueUploadUrl(MAX_RETRY, NOW);
+            }
+
+            assertThatThrownBy(() -> file.reissueUploadUrl(MAX_RETRY, NOW))
+                .isInstanceOf(UploadRetryExceededException.class);
+            assertThat(file.getRetryCount()).isEqualTo(MAX_RETRY);
+        }
+
+        @Test
+        void 재압축해서_크기가_바뀌면_반영한다() {
+            StoredFile file = reserved();
+
+            file.changeFileSize(FileSize.ofKilobytes(500));
+
+            assertThat(file.getFileSize().bytes()).isEqualTo(500 * 1024);
+        }
+
+        @Test
+        void 바뀐_크기가_한도를_넘으면_예외() {
+            StoredFile file = reserved();
+
+            assertThatThrownBy(() -> file.changeFileSize(FileSize.ofMegabytes(11)))
+                .isInstanceOf(FileSizeExceededException.class);
+        }
+    }
 
     @Nested
     class 실제_업로드_대조 {

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadApiTest.java
@@ -158,7 +158,31 @@ class MediaUploadApiTest extends PostgresContainerSupport {
             .andExpect(jsonPath("$.data.failed[0].code").value("UPLOAD_NOT_COMPLETED"));
     }
 
+    @Test
+    void 재발급하면_같은_미디어_ID로_새_URL을_받는다() throws Exception {
+        String issued = issue(oneImage()).andReturn().getResponse().getContentAsString();
+        Long mediaId = issuedMediaId(issued);
 
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media/{mediaId}/upload-url", roomId, mediaId)
+                .header("Authorization", token))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.mediaId").value(mediaId))
+            .andExpect(jsonPath("$.data.retryCount").value(1));
+    }
+
+    @Test
+    void 남의_예약은_재발급할_수_없다() throws Exception {
+        String issued = issue(oneImage()).andReturn().getResponse().getContentAsString();
+        Long mediaId = issuedMediaId(issued);
+
+        AuthResult guest = anonymousAuthService.authenticate("민수");
+        joinRoomService.join(roomId, guest.userId());
+
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media/{mediaId}/upload-url", roomId, mediaId)
+                .header("Authorization", "Bearer " + guest.accessToken()))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("MEDIA_FORBIDDEN"));
+    }
 
     @Test
     void 입장하지_않은_사용자는_발급받을_수_없다() throws Exception {

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaUploadControllerTest.java
@@ -15,6 +15,8 @@ import com.sssok.application.media.IssueUploadUrlsResult;
 import com.sssok.application.media.IssueUploadUrlsService;
 import com.sssok.application.media.MediaDetail;
 import com.sssok.application.media.RejectedFile;
+import com.sssok.application.media.ReissueUploadUrlService;
+import com.sssok.application.media.ReissuedUploadUrl;
 import com.sssok.application.media.UploadUrl;
 import com.sssok.application.media.exception.InvalidUploadParamException;
 import com.sssok.application.media.exception.MediaForbiddenException;
@@ -23,6 +25,8 @@ import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.application.port.out.TokenProvider;
 import com.sssok.domain.file.UploadRejectionReason;
+import com.sssok.domain.file.exception.UploadAlreadyCompletedException;
+import com.sssok.domain.file.exception.UploadRetryExceededException;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
 import com.sssok.domain.room.RoomExpiration;
@@ -62,6 +66,9 @@ class MediaUploadControllerTest {
     CompleteUploadService completeUploadService;
 
     @MockitoBean
+    ReissueUploadUrlService reissueUploadUrlService;
+
+    @MockitoBean
     TokenProvider tokenProvider;
 
     @MockitoBean
@@ -94,6 +101,14 @@ class MediaUploadControllerTest {
 
     private ResultActions completeUpload(String body) throws Exception {
         return mockMvc.perform(post("/api/v1/rooms/{roomId}/media", ROOM_ID)
+            .header("Authorization", BEARER)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body));
+    }
+
+    private ResultActions reissue(String body) throws Exception {
+        return mockMvc.perform(post("/api/v1/rooms/{roomId}/media/{mediaId}/upload-url",
+                ROOM_ID, MEDIA_ID)
             .header("Authorization", BEARER)
             .contentType(MediaType.APPLICATION_JSON)
             .content(body));
@@ -162,9 +177,51 @@ class MediaUploadControllerTest {
             .andExpect(jsonPath("$.code").value("MEDIA_FORBIDDEN"));
     }
 
+    @Test
+    void 재발급하면_200과_재시도_횟수를_반환한다() throws Exception {
+        ReissuedUploadUrl url = new ReissuedUploadUrl(MEDIA_ID, "a.jpg", "https://storage/new",
+            "PUT", Map.of("Content-Type", "image/jpeg"), 600, 2, 5);
+        given(reissueUploadUrlService.reissue(anyLong(), anyLong(), anyLong(), any())).willReturn(url);
 
+        reissue("{\"size\":512}")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.mediaId").value(MEDIA_ID))
+            .andExpect(jsonPath("$.data.retryCount").value(2))
+            .andExpect(jsonPath("$.data.maxRetryCount").value(5));
+    }
 
+    @Test
+    void 바디_없이_재발급해도_200이다() throws Exception {
+        ReissuedUploadUrl url = new ReissuedUploadUrl(MEDIA_ID, "a.jpg", "https://storage/new",
+            "PUT", Map.of("Content-Type", "image/jpeg"), 600, 1, 5);
+        given(reissueUploadUrlService.reissue(anyLong(), anyLong(), anyLong(), any())).willReturn(url);
 
+        // 대부분의 재시도는 파일이 그대로라 바디 없이 온다.
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media/{mediaId}/upload-url", ROOM_ID, MEDIA_ID)
+                .header("Authorization", BEARER))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.retryCount").value(1));
+    }
+
+    @Test
+    void 이미_등록된_업로드를_재발급하면_409() throws Exception {
+        given(reissueUploadUrlService.reissue(anyLong(), anyLong(), anyLong(), any()))
+            .willThrow(new UploadAlreadyCompletedException());
+
+        reissue("{}")
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("UPLOAD_ALREADY_COMPLETED"));
+    }
+
+    @Test
+    void 재시도_한도를_넘기면_429() throws Exception {
+        given(reissueUploadUrlService.reissue(anyLong(), anyLong(), anyLong(), any()))
+            .willThrow(new UploadRetryExceededException(5));
+
+        reissue("{}")
+            .andExpect(status().isTooManyRequests())
+            .andExpect(jsonPath("$.code").value("UPLOAD_RETRY_EXCEEDED"));
+    }
 
     @Test
     void 인증_없이_요청하면_401() throws Exception {


### PR DESCRIPTION
## 작업 내용
- 업로드 URL 재발급 API(POST /api/v1/rooms/{roomId}/media/{mediaId}/upload-url)를 main에 랜딩한다.
  #105에서 리뷰·머지되었으나, 그때 base였던 feature/be-#76-upload-complete-api 브랜치가 머지 후
  삭제되지 않아 GitHub가 base를 main으로 자동 전환하지 못했다. 그 결과 #105 코드가 main이 아니라
  중간 브랜치에만 들어간 상태라, 같은 커밋을 이번엔 main을 base로 다시 PR한다.
- 코드 변경은 #105와 완전히 동일하다 (커밋 5b87835, 새로 만든 커밋 없음).

## 관련 이슈
관련: #76 (이미 closed 상태. 이 PR로 해당 이슈 범위가 모두 main에 랜딩된다)

## 작업 영역
- [x] Backend

## 변경 사항
- [x] feat(backend): 업로드 URL 재발급 API 구현 (#105과 동일 커밋)

## 테스트
- [x] 단위 테스트 작성/통과 (#105에서 이미 CI 통과)
- [ ] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
- #105와 diff가 동일합니다 — 재리뷰보다는 base가 main으로 제대로 잡혔는지, CI가 다시 통과하는지만
  확인해주시면 됩니다.
- 머지 시 브랜치 삭제를 눌러주세요 (지난번 삭제 누락으로 이 상황이 발생했습니다).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 만료되거나 실패한 미디어 업로드 URL을 같은 파일 ID로 재발급할 수 있습니다.
  - 재발급 시 방 접근 권한과 파일 소유자를 확인합니다.
  - 필요하면 파일 크기를 변경해 다시 업로드할 수 있습니다.
  - 재시도 횟수와 URL 만료 정보를 응답에서 확인할 수 있습니다.

- **개선 사항**
  - 업로드 URL 재발급은 최대 5회로 제한됩니다.
  - 이미 완료된 업로드, 재시도 초과, 잘못된 파일 크기에 대해 명확한 오류가 제공됩니다.
  - 업로드 재발급 과정의 권한 및 예외 처리를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->