### PR TITLE
feat: 미디어 목록·단건 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/sssok/application/media/GetMediaListService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetMediaListService.java
@@ -1,0 +1,48 @@
+package com.sssok.application.media;
+
+import com.sssok.application.folder.exception.FolderNotFoundException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.application.port.out.FolderRepository;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class GetMediaListService {
+
+    private final FileRepository fileRepository;
+    private final FolderRepository folderRepository;
+    private final FolderMediaRepository folderMediaRepository;
+    private final MediaDetailAssembler assembler;
+
+    @Transactional(readOnly = true)
+    public List<MediaDetail> list(Long roomId, Long folderId) {
+        return assembler.assemble(find(roomId, folderId));
+    }
+
+    private List<StoredFile> find(Long roomId, Long folderId) {
+        if (folderId == null) {
+            return fileRepository.findAllByRoomIdAndStatusInOrderByNewest(
+                roomId, UploadStatus.visibleStatuses());
+        }
+        requireFolderInRoom(roomId, folderId);
+        // 방 조건을 여기서도 건다. 폴더가 이 방 소속인 건 확인했지만, 담긴 미디어까지
+        // 같은 방인지는 보장되지 않아서다.
+        return fileRepository.findAllByRoomIdAndIdInAndStatusInOrderByNewest(
+            roomId, folderMediaRepository.findMediaIdsByFolderId(folderId),
+            UploadStatus.visibleStatuses());
+    }
+
+    // 다른 방 폴더로 남의 사진을 들여다보지 못하도록 소속까지 확인한다.
+    private void requireFolderInRoom(Long roomId, Long folderId) {
+        folderRepository.findById(folderId)
+            .filter(folder -> folder.belongsTo(roomId))
+            .orElseThrow(() -> new FolderNotFoundException(folderId));
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/GetMediaService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetMediaService.java
@@ -1,0 +1,42 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.file.FilePermissionPolicy;
+import com.sssok.domain.file.StoredFile;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class GetMediaService {
+
+    private final FileRepository fileRepository;
+    private final RoomRepository roomRepository;
+    private final MediaDetailAssembler assembler;
+
+    // 다른 방 미디어와 아직 실물이 없는 미디어를 모두 404 로 낸다. 403 으로 나누면
+    // 남의 방에 그 ID 가 있다는 사실이 드러난다.
+    @Transactional(readOnly = true)
+    public MediaFullDetail get(Long roomId, Long mediaId, Long requesterId) {
+        StoredFile file = fileRepository.findById(mediaId)
+            .filter(found -> found.getRoomId().equals(roomId))
+            .filter(found -> found.getStatus().isVisible())
+            .orElseThrow(MediaNotFoundException::new);
+
+        MediaDetail media = assembler.assemble(List.of(file)).getFirst();
+        return MediaFullDetail.of(file, media, canDelete(file, roomId, requesterId));
+    }
+
+    // 올린 본인과 방장이 지울 수 있다. 프론트가 삭제 버튼을 보일지 정하는 데 쓴다.
+    private boolean canDelete(StoredFile file, Long roomId, Long requesterId) {
+        boolean isHost = roomRepository.findById(roomId)
+            .map(room -> room.getHostId().equals(requesterId))
+            .orElse(false);
+        return FilePermissionPolicy.canDelete(file, requesterId, isHost);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/GetMediaService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetMediaService.java
@@ -2,8 +2,6 @@ package com.sssok.application.media;
 
 import com.sssok.application.media.exception.MediaNotFoundException;
 import com.sssok.application.port.out.FileRepository;
-import com.sssok.application.port.out.RoomRepository;
-import com.sssok.domain.file.FilePermissionPolicy;
 import com.sssok.domain.file.StoredFile;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,27 +14,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetMediaService {
 
     private final FileRepository fileRepository;
-    private final RoomRepository roomRepository;
     private final MediaDetailAssembler assembler;
 
     // 다른 방 미디어와 아직 실물이 없는 미디어를 모두 404 로 낸다. 403 으로 나누면
     // 남의 방에 그 ID 가 있다는 사실이 드러난다.
     @Transactional(readOnly = true)
-    public MediaFullDetail get(Long roomId, Long mediaId, Long requesterId) {
+    public MediaDetail get(Long roomId, Long mediaId) {
         StoredFile file = fileRepository.findById(mediaId)
             .filter(found -> found.getRoomId().equals(roomId))
             .filter(found -> found.getStatus().isVisible())
             .orElseThrow(MediaNotFoundException::new);
 
-        MediaDetail media = assembler.assemble(List.of(file)).getFirst();
-        return MediaFullDetail.of(file, media, canDelete(file, roomId, requesterId));
-    }
-
-    // 올린 본인과 방장이 지울 수 있다. 프론트가 삭제 버튼을 보일지 정하는 데 쓴다.
-    private boolean canDelete(StoredFile file, Long roomId, Long requesterId) {
-        boolean isHost = roomRepository.findById(roomId)
-            .map(room -> room.getHostId().equals(requesterId))
-            .orElse(false);
-        return FilePermissionPolicy.canDelete(file, requesterId, isHost);
+        return assembler.assemble(List.of(file)).getFirst();
     }
 }

--- a/backend/src/main/java/com/sssok/application/media/MediaDetailAssembler.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaDetailAssembler.java
@@ -1,0 +1,50 @@
+package com.sssok.application.media;
+
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.member.Member;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// 파일 행만으로는 응답을 만들 수 없다. 폴더 소속과 업로더 이름이 다른 테이블에 있어서다.
+// 미디어마다 찾아오면 30장짜리 목록에 쿼리가 60번 나가므로, 종류별로 한 번씩만 모아서 채운다.
+@Component
+@RequiredArgsConstructor
+public class MediaDetailAssembler {
+
+    private final FolderMediaRepository folderMediaRepository;
+    private final MemberRepository memberRepository;
+
+    public List<MediaDetail> assemble(List<StoredFile> files) {
+        if (files.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, List<Long>> folderIds = folderMediaRepository.findFolderIdsByMedia(
+            files.stream().map(StoredFile::getId).toList());
+        Map<Long, String> uploaderNames = uploaderNames(files);
+
+        return files.stream()
+            .map(file -> MediaDetail.of(
+                file,
+                uploaderNames.get(file.getUploaderId()),
+                folderIds.getOrDefault(file.getId(), List.of())))
+            .toList();
+    }
+
+    // 방을 나간 사람이 올린 사진은 회원 행이 없을 수 있어, 이름이 빠진 채로 내려간다.
+    // 사진 자체는 방에 남으므로 목록에서 빼지는 않는다.
+    private Map<Long, String> uploaderNames(List<StoredFile> files) {
+        Set<Long> uploaderIds = files.stream()
+            .map(StoredFile::getUploaderId)
+            .collect(Collectors.toSet());
+
+        return memberRepository.findAllByIdIn(uploaderIds).stream()
+            .collect(Collectors.toMap(Member::getId,
+                member -> member.getDisplayName().value(), (first, second) -> first));
+    }
+}

--- a/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
@@ -2,7 +2,6 @@ package com.sssok.application.port.out;
 
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -33,8 +32,6 @@ public interface FileRepository {
     List<StoredFile> findAllByRoomIdAndIdInAndStatusInOrderByNewest(
         Long roomId, Collection<Long> ids, Collection<UploadStatus> statuses);
 
-    // 썸네일 회수 배치용. 이 시각보다 오래 PROCESSING 에 남아 있는 미디어 id 를 오래된 순으로 준다.
-    List<Long> findStuckInProcessing(Instant stuckBefore, int limit);
 
     void deleteAllByRoomId(Long roomId);
 }

--- a/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
@@ -1,6 +1,9 @@
 package com.sssok.application.port.out;
 
 import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +23,18 @@ public interface FileRepository {
     List<Long> findExistingIds(List<Long> ids);
 
     List<StoredFile> findAllByRoomId(Long roomId);
+
+    // 조회 API 전용. 같은 업로드 요청에 묶인 파일은 createdAt 이 전부 같아서, id 까지 봐야
+    // 순서가 호출마다 흔들리지 않는다.
+    List<StoredFile> findAllByRoomIdAndStatusInOrderByNewest(
+        Long roomId, Collection<UploadStatus> statuses);
+
+    // 위와 같지만 대상을 주어진 id 로 한정한다(폴더 필터).
+    List<StoredFile> findAllByRoomIdAndIdInAndStatusInOrderByNewest(
+        Long roomId, Collection<Long> ids, Collection<UploadStatus> statuses);
+
+    // 썸네일 회수 배치용. 이 시각보다 오래 PROCESSING 에 남아 있는 미디어 id 를 오래된 순으로 준다.
+    List<Long> findStuckInProcessing(Instant stuckBefore, int limit);
 
     void deleteAllByRoomId(Long roomId);
 }

--- a/backend/src/main/java/com/sssok/application/port/out/MemberRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/MemberRepository.java
@@ -2,6 +2,7 @@ package com.sssok.application.port.out;
 
 import com.sssok.domain.member.Member;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 // 회원 영속화 출력
@@ -10,6 +11,9 @@ public interface MemberRepository {
     Member save(Member member);
 
     Optional<Member> findById(Long id);
+
+    // 미디어 목록에 업로더 이름을 붙일 때 쓴다. 하나씩 찾으면 미디어 수만큼 쿼리가 나간다.
+    List<Member> findAllByIdIn(Collection<Long> memberIds);
 
     void deleteAllByIdIn(Collection<Long> memberIds);
 }

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -42,7 +42,6 @@ public enum ErrorCode {
     LINK_CODE_NOT_FOUND(404, "유효하지 않은 코드입니다"),
     FOLDER_NOT_FOUND(404, "존재하지 않는 폴더입니다: %s"),
     MEDIA_NOT_FOUND(404, "존재하지 않는 미디어입니다"),
-    THUMBNAIL_NOT_FOUND(404, "썸네일이 아직 준비되지 않았습니다"),
     DOWNLOAD_NOT_FOUND(404, "다운로드 요청을 찾을 수 없습니다"),
 
     // 405 Method Not Allowed

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -41,7 +41,8 @@ public enum ErrorCode {
     ROOM_NOT_FOUND(404, "존재하지 않는 방입니다: %s"),
     LINK_CODE_NOT_FOUND(404, "유효하지 않은 코드입니다"),
     FOLDER_NOT_FOUND(404, "존재하지 않는 폴더입니다: %s"),
-    MEDIA_NOT_FOUND(404, "업로드 요청을 찾을 수 없습니다"),
+    MEDIA_NOT_FOUND(404, "존재하지 않는 미디어입니다"),
+    THUMBNAIL_NOT_FOUND(404, "썸네일이 아직 준비되지 않았습니다"),
     DOWNLOAD_NOT_FOUND(404, "다운로드 요청을 찾을 수 없습니다"),
 
     // 405 Method Not Allowed

--- a/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
+++ b/backend/src/main/java/com/sssok/domain/file/UploadStatus.java
@@ -2,7 +2,7 @@ package com.sssok.domain.file;
 
 import java.util.Set;
 
-// RESERVED 는 서명 URL 만 나가고 스토리지에는 아직 아무것도 없는 상태라, 목록에 보이면 안 된다.
+// RESERVED 는 서명 URL 만 나가고 스토리지에는 아직 아무것도 없는 상태다.
 public enum UploadStatus {
 
     RESERVED,
@@ -13,6 +13,18 @@ public enum UploadStatus {
     private static final Set<UploadStatus> FROM_RESERVED = Set.of(PROCESSING, FAILED);
     private static final Set<UploadStatus> FROM_PROCESSING = Set.of(READY, FAILED);
     private static final Set<UploadStatus> FROM_FAILED = Set.of(PROCESSING);
+
+    // 조회에 노출되는 상태. RESERVED·FAILED 는 스토리지에 실물이 없어, 내려보내면 클라이언트가
+    // 열 수 없는 빈 항목을 그리게 된다. 다운로드 API 도 이 둘을 없는 것과 동일하게 취급한다.
+    private static final Set<UploadStatus> VISIBLE = Set.of(PROCESSING, READY);
+
+    public static Set<UploadStatus> visibleStatuses() {
+        return VISIBLE;
+    }
+
+    public boolean isVisible() {
+        return VISIBLE.contains(this);
+    }
 
     // 서명 URL 을 다시 발급해도 되는 상태. 이미 올라간 파일을 덮어쓰지 못하게 막는 기준이다.
     public boolean canReissueUploadUrl() {

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
@@ -2,17 +2,14 @@ package com.sssok.infrastructure.persistence.file;
 
 import com.sssok.application.port.out.FileRepository;
 import com.sssok.domain.file.FileSize;
-import com.sssok.domain.file.GeoPoint;
 import com.sssok.domain.file.MediaType;
 import com.sssok.domain.file.StorageKey;
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -81,11 +78,6 @@ public class FileRepositoryAdapter implements FileRepository {
             .toList();
     }
 
-    @Override
-    public List<Long> findStuckInProcessing(Instant stuckBefore, int limit) {
-        return jpaRepository.findStuckInProcessing(
-            UploadStatus.PROCESSING.name(), stuckBefore, Limit.of(limit));
-    }
 
     @Override
     public void deleteAllByRoomId(Long roomId) {
@@ -110,13 +102,7 @@ public class FileRepositoryAdapter implements FileRepository {
             file.getStatus().name(),
             file.getCreatedAt(),
             file.getReservedAt(),
-            file.getRetryCount(),
-            file.getThumbnailKey() == null ? null : file.getThumbnailKey().value(),
-            file.getWidth(),
-            file.getHeight(),
-            file.getTakenAt(),
-            file.getLocation() == null ? null : file.getLocation().latitude(),
-            file.getLocation() == null ? null : file.getLocation().longitude()
+            file.getRetryCount()
         );
     }
 
@@ -133,12 +119,7 @@ public class FileRepositoryAdapter implements FileRepository {
             UploadStatus.valueOf(entity.getStatus()),
             entity.getCreatedAt(),
             entity.getReservedAt(),
-            entity.getRetryCount(),
-            entity.getThumbnailKey() == null ? null : new StorageKey(entity.getThumbnailKey()),
-            entity.getWidth(),
-            entity.getHeight(),
-            entity.getTakenAt(),
-            GeoPoint.ofNullable(entity.getLatitude(), entity.getLongitude())
+            entity.getRetryCount()
         );
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
@@ -2,13 +2,17 @@ package com.sssok.infrastructure.persistence.file;
 
 import com.sssok.application.port.out.FileRepository;
 import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.GeoPoint;
 import com.sssok.domain.file.MediaType;
 import com.sssok.domain.file.StorageKey;
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -55,8 +59,42 @@ public class FileRepositoryAdapter implements FileRepository {
     }
 
     @Override
+    public List<StoredFile> findAllByRoomIdAndStatusInOrderByNewest(
+        Long roomId, Collection<UploadStatus> statuses) {
+        return jpaRepository
+            .findAllByRoomIdAndStatusInOrderByCreatedAtDescIdDesc(roomId, names(statuses)).stream()
+            .map(this::toDomain)
+            .toList();
+    }
+
+    @Override
+    public List<StoredFile> findAllByRoomIdAndIdInAndStatusInOrderByNewest(
+        Long roomId, Collection<Long> ids, Collection<UploadStatus> statuses) {
+        // IN () 은 유효한 SQL 이 아니라, 빈 목록을 그대로 넘기면 드라이버가 오류를 낸다.
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return jpaRepository
+            .findAllByRoomIdAndIdInAndStatusInOrderByCreatedAtDescIdDesc(roomId, ids, names(statuses))
+            .stream()
+            .map(this::toDomain)
+            .toList();
+    }
+
+    @Override
+    public List<Long> findStuckInProcessing(Instant stuckBefore, int limit) {
+        return jpaRepository.findStuckInProcessing(
+            UploadStatus.PROCESSING.name(), stuckBefore, Limit.of(limit));
+    }
+
+    @Override
     public void deleteAllByRoomId(Long roomId) {
         jpaRepository.deleteAllByRoomId(roomId);
+    }
+
+    // 상태를 문자열 컬럼으로 저장하고 있어, 조회 조건도 이름으로 맞춰 넘긴다.
+    private List<String> names(Collection<UploadStatus> statuses) {
+        return statuses.stream().map(UploadStatus::name).toList();
     }
 
     private StoredFileJpaEntity toEntity(StoredFile file) {
@@ -72,7 +110,13 @@ public class FileRepositoryAdapter implements FileRepository {
             file.getStatus().name(),
             file.getCreatedAt(),
             file.getReservedAt(),
-            file.getRetryCount()
+            file.getRetryCount(),
+            file.getThumbnailKey() == null ? null : file.getThumbnailKey().value(),
+            file.getWidth(),
+            file.getHeight(),
+            file.getTakenAt(),
+            file.getLocation() == null ? null : file.getLocation().latitude(),
+            file.getLocation() == null ? null : file.getLocation().longitude()
         );
     }
 
@@ -89,7 +133,12 @@ public class FileRepositoryAdapter implements FileRepository {
             UploadStatus.valueOf(entity.getStatus()),
             entity.getCreatedAt(),
             entity.getReservedAt(),
-            entity.getRetryCount()
+            entity.getRetryCount(),
+            entity.getThumbnailKey() == null ? null : new StorageKey(entity.getThumbnailKey()),
+            entity.getWidth(),
+            entity.getHeight(),
+            entity.getTakenAt(),
+            GeoPoint.ofNullable(entity.getLatitude(), entity.getLongitude())
         );
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaRepository.java
@@ -1,12 +1,8 @@
 package com.sssok.infrastructure.persistence.file;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface StoredFileJpaRepository extends JpaRepository<StoredFileJpaEntity, Long> {
 
@@ -18,15 +14,6 @@ public interface StoredFileJpaRepository extends JpaRepository<StoredFileJpaEnti
     List<StoredFileJpaEntity> findAllByRoomIdAndIdInAndStatusInOrderByCreatedAtDescIdDesc(
         Long roomId, Collection<Long> ids, Collection<String> statuses);
 
-    // 오래된 것부터 가져와, 밀린 작업이 뒤에서 계속 굶지 않게 한다.
-    @Query("""
-        select f.id from StoredFileJpaEntity f
-        where f.status = :status and f.createdAt < :stuckBefore
-        order by f.createdAt asc
-        """)
-    List<Long> findStuckInProcessing(@Param("status") String status,
-                                     @Param("stuckBefore") Instant stuckBefore,
-                                     Limit limit);
 
     void deleteAllByRoomId(Long roomId);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaRepository.java
@@ -1,11 +1,32 @@
 package com.sssok.infrastructure.persistence.file;
 
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoredFileJpaRepository extends JpaRepository<StoredFileJpaEntity, Long> {
 
     List<StoredFileJpaEntity> findAllByRoomId(Long roomId);
+
+    List<StoredFileJpaEntity> findAllByRoomIdAndStatusInOrderByCreatedAtDescIdDesc(
+        Long roomId, Collection<String> statuses);
+
+    List<StoredFileJpaEntity> findAllByRoomIdAndIdInAndStatusInOrderByCreatedAtDescIdDesc(
+        Long roomId, Collection<Long> ids, Collection<String> statuses);
+
+    // 오래된 것부터 가져와, 밀린 작업이 뒤에서 계속 굶지 않게 한다.
+    @Query("""
+        select f.id from StoredFileJpaEntity f
+        where f.status = :status and f.createdAt < :stuckBefore
+        order by f.createdAt asc
+        """)
+    List<Long> findStuckInProcessing(@Param("status") String status,
+                                     @Param("stuckBefore") Instant stuckBefore,
+                                     Limit limit);
 
     void deleteAllByRoomId(Long roomId);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/member/MemberRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.sssok.application.port.out.MemberRepository;
 import com.sssok.domain.member.Member;
 import com.sssok.domain.member.Nickname;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,14 @@ public class MemberRepositoryAdapter implements MemberRepository {
     @Override
     public Optional<Member> findById(Long id) {
         return jpaRepository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public List<Member> findAllByIdIn(Collection<Long> memberIds) {
+        if (memberIds.isEmpty()) {
+            return List.of();
+        }
+        return jpaRepository.findAllById(memberIds).stream().map(this::toDomain).toList();
     }
 
     @Override

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaListResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaListResponse.java
@@ -1,0 +1,15 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.MediaDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+// 배열을 그대로 내리지 않고 한 겹 감싼다. 나중에 페이지네이션이 붙어도
+// 필드만 늘리면 되고, 이미 붙인 클라이언트가 깨지지 않는다.
+public record MediaListResponse(
+    @Schema(description = "최신순으로 정렬된 미디어 목록") List<MediaResponse> items
+) {
+    public static MediaListResponse from(List<MediaDetail> details) {
+        return new MediaListResponse(details.stream().map(MediaResponse::from).toList());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
@@ -1,0 +1,64 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.GetMediaListService;
+import com.sssok.application.media.GetMediaService;
+import com.sssok.presentation.api.common.ApiResponse;
+import com.sssok.presentation.auth.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "미디어 조회", description = "방에 올라온 미디어의 메타데이터를 읽는다. 실제 바이트는 다운로드 API로 받는다.")
+@RestController
+@RequestMapping("/rooms/{roomId}/media")
+@RequiredArgsConstructor
+public class MediaQueryController {
+
+    private final GetMediaListService getMediaListService;
+    private final GetMediaService getMediaService;
+
+    @Operation(
+        summary = "미디어 목록 조회",
+        description = "방에 올라온 미디어를 최신순으로 내려준다. folderId를 주면 그 폴더에 담긴 것만, "
+            + "생략하면 방 전체를 반환한다. 아직 스토리지에 실물이 없는 미디어(발급만 받고 올리지 않았거나 "
+            + "업로드에 실패한 것)는 목록에 나오지 않는다. thumbnailUrl·width·duration은 워커가 채우기 "
+            + "전까지 null이다. 없는 폴더나 다른 방 폴더로 필터하면 404, 입장하지 않은 사용자는 403, "
+            + "없는 방은 404, 만료·삭제된 방은 410이 난다."
+    )
+    @GetMapping
+    public ApiResponse<MediaListResponse> getMediaList(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "이 폴더에 담긴 미디어만 조회한다. 생략하면 방 전체")
+        @RequestParam(required = false) Long folderId
+    ) {
+        return ApiResponse.of(MediaListResponse.from(getMediaListService.list(roomId, folderId)));
+    }
+
+    @Operation(
+        summary = "미디어 단건 조회",
+        description = "미디어 하나의 메타데이터를 반환한다. 목록 항목의 필드를 모두 포함하고 "
+            + "여기에 촬영 시각(takenAt)·촬영 위치(location)·삭제 권한(canDelete)이 더해진다. "
+            + "takenAt과 location은 원본 EXIF에서 읽으며, 카메라가 남기지 않았거나 위치 기록이 "
+            + "꺼져 있었으면 null이다. location.name은 역지오코딩이 붙기 전까지 null이다. "
+            + "canDelete는 보는 사람에 따라 달라져서 목록에는 싣지 않는다 — 올린 본인과 방장만 true다. "
+            + "없는 mediaId, 다른 방의 미디어, 아직 실물이 없는 미디어는 모두 404가 난다 — "
+            + "다른 방에 그 ID가 있는지 알 수 없도록 구분하지 않는다. "
+            + "방 관련 실패 케이스(403/404/410)는 목록 조회와 동일하다."
+    )
+    @GetMapping("/{mediaId}")
+    public ApiResponse<MediaFullResponse> getMedia(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "조회할 미디어 ID") @PathVariable Long mediaId
+    ) {
+        return ApiResponse.of(
+            MediaFullResponse.from(getMediaService.get(roomId, mediaId, memberId)));
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
@@ -43,22 +43,17 @@ public class MediaQueryController {
 
     @Operation(
         summary = "미디어 단건 조회",
-        description = "미디어 하나의 메타데이터를 반환한다. 목록 항목의 필드를 모두 포함하고 "
-            + "여기에 촬영 시각(takenAt)·촬영 위치(location)·삭제 권한(canDelete)이 더해진다. "
-            + "takenAt과 location은 원본 EXIF에서 읽으며, 카메라가 남기지 않았거나 위치 기록이 "
-            + "꺼져 있었으면 null이다. location.name은 역지오코딩이 붙기 전까지 null이다. "
-            + "canDelete는 보는 사람에 따라 달라져서 목록에는 싣지 않는다 — 올린 본인과 방장만 true다. "
+        description = "미디어 하나의 메타데이터를 반환한다. 응답 형태는 목록의 항목과 같다. "
             + "없는 mediaId, 다른 방의 미디어, 아직 실물이 없는 미디어는 모두 404가 난다 — "
             + "다른 방에 그 ID가 있는지 알 수 없도록 구분하지 않는다. "
             + "방 관련 실패 케이스(403/404/410)는 목록 조회와 동일하다."
     )
     @GetMapping("/{mediaId}")
-    public ApiResponse<MediaFullResponse> getMedia(
+    public ApiResponse<MediaResponse> getMedia(
         @Parameter(hidden = true) @AuthMember Long memberId,
         @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
         @Parameter(description = "조회할 미디어 ID") @PathVariable Long mediaId
     ) {
-        return ApiResponse.of(
-            MediaFullResponse.from(getMediaService.get(roomId, mediaId, memberId)));
+        return ApiResponse.of(MediaResponse.from(getMediaService.get(roomId, mediaId)));
     }
 }

--- a/backend/src/test/java/com/sssok/application/media/GetMediaListServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GetMediaListServiceTest.java
@@ -1,0 +1,225 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.folder.CreateFolderService;
+import com.sssok.application.folder.exception.FolderNotFoundException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import com.sssok.domain.folder.Folder;
+import com.sssok.domain.member.Member;
+import com.sssok.domain.member.Nickname;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+// Repository + Service 통합 테스트 (H2). 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가
+// 컨트롤러 앞에서 거르므로 여기서는 다루지 않는다.
+@SpringBootTest
+@ActiveProfiles("test")
+class GetMediaListServiceTest {
+
+    private static final Long ROOM_ID = 700L;
+    private static final Long OTHER_ROOM_ID = 701L;
+
+    @Autowired
+    GetMediaListService getMediaListService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CreateFolderService createFolderService;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    private Long uploaderId;
+
+    // 이 테스트는 롤백되지 않으므로 방 전용 id 를 쓰고 직접 비운다.
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM folder_media");
+        jdbcTemplate.update("DELETE FROM stored_file WHERE room_id IN (?, ?)", ROOM_ID, OTHER_ROOM_ID);
+        jdbcTemplate.update("DELETE FROM folder WHERE room_id IN (?, ?)", ROOM_ID, OTHER_ROOM_ID);
+        uploaderId = memberRepository.save(Member.register(new Nickname("가현"), Instant.now())).getId();
+    }
+
+    @Test
+    void 방에_올라온_미디어를_반환한다() {
+        StoredFile file = save(ROOM_ID, UploadStatus.READY, Instant.now());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).extracting(MediaDetail::mediaId).containsExactly(file.getId());
+    }
+
+    @Test
+    void 다른_방의_미디어는_섞이지_않는다() {
+        StoredFile mine = save(ROOM_ID, UploadStatus.READY, Instant.now());
+        save(OTHER_ROOM_ID, UploadStatus.READY, Instant.now());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).extracting(MediaDetail::mediaId).containsExactly(mine.getId());
+    }
+
+    @Test
+    void 최신순으로_반환한다() {
+        Instant base = Instant.parse("2026-08-01T00:00:00Z");
+        StoredFile oldest = save(ROOM_ID, UploadStatus.READY, base);
+        StoredFile newest = save(ROOM_ID, UploadStatus.READY, base.plusSeconds(60));
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).extracting(MediaDetail::mediaId)
+            .containsExactly(newest.getId(), oldest.getId());
+    }
+
+    // 한 번에 여러 장을 올리면 createdAt 이 전부 같아서, 시각만으로 정렬하면 순서가
+    // 호출마다 바뀐다. 나중에 만들어진 것(= 큰 id)이 먼저 와야 한다.
+    @Test
+    void 같은_시각에_올라온_미디어도_순서가_고정된다() {
+        Instant sameMoment = Instant.parse("2026-08-01T00:00:00Z");
+        StoredFile first = save(ROOM_ID, UploadStatus.READY, sameMoment);
+        StoredFile second = save(ROOM_ID, UploadStatus.READY, sameMoment);
+        StoredFile third = save(ROOM_ID, UploadStatus.READY, sameMoment);
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).extracting(MediaDetail::mediaId)
+            .containsExactly(third.getId(), second.getId(), first.getId());
+    }
+
+    // 발급만 받고 올리지 않았거나 업로드에 실패한 미디어는 스토리지에 실물이 없다.
+    // 목록에 내려보내면 클라이언트가 열 수 없는 빈 항목을 그린다.
+    @Test
+    void 실물이_없는_미디어는_목록에_나오지_않는다() {
+        save(ROOM_ID, UploadStatus.RESERVED, Instant.now());
+        save(ROOM_ID, UploadStatus.FAILED, Instant.now());
+        StoredFile processing = save(ROOM_ID, UploadStatus.PROCESSING, Instant.now());
+        StoredFile ready = save(ROOM_ID, UploadStatus.READY, Instant.now());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).extracting(MediaDetail::mediaId)
+            .containsExactlyInAnyOrder(processing.getId(), ready.getId());
+    }
+
+    @Test
+    void 업로더_이름을_채워서_반환한다() {
+        save(ROOM_ID, UploadStatus.READY, Instant.now());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).singleElement()
+            .extracting(MediaDetail::uploaderName).isEqualTo("가현");
+    }
+
+    // 방을 나간 사람이 올린 사진은 방에 그대로 남는다. 이름만 비고 목록에서 빠지면 안 된다.
+    @Test
+    void 업로더_회원이_사라져도_미디어는_남는다() {
+        save(ROOM_ID, UploadStatus.READY, Instant.now());
+        jdbcTemplate.update("DELETE FROM member WHERE id = ?", uploaderId);
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).singleElement()
+            .extracting(MediaDetail::uploaderName).isNull();
+    }
+
+    @Test
+    void 어느_폴더에도_없으면_folderIds가_빈_배열이다() {
+        save(ROOM_ID, UploadStatus.READY, Instant.now());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).singleElement().extracting(MediaDetail::folderIds)
+            .isEqualTo(List.of());
+    }
+
+    @Test
+    void 담긴_폴더_목록을_채워서_반환한다() {
+        StoredFile file = save(ROOM_ID, UploadStatus.READY, Instant.now());
+        Folder folder = createFolderService.create(ROOM_ID, "회식");
+        attach(folder.getId(), file.getId());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, null);
+
+        assertThat(media).singleElement().extracting(MediaDetail::folderIds)
+            .isEqualTo(List.of(folder.getId()));
+    }
+
+    @Test
+    void folderId를_주면_그_폴더에_담긴_것만_반환한다() {
+        StoredFile inFolder = save(ROOM_ID, UploadStatus.READY, Instant.now());
+        save(ROOM_ID, UploadStatus.READY, Instant.now());
+        Folder folder = createFolderService.create(ROOM_ID, "회식");
+        attach(folder.getId(), inFolder.getId());
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, folder.getId());
+
+        assertThat(media).extracting(MediaDetail::mediaId).containsExactly(inFolder.getId());
+    }
+
+    @Test
+    void 빈_폴더로_필터하면_빈_목록이_나온다() {
+        save(ROOM_ID, UploadStatus.READY, Instant.now());
+        Folder folder = createFolderService.create(ROOM_ID, "빈폴더");
+
+        List<MediaDetail> media = getMediaListService.list(ROOM_ID, folder.getId());
+
+        assertThat(media).isEmpty();
+    }
+
+    @Test
+    void 없는_폴더로_필터하면_404() {
+        assertThatThrownBy(() -> getMediaListService.list(ROOM_ID, 999_999L))
+            .isInstanceOf(FolderNotFoundException.class);
+    }
+
+    // 다른 방 폴더 id 로 남의 방 사진을 들여다볼 수 없어야 한다.
+    @Test
+    void 다른_방의_폴더로_필터하면_404() {
+        Folder otherRoomFolder = createFolderService.create(OTHER_ROOM_ID, "남의방");
+
+        assertThatThrownBy(() -> getMediaListService.list(ROOM_ID, otherRoomFolder.getId()))
+            .isInstanceOf(FolderNotFoundException.class);
+    }
+
+    private StoredFile save(Long roomId, UploadStatus status, Instant createdAt) {
+        StoredFile file = StoredFile.reserve(
+            roomId, uploaderId, "사진.jpg", "image/jpeg", new FileSize(1024), createdAt);
+        switch (status) {
+            case PROCESSING -> file.startProcessing();
+            case READY -> {
+                file.startProcessing();
+                file.markReady();
+            }
+            case FAILED -> file.failUpload();
+            default -> {
+            }
+        }
+        return fileRepository.save(file);
+    }
+
+    // 폴더 담기 어댑터는 PostgreSQL 전용 ON CONFLICT 를 써서 H2 로는 못 돈다.
+    private void attach(Long folderId, Long mediaId) {
+        jdbcTemplate.update("""
+            INSERT INTO folder_media (folder_id, media_id, created_at, updated_at)
+            VALUES (?, ?, now(), now())
+            """, folderId, mediaId);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/GetMediaServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GetMediaServiceTest.java
@@ -8,13 +8,10 @@ import com.sssok.application.port.out.FileRepository;
 import com.sssok.application.port.out.MemberRepository;
 import com.sssok.application.room.CreateRoomService;
 import com.sssok.domain.file.FileSize;
-import com.sssok.domain.file.GeoPoint;
-import com.sssok.domain.file.ProcessedMedia;
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
 import com.sssok.domain.member.Member;
 import com.sssok.domain.member.Nickname;
-import java.math.BigDecimal;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +60,7 @@ class GetMediaServiceTest {
     void 미디어_메타데이터를_반환한다() {
         StoredFile file = save(roomId, UploadStatus.READY);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+        MediaDetail media = getMediaService.get(roomId, file.getId());
 
         assertThat(media.mediaId()).isEqualTo(file.getId());
         assertThat(media.fileName()).isEqualTo("사진.jpg");
@@ -76,60 +73,17 @@ class GetMediaServiceTest {
         assertThat(media.folderIds()).isEmpty();
     }
 
-    // 워커가 EXIF 에서 읽어 채운다. 카메라가 남기지 않았으면 비어 있다.
+
+
+
+
+
+    // 썸네일 워커가 붙기 전까지는 채울 수 없는 값들이다. 프론트가 null 을 전제로 만들어야 한다.
     @Test
-    void 촬영_시각과_위치를_반환한다() {
-        Instant takenAt = Instant.parse("2026-08-01T12:30:00Z");
-        GeoPoint seoul = new GeoPoint(
-            new BigDecimal("37.566500"), new BigDecimal("126.978000"));
-        StoredFile file = processed(roomId, takenAt, seoul);
-
-        MediaFullDetail full = getMediaService.get(roomId, file.getId(), uploaderId);
-
-        assertThat(full.takenAt()).isEqualTo(takenAt);
-        assertThat(full.location()).isEqualTo(seoul);
-    }
-
-    @Test
-    void 촬영_정보가_없으면_비어_있다() {
-        StoredFile file = save(roomId, UploadStatus.READY);
-
-        MediaFullDetail full = getMediaService.get(roomId, file.getId(), uploaderId);
-
-        assertThat(full.takenAt()).isNull();
-        assertThat(full.location()).isNull();
-    }
-
-    @Test
-    void 올린_본인은_지울_수_있다() {
-        StoredFile file = save(roomId, UploadStatus.READY);
-
-        assertThat(getMediaService.get(roomId, file.getId(), uploaderId).canDelete()).isTrue();
-    }
-
-    // 방을 관리하는 사람이라 남이 올린 사진도 내릴 수 있어야 한다.
-    @Test
-    void 방장은_남이_올린_것도_지울_수_있다() {
-        StoredFile file = save(roomId, UploadStatus.READY);
-
-        assertThat(getMediaService.get(roomId, file.getId(), hostId).canDelete()).isTrue();
-    }
-
-    @Test
-    void 남이_올린_사진은_지울_수_없다() {
-        StoredFile file = save(roomId, UploadStatus.READY);
-        Long other = memberRepository.save(
-            Member.register(new Nickname("의찬"), Instant.now())).getId();
-
-        assertThat(getMediaService.get(roomId, file.getId(), other).canDelete()).isFalse();
-    }
-
-    // 워커가 손대는 중이면 원본이 바뀌는 중일 수 있어 표시용 주소를 주지 않는다.
-    @Test
-    void 워커가_채우는_값은_처리_전까지_비어_있다() {
+    void 워커가_채우는_값은_아직_비어_있다() {
         StoredFile file = save(roomId, UploadStatus.PROCESSING);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+        MediaDetail media = getMediaService.get(roomId, file.getId());
 
         assertThat(media.thumbnailUrl()).isNull();
         assertThat(media.originalUrl()).isNull();
@@ -138,23 +92,10 @@ class GetMediaServiceTest {
         assertThat(media.duration()).isNull();
     }
 
-    @Test
-    void 처리가_끝나면_썸네일과_원본_주소가_생긴다() {
-        StoredFile file = processed(roomId, null, null);
-
-        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
-
-        assertThat(media.thumbnailUrl())
-            .isEqualTo("/api/v1/rooms/%d/media/%d/thumbnail".formatted(roomId, file.getId()));
-        assertThat(media.originalUrl())
-            .isEqualTo("/api/v1/rooms/%d/media/%d/original".formatted(roomId, file.getId()));
-        assertThat(media.width()).isEqualTo(1200);
-        assertThat(media.height()).isEqualTo(900);
-    }
 
     @Test
     void 없는_mediaId면_404() {
-        assertThatThrownBy(() -> getMediaService.get(roomId, 999_999L, uploaderId))
+        assertThatThrownBy(() -> getMediaService.get(roomId, 999_999L))
             .isInstanceOf(MediaNotFoundException.class);
     }
 
@@ -163,7 +104,7 @@ class GetMediaServiceTest {
     void 다른_방의_mediaId면_404() {
         StoredFile file = save(OTHER_ROOM_ID, UploadStatus.READY);
 
-        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId(), uploaderId))
+        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId()))
             .isInstanceOf(MediaNotFoundException.class);
     }
 
@@ -172,7 +113,7 @@ class GetMediaServiceTest {
     void 실물이_없는_미디어면_404(UploadStatus status) {
         StoredFile file = save(roomId, status);
 
-        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId(), uploaderId))
+        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId()))
             .isInstanceOf(MediaNotFoundException.class);
     }
 
@@ -181,7 +122,7 @@ class GetMediaServiceTest {
     void PROCESSING_상태도_조회된다() {
         StoredFile file = save(roomId, UploadStatus.PROCESSING);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+        MediaDetail media = getMediaService.get(roomId, file.getId());
 
         assertThat(media.status()).isEqualTo("PROCESSING");
     }
@@ -191,7 +132,7 @@ class GetMediaServiceTest {
         StoredFile file = save(roomId, UploadStatus.READY);
         jdbcTemplate.update("DELETE FROM member WHERE id = ?", uploaderId);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+        MediaDetail media = getMediaService.get(roomId, file.getId());
 
         assertThat(media.uploaderName()).isNull();
     }
@@ -212,11 +153,4 @@ class GetMediaServiceTest {
         return fileRepository.save(file);
     }
 
-    // 워커가 처리를 마친 상태. 썸네일 키와 크기, 촬영 정보가 채워져 있다.
-    private StoredFile processed(Long targetRoomId, Instant takenAt, GeoPoint location) {
-        StoredFile file = save(targetRoomId, UploadStatus.PROCESSING);
-        file.completeProcessing(new ProcessedMedia(
-            file.getStorageKey().thumbnail(), 1200, 900, takenAt, location));
-        return fileRepository.save(file);
-    }
 }

--- a/backend/src/test/java/com/sssok/application/media/GetMediaServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GetMediaServiceTest.java
@@ -1,0 +1,222 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.GeoPoint;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import com.sssok.domain.member.Member;
+import com.sssok.domain.member.Nickname;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+// Repository + Service 통합 테스트 (H2). 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가
+// 컨트롤러 앞에서 거른다.
+@SpringBootTest
+@ActiveProfiles("test")
+class GetMediaServiceTest {
+
+    private static final Long OTHER_ROOM_ID = 711L;
+
+    @Autowired
+    GetMediaService getMediaService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    private Long hostId;
+    private Long uploaderId;
+    private Long roomId;
+
+    @BeforeEach
+    void setUp() {
+        hostId = memberRepository.save(Member.register(new Nickname("방장"), Instant.now())).getId();
+        uploaderId = memberRepository.save(Member.register(new Nickname("가현"), Instant.now())).getId();
+        roomId = createRoomService.create(hostId, "우테코 회식", null, null).room().getId();
+    }
+
+    @Test
+    void 미디어_메타데이터를_반환한다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+
+        assertThat(media.mediaId()).isEqualTo(file.getId());
+        assertThat(media.fileName()).isEqualTo("사진.jpg");
+        assertThat(media.mimeType()).isEqualTo("image/jpeg");
+        assertThat(media.size()).isEqualTo(1024);
+        assertThat(media.type()).isEqualTo("IMAGE");
+        assertThat(media.status()).isEqualTo("READY");
+        assertThat(media.uploaderId()).isEqualTo(uploaderId);
+        assertThat(media.uploaderName()).isEqualTo("가현");
+        assertThat(media.folderIds()).isEmpty();
+    }
+
+    // 워커가 EXIF 에서 읽어 채운다. 카메라가 남기지 않았으면 비어 있다.
+    @Test
+    void 촬영_시각과_위치를_반환한다() {
+        Instant takenAt = Instant.parse("2026-08-01T12:30:00Z");
+        GeoPoint seoul = new GeoPoint(
+            new BigDecimal("37.566500"), new BigDecimal("126.978000"));
+        StoredFile file = processed(roomId, takenAt, seoul);
+
+        MediaFullDetail full = getMediaService.get(roomId, file.getId(), uploaderId);
+
+        assertThat(full.takenAt()).isEqualTo(takenAt);
+        assertThat(full.location()).isEqualTo(seoul);
+    }
+
+    @Test
+    void 촬영_정보가_없으면_비어_있다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        MediaFullDetail full = getMediaService.get(roomId, file.getId(), uploaderId);
+
+        assertThat(full.takenAt()).isNull();
+        assertThat(full.location()).isNull();
+    }
+
+    @Test
+    void 올린_본인은_지울_수_있다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        assertThat(getMediaService.get(roomId, file.getId(), uploaderId).canDelete()).isTrue();
+    }
+
+    // 방을 관리하는 사람이라 남이 올린 사진도 내릴 수 있어야 한다.
+    @Test
+    void 방장은_남이_올린_것도_지울_수_있다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        assertThat(getMediaService.get(roomId, file.getId(), hostId).canDelete()).isTrue();
+    }
+
+    @Test
+    void 남이_올린_사진은_지울_수_없다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+        Long other = memberRepository.save(
+            Member.register(new Nickname("의찬"), Instant.now())).getId();
+
+        assertThat(getMediaService.get(roomId, file.getId(), other).canDelete()).isFalse();
+    }
+
+    // 워커가 손대는 중이면 원본이 바뀌는 중일 수 있어 표시용 주소를 주지 않는다.
+    @Test
+    void 워커가_채우는_값은_처리_전까지_비어_있다() {
+        StoredFile file = save(roomId, UploadStatus.PROCESSING);
+
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+
+        assertThat(media.thumbnailUrl()).isNull();
+        assertThat(media.originalUrl()).isNull();
+        assertThat(media.width()).isNull();
+        assertThat(media.height()).isNull();
+        assertThat(media.duration()).isNull();
+    }
+
+    @Test
+    void 처리가_끝나면_썸네일과_원본_주소가_생긴다() {
+        StoredFile file = processed(roomId, null, null);
+
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+
+        assertThat(media.thumbnailUrl())
+            .isEqualTo("/api/v1/rooms/%d/media/%d/thumbnail".formatted(roomId, file.getId()));
+        assertThat(media.originalUrl())
+            .isEqualTo("/api/v1/rooms/%d/media/%d/original".formatted(roomId, file.getId()));
+        assertThat(media.width()).isEqualTo(1200);
+        assertThat(media.height()).isEqualTo(900);
+    }
+
+    @Test
+    void 없는_mediaId면_404() {
+        assertThatThrownBy(() -> getMediaService.get(roomId, 999_999L, uploaderId))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    // 403 으로 나누면 남의 방에 그 ID 가 있다는 사실이 드러난다.
+    @Test
+    void 다른_방의_mediaId면_404() {
+        StoredFile file = save(OTHER_ROOM_ID, UploadStatus.READY);
+
+        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId(), uploaderId))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = UploadStatus.class, names = {"RESERVED", "FAILED"})
+    void 실물이_없는_미디어면_404(UploadStatus status) {
+        StoredFile file = save(roomId, status);
+
+        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId(), uploaderId))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    // 아직 처리 중이어도 실물은 스토리지에 있어 목록·단건에는 나온다. 다운로드만 409 로 막는다.
+    @Test
+    void PROCESSING_상태도_조회된다() {
+        StoredFile file = save(roomId, UploadStatus.PROCESSING);
+
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+
+        assertThat(media.status()).isEqualTo("PROCESSING");
+    }
+
+    @Test
+    void 업로더_회원이_사라져도_조회된다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+        jdbcTemplate.update("DELETE FROM member WHERE id = ?", uploaderId);
+
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+
+        assertThat(media.uploaderName()).isNull();
+    }
+
+    private StoredFile save(Long targetRoomId, UploadStatus status) {
+        StoredFile file = StoredFile.reserve(
+            targetRoomId, uploaderId, "사진.jpg", "image/jpeg", new FileSize(1024), Instant.now());
+        switch (status) {
+            case PROCESSING -> file.startProcessing();
+            case READY -> {
+                file.startProcessing();
+                file.markReady();
+            }
+            case FAILED -> file.failUpload();
+            default -> {
+            }
+        }
+        return fileRepository.save(file);
+    }
+
+    // 워커가 처리를 마친 상태. 썸네일 키와 크기, 촬영 정보가 채워져 있다.
+    private StoredFile processed(Long targetRoomId, Instant takenAt, GeoPoint location) {
+        StoredFile file = save(targetRoomId, UploadStatus.PROCESSING);
+        file.completeProcessing(new ProcessedMedia(
+            file.getStorageKey().thumbnail(), 1200, 900, takenAt, location));
+        return fileRepository.save(file);
+    }
+}

--- a/backend/src/test/java/com/sssok/domain/file/UploadStatusVisibilityTest.java
+++ b/backend/src/test/java/com/sssok/domain/file/UploadStatusVisibilityTest.java
@@ -1,0 +1,35 @@
+package com.sssok.domain.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+// 조회 API 가 어떤 상태를 내려보낼지 정하는 규칙.
+class UploadStatusVisibilityTest {
+
+    // 스토리지에 실물이 올라간 뒤의 상태들이다.
+    @ParameterizedTest
+    @EnumSource(value = UploadStatus.class, names = {"PROCESSING", "READY"})
+    void 실물이_있는_상태는_조회에_노출된다(UploadStatus status) {
+        assertThat(status.isVisible()).isTrue();
+    }
+
+    // RESERVED 는 서명 URL 만 나간 상태고, FAILED 는 전송이 끝내 실패한 상태라 둘 다 실물이 없다.
+    // 내려보내면 클라이언트가 열 수 없는 빈 항목을 그리게 된다.
+    @ParameterizedTest
+    @EnumSource(value = UploadStatus.class, names = {"RESERVED", "FAILED"})
+    void 실물이_없는_상태는_조회에_노출되지_않는다(UploadStatus status) {
+        assertThat(status.isVisible()).isFalse();
+    }
+
+    // 상태를 새로 추가하면서 노출 여부를 정하지 않으면 여기서 걸린다.
+    @Test
+    void 노출_대상_목록과_판정이_일치한다() {
+        for (UploadStatus status : UploadStatus.values()) {
+            assertThat(status.isVisible())
+                .isEqualTo(UploadStatus.visibleStatuses().contains(status));
+        }
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryApiTest.java
@@ -1,0 +1,215 @@
+package com.sssok.presentation.api.media;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.auth.AuthResult;
+import com.sssok.application.folder.CreateFolderService;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FileStoragePort.UploadedObject;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.domain.folder.Folder;
+import com.sssok.domain.room.Room;
+import com.sssok.support.PostgresContainerSupport;
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+// API 인수 테스트 (Testcontainers). 폴더 담기가 PostgreSQL 전용 ON CONFLICT 를 써서 H2 로는 못 돈다.
+// 업로드부터 조회까지 실제 흐름 그대로 태우고, 스토리지만 목으로 둔다.
+@SpringBootTest
+class MediaQueryApiTest extends PostgresContainerSupport {
+
+    private static final String MIME = "image/jpeg";
+    private static final long SIZE = 1024L;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    CreateFolderService createFolderService;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    private MockMvc mockMvc;
+    private Long roomId;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        AuthResult host = anonymousAuthService.authenticate("가현");
+        token = "Bearer " + host.accessToken();
+        Room room = createRoomService.create(host.userId(), "우테코 회식", null, null).room();
+        roomId = room.getId();
+        given(fileStoragePort.presignPut(any(), anyString(), any(Duration.class)))
+            .willReturn("https://storage.example.com/signed");
+        given(fileStoragePort.findUploaded(any()))
+            .willReturn(Optional.of(new UploadedObject(SIZE, MIME)));
+    }
+
+    @Test
+    void 업로드한_미디어가_목록에_나온다() throws Exception {
+        Long mediaId = upload("a.jpg", null);
+
+        getMediaList("")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items[0].mediaId").value(mediaId))
+            .andExpect(jsonPath("$.data.items[0].fileName").value("a.jpg"))
+            .andExpect(jsonPath("$.data.items[0].status").value("PROCESSING"))
+            .andExpect(jsonPath("$.data.items[0].uploaderName").value("가현"));
+    }
+
+    @Test
+    void 나중에_올린_미디어가_먼저_나온다() throws Exception {
+        Long first = upload("a.jpg", null);
+        Long second = upload("b.jpg", null);
+
+        getMediaList("")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items[0].mediaId").value(second))
+            .andExpect(jsonPath("$.data.items[1].mediaId").value(first));
+    }
+
+    // 발급만 받고 스토리지에 올리지 않은 미디어는 실물이 없어 목록에 뜨면 안 된다.
+    @Test
+    void 발급만_받고_올리지_않은_미디어는_목록에_없다() throws Exception {
+        Long uploaded = upload("a.jpg", null);
+        issueOnly("b.jpg");
+
+        getMediaList("")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.items[0].mediaId").value(uploaded));
+    }
+
+    @Test
+    void 폴더로_필터하면_그_폴더에_담긴_것만_나온다() throws Exception {
+        Folder folder = createFolderService.create(roomId, "1일차");
+        Long inFolder = upload("a.jpg", folder.getId());
+        upload("b.jpg", null);
+
+        getMediaList("?folderId=" + folder.getId())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.items[0].mediaId").value(inFolder))
+            .andExpect(jsonPath("$.data.items[0].folderIds[0]").value(folder.getId()));
+    }
+
+    @Test
+    void 없는_폴더로_필터하면_404() throws Exception {
+        getMediaList("?folderId=-1")
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("FOLDER_NOT_FOUND"));
+    }
+
+    @Test
+    void 단건으로_조회하면_같은_내용이_나온다() throws Exception {
+        Folder folder = createFolderService.create(roomId, "1일차");
+        Long mediaId = upload("a.jpg", folder.getId());
+
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, mediaId)
+                .header("Authorization", token))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.mediaId").value(mediaId))
+            .andExpect(jsonPath("$.data.fileName").value("a.jpg"))
+            .andExpect(jsonPath("$.data.mimeType").value(MIME))
+            .andExpect(jsonPath("$.data.size").value(SIZE))
+            .andExpect(jsonPath("$.data.folderIds[0]").value(folder.getId()));
+    }
+
+    // 올린 본인이라 지울 수 있고, EXIF 가 없는 이미지라 촬영 정보는 비어 있다.
+    @Test
+    void 단건에는_촬영_정보와_삭제_권한이_함께_나온다() throws Exception {
+        Long mediaId = upload("a.jpg", null);
+
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, mediaId)
+                .header("Authorization", token))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.canDelete").value(true))
+            .andExpect(jsonPath("$.data.takenAt").doesNotExist())
+            .andExpect(jsonPath("$.data.location").doesNotExist());
+    }
+
+    @Test
+    void 없는_미디어를_조회하면_404() throws Exception {
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, -1L)
+                .header("Authorization", token))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
+    }
+
+    // 입장하지 않은 사용자는 RoomMembershipInterceptor 가 컨트롤러 앞에서 막는다.
+    @Test
+    void 입장하지_않은_사용자는_403() throws Exception {
+        String outsider = "Bearer " + anonymousAuthService.authenticate("의찬").accessToken();
+
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media", roomId)
+                .header("Authorization", outsider))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("NOT_ROOM_MEMBER"));
+    }
+
+    private ResultActions getMediaList(String query) throws Exception {
+        return mockMvc.perform(get("/api/v1/rooms/" + roomId + "/media" + query)
+            .header("Authorization", token));
+    }
+
+    // 발급 → 완료 등록까지 한 번에 태워 조회 대상 미디어를 만든다.
+    private Long upload(String fileName, Long folderId) throws Exception {
+        Long mediaId = issueOnly(fileName, folderId);
+        mockMvc.perform(post("/api/v1/rooms/{roomId}/media", roomId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[%d]}".formatted(mediaId)))
+            .andExpect(status().isCreated());
+        return mediaId;
+    }
+
+    private Long issueOnly(String fileName) throws Exception {
+        return issueOnly(fileName, null);
+    }
+
+    private Long issueOnly(String fileName, Long folderId) throws Exception {
+        String folders = folderId == null ? "" : ",\"folderIds\":[%d]".formatted(folderId);
+        String body = "{\"files\":[{\"fileName\":\"%s\",\"mimeType\":\"%s\",\"size\":%d}]%s}"
+            .formatted(fileName, MIME, SIZE, folders);
+
+        String response = mockMvc.perform(post("/api/v1/rooms/{roomId}/media/upload-urls", roomId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        return root.path("data").path("issued").get(0).path("mediaId").asLong();
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryApiTest.java
@@ -145,18 +145,6 @@ class MediaQueryApiTest extends PostgresContainerSupport {
             .andExpect(jsonPath("$.data.folderIds[0]").value(folder.getId()));
     }
 
-    // 올린 본인이라 지울 수 있고, EXIF 가 없는 이미지라 촬영 정보는 비어 있다.
-    @Test
-    void 단건에는_촬영_정보와_삭제_권한이_함께_나온다() throws Exception {
-        Long mediaId = upload("a.jpg", null);
-
-        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, mediaId)
-                .header("Authorization", token))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.canDelete").value(true))
-            .andExpect(jsonPath("$.data.takenAt").doesNotExist())
-            .andExpect(jsonPath("$.data.location").doesNotExist());
-    }
 
     @Test
     void 없는_미디어를_조회하면_404() throws Exception {

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
@@ -1,0 +1,210 @@
+package com.sssok.presentation.api.media;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.folder.exception.FolderNotFoundException;
+import com.sssok.application.media.GetMediaListService;
+import com.sssok.application.media.GetMediaService;
+import com.sssok.application.media.MediaDetail;
+import com.sssok.application.media.MediaFullDetail;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.port.out.RoomMemberRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.domain.file.GeoPoint;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomMember;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.math.BigDecimal;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MediaQueryController.class)
+class MediaQueryControllerTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long MEMBER_ID = 2L;
+    private static final Long MEDIA_ID = 5012L;
+    private static final Long FOLDER_ID = 31L;
+    private static final String BEARER = "Bearer valid-token";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    GetMediaListService getMediaListService;
+
+    @MockitoBean
+    GetMediaService getMediaService;
+
+    @MockitoBean
+    TokenProvider tokenProvider;
+
+    @MockitoBean
+    RoomRepository roomRepository;
+
+    @MockitoBean
+    RoomMemberRepository roomMemberRepository;
+
+    @BeforeEach
+    void setUp() {
+        given(tokenProvider.parse("valid-token")).willReturn(MEMBER_ID);
+        given(roomRepository.findById(ROOM_ID)).willReturn(Optional.of(activeRoom()));
+        given(roomMemberRepository.findByRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+            .willReturn(Optional.of(RoomMember.reconstruct(1L, ROOM_ID, MEMBER_ID, Instant.now())));
+    }
+
+    @Test
+    void 목록을_조회하면_200과_items_를_반환한다() throws Exception {
+        given(getMediaListService.list(anyLong(), any())).willReturn(List.of(media()));
+
+        getMediaList("")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items[0].mediaId").value(MEDIA_ID))
+            .andExpect(jsonPath("$.data.items[0].type").value("IMAGE"))
+            .andExpect(jsonPath("$.data.items[0].fileName").value("사진.jpg"))
+            .andExpect(jsonPath("$.data.items[0].mimeType").value("image/jpeg"))
+            .andExpect(jsonPath("$.data.items[0].size").value(1024))
+            .andExpect(jsonPath("$.data.items[0].status").value("READY"))
+            .andExpect(jsonPath("$.data.items[0].uploaderId").value(7))
+            .andExpect(jsonPath("$.data.items[0].uploaderName").value("가현"))
+            .andExpect(jsonPath("$.data.items[0].folderIds[0]").value(FOLDER_ID))
+            .andExpect(jsonPath("$.data.items[0].thumbnailUrl").doesNotExist())
+            .andExpect(jsonPath("$.data.items[0].uploadedAt").exists());
+    }
+
+    @Test
+    void 미디어가_없으면_빈_배열을_반환한다() throws Exception {
+        given(getMediaListService.list(anyLong(), any())).willReturn(List.of());
+
+        getMediaList("")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items").isArray())
+            .andExpect(jsonPath("$.data.items").isEmpty());
+    }
+
+    @Test
+    void folderId를_생략하면_null로_넘긴다() throws Exception {
+        given(getMediaListService.list(anyLong(), any())).willReturn(List.of());
+
+        getMediaList("");
+
+        verify(getMediaListService).list(eq(ROOM_ID), isNull());
+    }
+
+    @Test
+    void folderId를_주면_그대로_넘긴다() throws Exception {
+        given(getMediaListService.list(anyLong(), any())).willReturn(List.of());
+
+        getMediaList("?folderId=" + FOLDER_ID);
+
+        verify(getMediaListService).list(ROOM_ID, FOLDER_ID);
+    }
+
+    @Test
+    void 없는_폴더로_필터하면_404() throws Exception {
+        willThrow(new FolderNotFoundException(FOLDER_ID))
+            .given(getMediaListService).list(anyLong(), any());
+
+        getMediaList("?folderId=" + FOLDER_ID)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("FOLDER_NOT_FOUND"));
+    }
+
+    // 목록 항목의 필드가 단건 응답에도 그대로 펼쳐져야 한다. 한 겹 더 감싸이면 프론트가 갈라진다.
+    @Test
+    void 단건을_조회하면_200과_미디어를_반환한다() throws Exception {
+        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(fullDetail());
+
+        getMedia(MEDIA_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.mediaId").value(MEDIA_ID))
+            .andExpect(jsonPath("$.data.fileName").value("사진.jpg"))
+            .andExpect(jsonPath("$.data.folderIds[0]").value(FOLDER_ID));
+    }
+
+    @Test
+    void 단건에는_촬영_정보와_삭제_권한이_함께_나온다() throws Exception {
+        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(fullDetail());
+
+        getMedia(MEDIA_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.takenAt").value("2026-08-01T12:30:00Z"))
+            .andExpect(jsonPath("$.data.location.latitude").value(37.5665))
+            .andExpect(jsonPath("$.data.location.longitude").value(126.978))
+            .andExpect(jsonPath("$.data.location.name").doesNotExist())
+            .andExpect(jsonPath("$.data.canDelete").value(true));
+    }
+
+    // EXIF 가 없는 사진이 훨씬 많다. 그때도 응답 구조가 흔들리면 안 된다.
+    @Test
+    void 촬영_정보가_없으면_location이_통째로_비어_있다() throws Exception {
+        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID))
+            .willReturn(new MediaFullDetail(media(), null, null, false));
+
+        getMedia(MEDIA_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.takenAt").doesNotExist())
+            .andExpect(jsonPath("$.data.location").doesNotExist())
+            .andExpect(jsonPath("$.data.canDelete").value(false));
+    }
+
+    @Test
+    void 없는_미디어를_조회하면_404() throws Exception {
+        willThrow(new MediaNotFoundException())
+            .given(getMediaService).get(anyLong(), anyLong(), anyLong());
+
+        getMedia(MEDIA_ID)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
+    }
+
+    private MediaFullDetail fullDetail() {
+        return new MediaFullDetail(media(), Instant.parse("2026-08-01T12:30:00Z"),
+            new GeoPoint(new BigDecimal("37.566500"), new BigDecimal("126.978000")), true);
+    }
+
+    private MediaDetail media() {
+        return new MediaDetail(MEDIA_ID, "IMAGE", "사진.jpg", "image/jpeg", 1024L,
+            null, null, null, null, null, List.of(FOLDER_ID), 7L, "가현", "READY", Instant.now());
+    }
+
+    private ResultActions getMediaList(String query) throws Exception {
+        return mockMvc.perform(get("/api/v1/rooms/" + ROOM_ID + "/media" + query)
+            .header("Authorization", BEARER));
+    }
+
+    private ResultActions getMedia(Long mediaId) throws Exception {
+        return mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}", ROOM_ID, mediaId)
+            .header("Authorization", BEARER));
+    }
+
+    private Room activeRoom() {
+        return Room.reconstruct(ROOM_ID, null, RoomCode.generate(new SecureRandom()),
+            new RoomName("우테코 회식"), RoomStatus.initial(),
+            new RoomExpiration(Instant.now().plusSeconds(3600)), UploadPolicy.ANYONE,
+            1L, Instant.now(), null);
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
@@ -15,12 +15,10 @@ import com.sssok.application.folder.exception.FolderNotFoundException;
 import com.sssok.application.media.GetMediaListService;
 import com.sssok.application.media.GetMediaService;
 import com.sssok.application.media.MediaDetail;
-import com.sssok.application.media.MediaFullDetail;
 import com.sssok.application.media.exception.MediaNotFoundException;
 import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.application.port.out.TokenProvider;
-import com.sssok.domain.file.GeoPoint;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
 import com.sssok.domain.room.RoomExpiration;
@@ -28,7 +26,6 @@ import com.sssok.domain.room.RoomMember;
 import com.sssok.domain.room.RoomName;
 import com.sssok.domain.room.UploadPolicy;
 import com.sssok.domain.room.roomstatus.RoomStatus;
-import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.List;
@@ -133,10 +130,9 @@ class MediaQueryControllerTest {
             .andExpect(jsonPath("$.code").value("FOLDER_NOT_FOUND"));
     }
 
-    // 목록 항목의 필드가 단건 응답에도 그대로 펼쳐져야 한다. 한 겹 더 감싸이면 프론트가 갈라진다.
     @Test
     void 단건을_조회하면_200과_미디어를_반환한다() throws Exception {
-        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(fullDetail());
+        given(getMediaService.get(ROOM_ID, MEDIA_ID)).willReturn(media());
 
         getMedia(MEDIA_ID)
             .andExpect(status().isOk())
@@ -145,46 +141,17 @@ class MediaQueryControllerTest {
             .andExpect(jsonPath("$.data.folderIds[0]").value(FOLDER_ID));
     }
 
-    @Test
-    void 단건에는_촬영_정보와_삭제_권한이_함께_나온다() throws Exception {
-        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(fullDetail());
 
-        getMedia(MEDIA_ID)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.takenAt").value("2026-08-01T12:30:00Z"))
-            .andExpect(jsonPath("$.data.location.latitude").value(37.5665))
-            .andExpect(jsonPath("$.data.location.longitude").value(126.978))
-            .andExpect(jsonPath("$.data.location.name").doesNotExist())
-            .andExpect(jsonPath("$.data.canDelete").value(true));
-    }
-
-    // EXIF 가 없는 사진이 훨씬 많다. 그때도 응답 구조가 흔들리면 안 된다.
-    @Test
-    void 촬영_정보가_없으면_location이_통째로_비어_있다() throws Exception {
-        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID))
-            .willReturn(new MediaFullDetail(media(), null, null, false));
-
-        getMedia(MEDIA_ID)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.takenAt").doesNotExist())
-            .andExpect(jsonPath("$.data.location").doesNotExist())
-            .andExpect(jsonPath("$.data.canDelete").value(false));
-    }
 
     @Test
     void 없는_미디어를_조회하면_404() throws Exception {
-        willThrow(new MediaNotFoundException())
-            .given(getMediaService).get(anyLong(), anyLong(), anyLong());
+        willThrow(new MediaNotFoundException()).given(getMediaService).get(anyLong(), anyLong());
 
         getMedia(MEDIA_ID)
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
     }
 
-    private MediaFullDetail fullDetail() {
-        return new MediaFullDetail(media(), Instant.parse("2026-08-01T12:30:00Z"),
-            new GeoPoint(new BigDecimal("37.566500"), new BigDecimal("126.978000")), true);
-    }
 
     private MediaDetail media() {
         return new MediaDetail(MEDIA_ID, "IMAGE", "사진.jpg", "image/jpeg", 1024L,


### PR DESCRIPTION
## 작업 내용

방에 올라온 미디어를 읽는 조회 전용 API 두 개를 구현했다.

```
GET /api/v1/rooms/{roomId}/media?folderId={id}   목록 (최신순)
GET /api/v1/rooms/{roomId}/media/{mediaId}       단건
```

> **이 PR 위에 `feature/be-#107-media-thumbnail-worker` 가 쌓여 있다.**
> 썸네일 워커·촬영 정보는 관심사가 달라 후속 PR로 분리했다. 이 PR이 먼저 머지돼야 diff가 정확하게 보인다.

## 관련 이슈

Closes #107

## 작업 영역

- [ ] Frontend
- [x] Backend

## 동작 흐름

```
GET /rooms/1/media?folderId=31
      │
      ▼
RoomMembershipInterceptor ──▶ 404 ROOM_NOT_FOUND / 410 ROOM_EXPIRED / 403 NOT_ROOM_MEMBER
      │
      ▼
GetMediaListService
      ├─ 폴더가 이 방 소속인가              → 404 FOLDER_NOT_FOUND
      ├─ folder_media 에서 미디어 id
      └─ 방 + 노출 상태 + 최신순 조회
      │
      ▼
MediaDetailAssembler          폴더 소속 1쿼리 + 업로더 이름 1쿼리
      │
      ▼
{ "data": { "items": [...] } }                    200
```

## 변경 사항

### 실물이 없는 미디어는 조회에 노출하지 않는다

이슈의 "삭제된 미디어는 목록에 노출하지 않는다"를 실제로 문제가 되는 기준으로 옮겼다. 지금 삭제 상태도 삭제 API도 없어서다.

| 상태 | 뜻 | 노출 |
| --- | --- | --- |
| `RESERVED` | URL만 발급, 아직 안 올림 | ❌ |
| `PROCESSING` | 올라감, 워커 대기 | ✅ |
| `READY` | 워커까지 완료 | ✅ |
| `FAILED` | 전송 끝내 실패 | ❌ |

기준은 **스토리지에 실물이 있는가**다. 없는 걸 내려주면 클라이언트가 열 수 없는 빈 칸을 그린다. 새로 만든 기준이 아니라 **기존 다운로드 API가 이미 쓰던 기준**이다.

### 정렬에 id 를 함께 넣는다

```java
findAllByRoomIdAndStatusInOrderByCreatedAtDescIdDesc
                                            ^^^^^^
```

`IssueUploadUrlsService` 가 `Instant now` 를 한 번 찍어 배치 전체에 쓴다. **한 번에 30장을 올리면 `createdAt` 이 전부 같아서**, 시각만으로 정렬하면 순서가 호출마다 바뀐다.

### 미디어가 몇 장이든 3쿼리

`folderIds` 와 `uploaderName` 이 다른 테이블에 있다. 미디어마다 찾아오면 30장짜리 목록에 쿼리가 60번 나간다. `MediaDetailAssembler` 가 종류별로 한 번씩만 모아 `Map` 으로 붙인다.

이를 위해 `MemberRepository.findAllByIdIn` 을 추가했다. 기존에는 `findById` 뿐이었다.

### 폴더 필터는 소속까지 확인한다

```java
folderRepository.findById(folderId)
    .filter(folder -> folder.belongsTo(roomId))   // ← 이 줄
    .orElseThrow(() -> new FolderNotFoundException(folderId));
```

없으면 **다른 방 폴더 ID로 그 방 사진을 들여다볼 수 있다.**

폴더로 좁힌 뒤에도 `roomId` 조건을 다시 건다. 폴더가 이 방 소속인 건 확인했지만, `folder_media` 에 담긴 미디어까지 같은 방이라는 보장은 없다.

### 세 가지 실패를 모두 404로 낸다

없는 ID / 다른 방 / 실물 없음. 다른 방일 때만 403을 주면 **그 ID가 남의 방에 존재한다는 사실이 새어나간다.**

### 목록을 `items` 로 한 겹 감쌌다

배열을 그대로 내리면 나중에 페이지네이션이 붙을 때 프론트가 깨진다. 감싸두면 필드만 늘리면 된다.

### 오류 메시지 수정

`MEDIA_NOT_FOUND` 가 "업로드 요청을 찾을 수 없습니다"로 나가고 있었다. 조회·다운로드·재발급이 함께 쓰는 코드라 업로드에 한정된 표현을 걷어내고 "존재하지 않는 미디어입니다"로 바꿨다.

## 테스트

- [x] 단위 테스트 작성/통과 (`./gradlew test` 전체 통과)
- [x] 로컬 동작 확인 (Swagger UI 및 실제 R2 업로드 후 조회)

| 테스트 | 개수 | 환경 | 검증 대상 |
| --- | --- | --- | --- |
| `GetMediaListServiceTest` | 13 | H2 | 방 격리·정렬·상태 필터·폴더 필터 |
| `GetMediaServiceTest` | 9 | H2 | 단건 조회와 404 케이스 |
| `MediaQueryControllerTest` | 7 | 슬라이스 | 응답 형태·파라미터 전달·오류 코드 |
| `MediaQueryApiTest` | 8 | Testcontainers | 업로드→조회 전체 경로 |
| `UploadStatusVisibilityTest` | 3 | 단위 | 노출 규칙 |

**고친 부분을 되돌려 테스트가 깨지는지 확인했다:**

- `IdDesc` 제거 → `같은_시각에_올라온_미디어도_순서가_고정된다` FAILED
- `belongsTo` 제거 → `다른_방의_폴더로_필터하면_404` FAILED
- `isVisible` 제거 → `실물이_없는_미디어면_404` FAILED

**Swagger UI에서 직접 실행해 이슈 완료 조건 전부를 실제 응답과 대조했다.** 목록·단건 200, 없는 폴더 404, 없는/다른 방 미디어 404, 미입장 403, 없는 방 404, 삭제된 방 410 확인.

## 리뷰 요청 사항 (선택)

### 명세와 다르게 간 부분

- **필드명을 `mediaId`·`uploadedAt` 으로 했다.** 이슈 본문은 `id`·`createdAt` 인데, #76 업로드 응답이 이미 `mediaId`·`uploadedAt` 을 쓰고 있어 그대로 두면 같은 사진이 API마다 다른 이름으로 나간다. **이슈 쪽을 고치는 게 맞다고 본다.**
- **커서 페이지네이션과 `type`·`uploader`·`root`·`sort` 필터를 넣지 않았다.** 이슈 완료 조건에 없어 제외했다. `folderId` 만 남겼는데, 이걸 빼면 **폴더에 담을 수는 있어도 열어볼 방법이 없어진다** — 폴더 내용을 보는 다른 경로가 저장소에 없다.

### 판단이 갈릴 수 있는 지점

- **`thumbnailUrl`·`width` 등은 이 PR에서 전부 `null` 이다.** 후속 PR의 워커가 채운다. 프론트가 `null` 을 전제로 만들어야 한다.
- **"삭제된 미디어 제외"를 `RESERVED`·`FAILED` 제외로 해석했다.** 삭제 API가 생기면 그때 기준을 다시 봐야 한다.
- **업로더가 방을 나가면 `uploaderName` 이 `null` 로 나간다.** 사진은 방에 남으므로 목록에서 빼지 않았다. 여기서 예외를 던지면 사진 한 장 때문에 목록 전체가 죽는다.
- **미디어 삭제 API는 이 PR 범위가 아니다.** 이슈가 조회 전용이라 넣지 않았다.
