### PR TITLE
fix: 다운로드 상태 조회 테스트 나노초 정밀도 flaky 수정 - #117

### DIFF
--- a/backend/src/test/java/com/sssok/application/download/GetDownloadJobStatusServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/download/GetDownloadJobStatusServiceTest.java
@@ -2,6 +2,7 @@ package com.sssok.application.download;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -16,6 +17,7 @@ import com.sssok.domain.download.DownloadJobStatus;
 import com.sssok.domain.file.StorageKey;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,7 +89,10 @@ class GetDownloadJobStatusServiceTest {
 
         assertThat(result.status()).isEqualTo(DownloadJobStatus.READY);
         assertThat(result.downloadUrl()).isEqualTo(PRESIGNED);
-        assertThat(result.expiresAt()).isEqualTo(readyAt.plus(Duration.ofHours(1)));
+        // DB 왕복(H2 ready_at 컬럼)에서 나노초 이하가 마이크로초 단위로 반올림되므로,
+        // 나노초까지 꽉 채워 주는 플랫폼(Linux)에서는 정확히 일치하지 않는다. 1ms 오차를 허용한다.
+        assertThat(result.expiresAt())
+            .isCloseTo(readyAt.plus(Duration.ofHours(1)), within(1, ChronoUnit.MILLIS));
         assertThat(result.progress()).isEqualTo(100);
     }
 


### PR DESCRIPTION
## 작업 내용
- GetDownloadJobStatusServiceTest.READY_잡은_다운로드_URL과_만료_시각을_돌려준다()가 Instant.now()
  (나노초 정밀도)와 DB 왕복 후 값을 isEqualTo로 비교해, H2 ready_at 컬럼이 마이크로초로 반올림하는
  것 때문에 나노초 정밀도 클럭을 쓰는 Linux CI에서 결정적으로 실패하던 문제를 고친다.
- isCloseTo(..., within(1, ChronoUnit.MILLIS))로 바꿔 DB 왕복 정밀도 손실을 허용하되, 실제 로직
  오류(1ms 이상 차이)는 여전히 잡아낸다.

## 관련 이슈
Closes #117

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] test(backend): 다운로드 상태 만료 시각 비교에 1ms 오차 허용

## 테스트
- [x] 단위 테스트 작성/통과 (GetDownloadJobStatusServiceTest, 관련 Download 테스트 전체 로컬 실행 —
  BUILD SUCCESSFUL, --rerun-tasks로 캐시 없이 재확인)

## 리뷰 요청 사항 (선택)
- #102 PR 체인 진행 중 CI에서 실제 실패로 발견 (로컬 macOS에서는 우연히 항상 통과해서 안 보였음).
  CI 리포트에서 expected/actual 값(나노초 vs 마이크로초 반올림) 직접 확인함.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 다운로드 URL 만료 시각 검증에 소폭의 시간 오차를 허용하도록 조정했습니다.
  * 환경에 따른 시간 정밀도 차이로 발생하던 테스트 실패를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->