### PR TITLE
feat: 썸네일 생성 워커와 촬영 정보 조회 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     // 이미지 썸네일
     implementation 'net.coobird:thumbnailator:0.4.20'
 
+    // EXIF 촬영 시각·GPS 추출
+    implementation 'com.drewnoakes:metadata-extractor:2.19.0'
+
     // JWT
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"

--- a/backend/src/main/java/com/sssok/application/media/GenerateThumbnailService.java
+++ b/backend/src/main/java/com/sssok/application/media/GenerateThumbnailService.java
@@ -1,0 +1,113 @@
+package com.sssok.application.media;
+
+import com.sssok.application.port.out.AbortableOutputStream;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.ImageProcessorPort;
+import com.sssok.application.port.out.ImageProcessorPort.CaptureInfo;
+import com.sssok.application.port.out.ImageProcessorPort.ProcessedImage;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StorageKey;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import com.sssok.infrastructure.config.ThumbnailProperties;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+// 등록된 미디어를 PROCESSING 에서 READY 로 넘기는 워커.
+//
+// 트랜잭션을 열지 않는다. 원본을 내려받고 줄여서 다시 올리는 동안 DB 커넥션을 쥐고 있으면
+// 사진 몇 장만 처리해도 풀이 마른다. 실제 쓰기는 MediaFinisher 가 짧게 연다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GenerateThumbnailService {
+
+    private final FileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+    private final ImageProcessorPort imageProcessor;
+    private final MediaFinisher mediaFinisher;
+    private final ThumbnailProperties properties;
+
+    public void generate(Long mediaId) {
+        StoredFile file = fileRepository.findById(mediaId).orElse(null);
+        if (file == null || file.getStatus() != UploadStatus.PROCESSING) {
+            return;
+        }
+        try {
+            process(file);
+        } catch (RuntimeException e) {
+            // 스토리지나 네트워크 오류는 대개 일시적이다. 여기서 FAILED 로 내리면 멀쩡히 올라간
+            // 사진이 목록에서 사라진다. PROCESSING 으로 두면 회수 배치가 다시 태운다.
+            log.warn("썸네일 생성에 실패했습니다. 회수 배치가 다시 시도합니다. mediaId={}", mediaId, e);
+        }
+    }
+
+    private void process(StoredFile file) {
+        // 영상은 프레임을 뽑으려면 별도 도구가 필요하다. 썸네일 없이 완료로 넘긴다 —
+        // PROCESSING 에 두면 다운로드가 영영 409 로 막힌다.
+        //
+        // 원본을 내려받지도 않는다. 영상은 최대 1GB 라, 길이 하나 읽자고 통째로 메모리에 올리면
+        // 서버가 죽는다. duration 은 스트리밍으로 읽는 도구가 붙은 뒤에 채운다.
+        if (!file.canGenerateThumbnail()) {
+            mediaFinisher.finish(file, ProcessedMedia.none());
+            return;
+        }
+
+        // 원본이 없으면 여기서 예외가 난다. 등록 때 실물을 확인했으므로 원래는 있어야 하고,
+        // 지금 안 보이는 것은 일시적일 수 있어 바깥에서 PROCESSING 으로 남긴다.
+        byte[] original = readOriginal(file.getStorageKey());
+
+        // 원본과 같은 형식으로 줄인다. PNG 를 JPEG 로 바꾸면 투명한 부분이 검게 나온다.
+        Optional<ProcessedImage> shrunk = imageProcessor.shrink(
+            original, properties.maxWidth(), file.getMediaType().extension());
+        if (shrunk.isEmpty()) {
+            // 파일이 깨졌거나 확장자와 실제 내용이 다르다. 다시 시도해도 결과가 같으므로
+            // 여기서만 FAILED 로 확정한다 — 되풀이해도 소용없는 유일한 경우다.
+            log.warn("이미지를 읽을 수 없습니다. mediaId={}", file.getId());
+            mediaFinisher.markFailed(file);
+            return;
+        }
+
+        ProcessedImage image = shrunk.get();
+        StorageKey thumbnailKey = file.getStorageKey().thumbnail();
+        upload(thumbnailKey, image.content(), file.getMediaType().contentType());
+
+        // 썸네일을 만들면서 EXIF 도 같이 읽는다. 원본이 이미 메모리에 있어 추가 왕복이 없다.
+        CaptureInfo capture = imageProcessor.readCaptureInfo(original);
+
+        // 크기는 썸네일이 아니라 원본의 것을 저장한다. 클라이언트가 자리를 미리 잡는 데 쓴다.
+        mediaFinisher.finish(file, new ProcessedMedia(thumbnailKey,
+            image.sourceWidth(), image.sourceHeight(), capture.takenAt(), capture.location()));
+    }
+
+    // 이미지는 최대 10MB 라 통째로 읽어도 괜찮다. 축소하려면 어차피 전체가 필요하다.
+    // 영상은 여기까지 오지 않는다 — 1GB 를 힙에 올리면 서버가 죽는다.
+    private byte[] readOriginal(StorageKey storageKey) {
+        try (InputStream in = fileStoragePort.openDownloadStream(storageKey)) {
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // 실패하면 abort 로 정리한다. 그냥 두면 완료되지 않은 멀티파트 조각이 스토리지에 남아 요금을 먹는다.
+    private void upload(StorageKey storageKey, byte[] content, String contentType) {
+        AbortableOutputStream out = fileStoragePort.openUploadStream(storageKey, contentType);
+        try {
+            out.write(content);
+            out.close();
+        } catch (IOException e) {
+            out.abort();
+            throw new UncheckedIOException(e);
+        } catch (RuntimeException e) {
+            out.abort();
+            throw e;
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/GetMediaService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetMediaService.java
@@ -2,6 +2,8 @@ package com.sssok.application.media;
 
 import com.sssok.application.media.exception.MediaNotFoundException;
 import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.file.FilePermissionPolicy;
 import com.sssok.domain.file.StoredFile;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,17 +16,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetMediaService {
 
     private final FileRepository fileRepository;
+    private final RoomRepository roomRepository;
     private final MediaDetailAssembler assembler;
 
     // 다른 방 미디어와 아직 실물이 없는 미디어를 모두 404 로 낸다. 403 으로 나누면
     // 남의 방에 그 ID 가 있다는 사실이 드러난다.
     @Transactional(readOnly = true)
-    public MediaDetail get(Long roomId, Long mediaId) {
+    public MediaFullDetail get(Long roomId, Long mediaId, Long requesterId) {
         StoredFile file = fileRepository.findById(mediaId)
             .filter(found -> found.getRoomId().equals(roomId))
             .filter(found -> found.getStatus().isVisible())
             .orElseThrow(MediaNotFoundException::new);
 
-        return assembler.assemble(List.of(file)).getFirst();
+        MediaDetail media = assembler.assemble(List.of(file)).getFirst();
+        return MediaFullDetail.of(file, media, canDelete(file, roomId, requesterId));
+    }
+
+    // 올린 본인과 방장이 지울 수 있다. 프론트가 삭제 버튼을 보일지 정하는 데 쓴다.
+    private boolean canDelete(StoredFile file, Long roomId, Long requesterId) {
+        boolean isHost = roomRepository.findById(roomId)
+            .map(room -> room.getHostId().equals(requesterId))
+            .orElse(false);
+        return FilePermissionPolicy.canDelete(file, requesterId, isHost);
     }
 }

--- a/backend/src/main/java/com/sssok/application/media/GetOriginalUrlService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetOriginalUrlService.java
@@ -1,0 +1,39 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.MediaNotReadyException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import com.sssok.infrastructure.config.DownloadProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 원본을 화면에 띄우기 위한 경로. 저장용 다운로드(#84)와 나뉘는 지점은 Content-Disposition 하나다 —
+// attachment 로 내려주면 브라우저가 저장 대화상자를 띄워, 크게 보기에는 쓸 수 없다.
+//
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class GetOriginalUrlService {
+
+    private final FileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+    private final DownloadProperties downloadProperties;
+
+    public String getUrl(Long roomId, Long mediaId) {
+        StoredFile file = fileRepository.findById(mediaId)
+            .filter(found -> found.getRoomId().equals(roomId))
+            .filter(found -> found.getStatus().isVisible())
+            .orElseThrow(MediaNotFoundException::new);
+
+        // 워커가 아직 손대는 중이면 원본이 바뀌는 중일 수 있다. 다운로드와 같은 기준으로 막는다.
+        if (file.getStatus() != UploadStatus.READY) {
+            throw new MediaNotReadyException();
+        }
+
+        return fileStoragePort.presignGet(file.getStorageKey(), "inline",
+            file.getMediaType().contentType(), downloadProperties.presignedGetTtl());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/GetThumbnailUrlService.java
+++ b/backend/src/main/java/com/sssok/application/media/GetThumbnailUrlService.java
@@ -1,0 +1,37 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.ThumbnailNotFoundException;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.infrastructure.config.DownloadProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 방 존재·만료·입장 여부는 RoomMembershipInterceptor 가 먼저 걸러준다.
+@Service
+@RequiredArgsConstructor
+public class GetThumbnailUrlService {
+
+    private final FileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+    private final DownloadProperties downloadProperties;
+
+    public String getUrl(Long roomId, Long mediaId) {
+        StoredFile file = fileRepository.findById(mediaId)
+            .filter(found -> found.getRoomId().equals(roomId))
+            .filter(found -> found.getStatus().isVisible())
+            .orElseThrow(MediaNotFoundException::new);
+
+        // 아직 워커가 만들지 않았거나(PROCESSING) 영상이라 만들 수 없는 경우다.
+        // 미디어 자체는 있으므로 404 MEDIA_NOT_FOUND 와 구분해서 알려준다.
+        if (file.getThumbnailKey() == null) {
+            throw new ThumbnailNotFoundException();
+        }
+
+        // attachment 가 아니라 inline 이다. 목록 타일에 그리는 용도라 저장 대화상자가 뜨면 안 된다.
+        return fileStoragePort.presignGet(file.getThumbnailKey(), "inline",
+            file.getMediaType().contentType(), downloadProperties.presignedGetTtl());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaDetail.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaDetail.java
@@ -1,6 +1,7 @@
 package com.sssok.application.media;
 
 import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
 import java.time.Instant;
 import java.util.List;
 
@@ -10,7 +11,13 @@ public record MediaDetail(Long mediaId, String type, String fileName, String mim
                           Integer duration, List<Long> folderIds, Long uploaderId,
                           String uploaderName, String status, Instant uploadedAt) {
 
-    // 썸네일·크기·재생 시간은 워커가 채우기 전까지 비어 있다.
+    // 서명 URL 을 그대로 싣지 않고 이 경로를 준다. 서명은 몇 분이면 만료되어, 목록을 캐싱하거나
+    // 잠시 뒤에 그리면 깨진다. 경로는 만료되지 않고, 방 참여자만 통과한다.
+    private static final String THUMBNAIL_PATH = "/api/v1/rooms/%d/media/%d/thumbnail";
+    private static final String ORIGINAL_PATH = "/api/v1/rooms/%d/media/%d/original";
+
+    // 썸네일·크기는 워커가 채우기 전까지, 영상은 끝까지 비어 있다.
+    // duration 은 영상 길이라, 스트리밍으로 읽는 도구가 붙기 전까지 비어 있다.
     public static MediaDetail of(StoredFile file, String uploaderName, List<Long> folderIds) {
         return new MediaDetail(
             file.getId(),
@@ -18,10 +25,10 @@ public record MediaDetail(Long mediaId, String type, String fileName, String mim
             file.getOriginalFileName(),
             file.getMediaType().contentType(),
             file.getFileSize().bytes(),
-            null,
-            null,
-            null,
-            null,
+            thumbnailUrl(file),
+            originalUrl(file),
+            file.getWidth(),
+            file.getHeight(),
             null,
             folderIds,
             file.getUploaderId(),
@@ -29,5 +36,20 @@ public record MediaDetail(Long mediaId, String type, String fileName, String mim
             file.getStatus().name(),
             file.getCreatedAt()
         );
+    }
+
+    private static String thumbnailUrl(StoredFile file) {
+        if (file.getThumbnailKey() == null) {
+            return null;
+        }
+        return THUMBNAIL_PATH.formatted(file.getRoomId(), file.getId());
+    }
+
+    // 워커가 손대는 중(PROCESSING)이면 원본이 바뀌는 중일 수 있어, 그동안은 주지 않는다.
+    private static String originalUrl(StoredFile file) {
+        if (file.getStatus() != UploadStatus.READY) {
+            return null;
+        }
+        return ORIGINAL_PATH.formatted(file.getRoomId(), file.getId());
     }
 }

--- a/backend/src/main/java/com/sssok/application/media/MediaEventListener.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaEventListener.java
@@ -21,4 +21,12 @@ public class MediaEventListener {
     public void handle(MediaCreatedEvent event) {
         eventPublisher.publish(event.roomId(), "media.created", event.media());
     }
+
+    // 썸네일이 붙어 목록에 실제로 그릴 수 있게 된 시점. 프론트는 media.created 로 자리를 잡아두고
+    // 이 이벤트로 같은 mediaId 의 항목을 갈아끼운다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MediaReadyEvent event) {
+        eventPublisher.publish(event.roomId(), "media.ready", event.media());
+    }
 }

--- a/backend/src/main/java/com/sssok/application/media/MediaFinisher.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaFinisher.java
@@ -1,0 +1,49 @@
+package com.sssok.application.media;
+
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.application.port.out.MemberRepository;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StoredFile;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// 워커 결과를 DB 에 반영하는 부분만 짧게 트랜잭션으로 감싼다.
+// GenerateThumbnailService 안에서 직접 호출하면 프록시를 타지 않아 @Transactional 이 걸리지 않으므로
+// 별도 빈으로 둔다.
+@Component
+@RequiredArgsConstructor
+public class MediaFinisher {
+
+    private final FileRepository fileRepository;
+    private final FolderMediaRepository folderMediaRepository;
+    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void finish(StoredFile file, ProcessedMedia processed) {
+        file.completeProcessing(processed);
+        StoredFile saved = fileRepository.save(file);
+        eventPublisher.publishEvent(new MediaReadyEvent(saved.getRoomId(), detailOf(saved)));
+    }
+
+    @Transactional
+    public void markFailed(StoredFile file) {
+        file.failUpload();
+        fileRepository.save(file);
+    }
+
+    // SSE 로 나가는 payload 는 목록 항목과 같은 모양이어야 프론트가 그대로 갈아끼울 수 있다.
+    private MediaDetail detailOf(StoredFile file) {
+        String uploaderName = memberRepository.findById(file.getUploaderId())
+            .map(member -> member.getDisplayName().value())
+            .orElse(null);
+        List<Long> folderIds = folderMediaRepository
+            .findFolderIdsByMedia(List.of(file.getId()))
+            .getOrDefault(file.getId(), List.of());
+        return MediaDetail.of(file, uploaderName, folderIds);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaFullDetail.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaFullDetail.java
@@ -1,0 +1,17 @@
+package com.sssok.application.media;
+
+import com.sssok.domain.file.GeoPoint;
+import com.sssok.domain.file.StoredFile;
+import java.time.Instant;
+
+// 단건 조회 전용. 목록의 항목에 촬영 정보와 삭제 권한을 더한 것이다.
+//
+// 목록에 함께 싣지 않는 이유는 canDelete 다. 이 값은 보는 사람에 따라 달라져서, 목록에 넣으면
+// 같은 방의 사진 목록을 사용자마다 다르게 캐싱해야 한다.
+public record MediaFullDetail(MediaDetail media, Instant takenAt, GeoPoint location,
+                              boolean canDelete) {
+
+    public static MediaFullDetail of(StoredFile file, MediaDetail media, boolean canDelete) {
+        return new MediaFullDetail(media, file.getTakenAt(), file.getLocation(), canDelete);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaReadyEvent.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaReadyEvent.java
@@ -1,0 +1,4 @@
+package com.sssok.application.media;
+
+public record MediaReadyEvent(Long roomId, MediaDetail media) {
+}

--- a/backend/src/main/java/com/sssok/application/media/ThumbnailTrigger.java
+++ b/backend/src/main/java/com/sssok/application/media/ThumbnailTrigger.java
@@ -1,0 +1,31 @@
+package com.sssok.application.media;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+// 등록이 커밋된 뒤에 썸네일 작업을 띄운다.
+//
+// AFTER_COMMIT 인 이유: 커밋 전에 시작하면 워커가 아직 없는 행을 찾아 아무 일도 하지 않고 끝난다.
+// @Async 인 이유: 원본을 내려받아 줄여서 다시 올리는 데 수 초가 걸린다. 응답이 그동안 기다리면
+// 30장을 올린 사용자는 화면이 멈춘 것으로 본다.
+//
+// 끌 수 있게 해둔 이유: 협력 객체를 목으로 둔 테스트에서 이 스레드가 같은 목을 동시에 건드리면
+// 검증이 간헐적으로 깨진다. 워커 자체는 GenerateThumbnailService 를 직접 불러 검증한다.
+@Component
+@ConditionalOnProperty(name = "media.thumbnail.auto-generate", havingValue = "true",
+    matchIfMissing = true)
+@RequiredArgsConstructor
+public class ThumbnailTrigger {
+
+    private final GenerateThumbnailService generateThumbnailService;
+
+    @Async("thumbnailExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMediaCreated(MediaCreatedEvent event) {
+        generateThumbnailService.generate(event.media().mediaId());
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/exception/ThumbnailNotFoundException.java
+++ b/backend/src/main/java/com/sssok/application/media/exception/ThumbnailNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.media.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class ThumbnailNotFoundException extends SssOkException {
+
+    public ThumbnailNotFoundException() {
+        super(ErrorCode.THUMBNAIL_NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
@@ -2,6 +2,7 @@ package com.sssok.application.port.out;
 
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,8 @@ public interface FileRepository {
     List<StoredFile> findAllByRoomIdAndIdInAndStatusInOrderByNewest(
         Long roomId, Collection<Long> ids, Collection<UploadStatus> statuses);
 
+    // 썸네일 회수 배치용. 이 시각보다 오래 PROCESSING 에 남아 있는 미디어 id 를 오래된 순으로 준다.
+    List<Long> findStuckInProcessing(Instant stuckBefore, int limit);
 
     void deleteAllByRoomId(Long roomId);
 }

--- a/backend/src/main/java/com/sssok/application/port/out/ImageProcessorPort.java
+++ b/backend/src/main/java/com/sssok/application/port/out/ImageProcessorPort.java
@@ -1,0 +1,28 @@
+package com.sssok.application.port.out;
+
+import com.sssok.domain.file.GeoPoint;
+import java.time.Instant;
+import java.util.Optional;
+
+// 이미지 축소 출력. 어떤 라이브러리로 줄이는지는 응용 계층이 알 필요가 없다.
+public interface ImageProcessorPort {
+
+    // 원본 크기와 축소본을 한 번에 돌려준다. 디코딩이 가장 비싼 일이라 두 번 읽지 않는다.
+    // 손상됐거나 읽을 수 없는 형식이면 비어 있다 — 예외 대신 빈 값으로 두어, 사진 한 장 때문에
+    // 배치가 멈추지 않게 한다.
+    Optional<ProcessedImage> shrink(byte[] source, int maxWidth, String format);
+
+    // 촬영 시각과 좌표. 카메라가 남기지 않았거나 편집 과정에서 지워졌으면 각각 비어 있다.
+    // 축소와 나눈 이유는, EXIF 를 못 읽는다고 썸네일까지 포기할 이유가 없어서다.
+    CaptureInfo readCaptureInfo(byte[] source);
+
+    record ProcessedImage(int sourceWidth, int sourceHeight, byte[] content) {
+    }
+
+    record CaptureInfo(Instant takenAt, GeoPoint location) {
+
+        public static CaptureInfo empty() {
+            return new CaptureInfo(null, null);
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/application/room/RoomPurger.java
+++ b/backend/src/main/java/com/sssok/application/room/RoomPurger.java
@@ -9,6 +9,7 @@ import com.sssok.application.port.out.MemberRepository;
 import com.sssok.application.port.out.RoomEventRepository;
 import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
+import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.room.Room;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -37,8 +38,7 @@ public class RoomPurger {
     public void purge(Room room) {
         Set<Long> members = membersOf(room);
 
-        fileRepository.findAllByRoomId(room.getId())
-            .forEach(file -> fileStoragePort.delete(file.getStorageKey()));
+        fileRepository.findAllByRoomId(room.getId()).forEach(this::deleteFromStorage);
 
         fileRepository.deleteAllByRoomId(room.getId());
         // 폴더가 미디어와 맺은 관계를 먼저 끊어야, 폴더를 지운 뒤 folder_media에 고아 행이 남지 않는다.
@@ -49,6 +49,14 @@ public class RoomPurger {
         roomRepository.delete(room);
 
         purgeMembers(members);
+    }
+
+    // 원본과 썸네일은 서로 다른 키라 각각 지워야 한다. 하나만 지우면 남은 쪽이 영영 요금을 먹는다.
+    private void deleteFromStorage(StoredFile file) {
+        fileStoragePort.delete(file.getStorageKey());
+        if (file.getThumbnailKey() != null) {
+            fileStoragePort.delete(file.getThumbnailKey());
+        }
     }
 
     // 방장도 생성 시점에 참여자로 등록되지만, 그 전에 만들어진 방은 기록이 없어 따로 넣는다.

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     LINK_CODE_NOT_FOUND(404, "유효하지 않은 코드입니다"),
     FOLDER_NOT_FOUND(404, "존재하지 않는 폴더입니다: %s"),
     MEDIA_NOT_FOUND(404, "존재하지 않는 미디어입니다"),
+    THUMBNAIL_NOT_FOUND(404, "썸네일이 아직 준비되지 않았습니다"),
     DOWNLOAD_NOT_FOUND(404, "다운로드 요청을 찾을 수 없습니다"),
 
     // 405 Method Not Allowed

--- a/backend/src/main/java/com/sssok/domain/file/GeoPoint.java
+++ b/backend/src/main/java/com/sssok/domain/file/GeoPoint.java
@@ -1,0 +1,36 @@
+package com.sssok.domain.file;
+
+import com.sssok.domain.file.exception.InvalidGeoPointException;
+import java.math.BigDecimal;
+
+// 사진이 찍힌 좌표. 둘 중 하나만 있는 좌표는 좌표가 아니라, 항상 쌍으로 다룬다.
+public record GeoPoint(BigDecimal latitude, BigDecimal longitude) {
+
+    private static final BigDecimal MIN_LATITUDE = BigDecimal.valueOf(-90);
+    private static final BigDecimal MAX_LATITUDE = BigDecimal.valueOf(90);
+    private static final BigDecimal MIN_LONGITUDE = BigDecimal.valueOf(-180);
+    private static final BigDecimal MAX_LONGITUDE = BigDecimal.valueOf(180);
+
+    public GeoPoint {
+        if (latitude == null || longitude == null) {
+            throw new InvalidGeoPointException("위도와 경도는 함께 있어야 합니다");
+        }
+        requireInRange(latitude, MIN_LATITUDE, MAX_LATITUDE, "위도");
+        requireInRange(longitude, MIN_LONGITUDE, MAX_LONGITUDE, "경도");
+    }
+
+    // 둘 다 있을 때만 좌표를 만든다. EXIF 가 한쪽만 남긴 사진이 실제로 있다.
+    public static GeoPoint ofNullable(BigDecimal latitude, BigDecimal longitude) {
+        if (latitude == null || longitude == null) {
+            return null;
+        }
+        return new GeoPoint(latitude, longitude);
+    }
+
+    private static void requireInRange(BigDecimal value, BigDecimal min, BigDecimal max,
+                                       String name) {
+        if (value.compareTo(min) < 0 || value.compareTo(max) > 0) {
+            throw new InvalidGeoPointException("%s 가 범위를 벗어났습니다: %s".formatted(name, value));
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/ProcessedMedia.java
+++ b/backend/src/main/java/com/sssok/domain/file/ProcessedMedia.java
@@ -1,0 +1,13 @@
+package com.sssok.domain.file;
+
+import java.time.Instant;
+
+// 워커가 원본을 들여다보고 알아낸 것들. 하나라도 빠질 수 있어 전부 비어 있을 수 있다.
+public record ProcessedMedia(StorageKey thumbnailKey, Integer width, Integer height,
+                             Instant takenAt, GeoPoint location) {
+
+    // 영상처럼 들여다볼 도구가 없는 경우. 썸네일 없이 완료로 넘길 때 쓴다.
+    public static ProcessedMedia none() {
+        return new ProcessedMedia(null, null, null, null, null);
+    }
+}

--- a/backend/src/main/java/com/sssok/domain/file/StorageKey.java
+++ b/backend/src/main/java/com/sssok/domain/file/StorageKey.java
@@ -16,4 +16,12 @@ public record StorageKey(String value) {
         return new StorageKey("rooms/%d/%s.%s".formatted(
                 roomId, UUID.randomUUID(), mediaType.extension()));
     }
+
+    // 원본 키에서 썸네일 키를 만든다. 같은 이름을 thumbnails/ 아래에 두면
+    // 원본과 짝이 눈에 보이고, 접두사만으로 썸네일 전체를 골라낼 수 있다.
+    public StorageKey thumbnail() {
+        int lastSlash = value.lastIndexOf('/');
+        return new StorageKey(
+                value.substring(0, lastSlash + 1) + "thumbnails/" + value.substring(lastSlash + 1));
+    }
 }

--- a/backend/src/main/java/com/sssok/domain/file/StoredFile.java
+++ b/backend/src/main/java/com/sssok/domain/file/StoredFile.java
@@ -27,10 +27,26 @@ public class StoredFile {
     private Instant reservedAt;
     private int retryCount;
 
+    // 썸네일 워커가 채운다. 그 전까지는 비어 있고, 영상은 끝까지 비어 있다.
+    private StorageKey thumbnailKey;
+    private Integer width;
+    private Integer height;
+
+    // 원본 EXIF 에서 읽는다. 카메라가 남기지 않았거나 편집 과정에서 지워졌으면 비어 있다.
+    private Instant takenAt;
+    private GeoPoint location;
+
     private StoredFile(Long id, Long roomId, Long uploaderId, String originalFileName,
                        MediaType mediaType, FileSize fileSize, StorageKey storageKey,
                        Long folderId, UploadStatus status, Instant createdAt,
-                       Instant reservedAt, int retryCount) {
+                       Instant reservedAt, int retryCount,
+                       StorageKey thumbnailKey, Integer width, Integer height,
+                       Instant takenAt, GeoPoint location) {
+        this.thumbnailKey = thumbnailKey;
+        this.width = width;
+        this.height = height;
+        this.takenAt = takenAt;
+        this.location = location;
         this.id = id;
         this.roomId = roomId;
         this.uploaderId = uploaderId;
@@ -52,16 +68,20 @@ public class StoredFile {
         validateSize(mediaType, fileSize);
 
         return new StoredFile(null, roomId, uploaderId, originalFileName, mediaType, fileSize,
-                StorageKey.generate(roomId, mediaType), null, UploadStatus.RESERVED, now, now, 0);
+                StorageKey.generate(roomId, mediaType), null, UploadStatus.RESERVED, now, now, 0,
+                null, null, null, null, null);
     }
 
     public static StoredFile reconstruct(Long id, Long roomId, Long uploaderId,
                                          String originalFileName, MediaType mediaType,
                                          FileSize fileSize, StorageKey storageKey, Long folderId,
                                          UploadStatus status, Instant createdAt,
-                                         Instant reservedAt, int retryCount) {
+                                         Instant reservedAt, int retryCount,
+                                         StorageKey thumbnailKey, Integer width, Integer height,
+                                         Instant takenAt, GeoPoint location) {
         return new StoredFile(id, roomId, uploaderId, originalFileName, mediaType, fileSize,
-                storageKey, folderId, status, createdAt, reservedAt, retryCount);
+                storageKey, folderId, status, createdAt, reservedAt, retryCount,
+                thumbnailKey, width, height, takenAt, location);
     }
 
     private static void validateSize(MediaType mediaType, FileSize fileSize) {
@@ -100,6 +120,23 @@ public class StoredFile {
 
     public void markReady() {
         transitionTo(UploadStatus.READY);
+    }
+
+    // 썸네일 워커가 일을 마쳤을 때. 결과를 담는 것과 상태를 넘기는 것이 항상 같이 일어나야
+    // 하므로 한 메서드로 묶는다 — 따로 두면 값만 채우고 PROCESSING 에 남는 경우가 생긴다.
+    public void completeProcessing(ProcessedMedia processed) {
+        this.thumbnailKey = processed.thumbnailKey();
+        this.width = processed.width();
+        this.height = processed.height();
+        this.takenAt = processed.takenAt();
+        this.location = processed.location();
+        transitionTo(UploadStatus.READY);
+    }
+
+    // 영상은 썸네일을 뽑지 못한다. 그렇다고 PROCESSING 에 두면 다운로드가 영영 409 로 막히므로
+    // 썸네일 없이 완료로 넘긴다.
+    public boolean canGenerateThumbnail() {
+        return mediaType.isImage();
     }
 
     public void failUpload() {

--- a/backend/src/main/java/com/sssok/domain/file/exception/InvalidGeoPointException.java
+++ b/backend/src/main/java/com/sssok/domain/file/exception/InvalidGeoPointException.java
@@ -1,0 +1,11 @@
+package com.sssok.domain.file.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class InvalidGeoPointException extends SssOkException {
+
+    public InvalidGeoPointException(String message) {
+        super(ErrorCode.INVALID_PARAM, message);
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/ThumbnailProperties.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/ThumbnailProperties.java
@@ -1,0 +1,21 @@
+package com.sssok.infrastructure.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+// 실행 스레드는 spring.task.execution 의 공용 워커 풀을 쓴다. 여기서는 썸네일 자체의 값만 갖는다.
+@ConfigurationProperties(prefix = "media.thumbnail")
+public record ThumbnailProperties(
+    Integer maxWidth,
+    // 이 시간이 지나도 PROCESSING 이면 워커가 죽었거나 서버가 재시작된 것으로 보고 다시 태운다.
+    Duration stuckAfter,
+    // 한 번에 회수할 개수. 밀린 작업이 많아도 배치 한 번이 서버를 독점하지 않게 한다.
+    Integer sweepBatchSize
+) {
+
+    public ThumbnailProperties {
+        maxWidth = maxWidth == null ? 400 : maxWidth;
+        stuckAfter = stuckAfter == null ? Duration.ofMinutes(10) : stuckAfter;
+        sweepBatchSize = sweepBatchSize == null ? 50 : sweepBatchSize;
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/image/ThumbnailatorImageProcessor.java
+++ b/backend/src/main/java/com/sssok/infrastructure/image/ThumbnailatorImageProcessor.java
@@ -1,0 +1,96 @@
+package com.sssok.infrastructure.image;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.lang.GeoLocation;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifSubIFDDirectory;
+import com.drew.metadata.exif.GpsDirectory;
+import com.sssok.application.port.out.ImageProcessorPort;
+import com.sssok.domain.file.GeoPoint;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Optional;
+import java.util.TimeZone;
+import javax.imageio.ImageIO;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThumbnailatorImageProcessor implements ImageProcessorPort {
+
+    // 소수점 6자리면 약 10cm 단위다. 사진이 찍힌 자리를 가리키기에 충분하고,
+    // 컬럼 정의(NUMERIC(9,6))와도 맞춘다.
+    private static final int COORDINATE_SCALE = 6;
+
+    @Override
+    public Optional<ProcessedImage> shrink(byte[] source, int maxWidth, String format) {
+        try {
+            BufferedImage original = ImageIO.read(new ByteArrayInputStream(source));
+            // ImageIO 는 읽을 수 없는 형식이면 예외 대신 null 을 준다.
+            if (original == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new ProcessedImage(
+                original.getWidth(),
+                original.getHeight(),
+                toThumbnail(original, maxWidth, format)));
+        } catch (IOException | IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    // EXIF 는 있는 사진도 있고 없는 사진도 있다. 없다고 오류가 아니라, 못 읽으면 비워서 돌려준다.
+    @Override
+    public CaptureInfo readCaptureInfo(byte[] source) {
+        try {
+            Metadata metadata = ImageMetadataReader.readMetadata(new ByteArrayInputStream(source));
+            return new CaptureInfo(takenAt(metadata), location(metadata));
+        } catch (ImageProcessingException | IOException | RuntimeException e) {
+            return CaptureInfo.empty();
+        }
+    }
+
+    // EXIF 의 촬영 시각에는 시간대가 없다. 어느 지역에서 찍혔는지 알 수 없으므로 UTC 로 읽는다 —
+    // 시스템 시간대로 읽으면 서버를 옮길 때 같은 사진의 시각이 달라진다.
+    private Instant takenAt(Metadata metadata) {
+        ExifSubIFDDirectory exif = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+        if (exif == null) {
+            return null;
+        }
+        Date original = exif.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL,
+            TimeZone.getTimeZone(ZoneOffset.UTC));
+        return original == null ? null : original.toInstant();
+    }
+
+    private GeoPoint location(Metadata metadata) {
+        GpsDirectory gps = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+        if (gps == null || gps.getGeoLocation() == null || gps.getGeoLocation().isZero()) {
+            return null;
+        }
+        GeoLocation found = gps.getGeoLocation();
+        return GeoPoint.ofNullable(
+            BigDecimal.valueOf(found.getLatitude()).setScale(COORDINATE_SCALE, RoundingMode.HALF_UP),
+            BigDecimal.valueOf(found.getLongitude()).setScale(COORDINATE_SCALE, RoundingMode.HALF_UP));
+    }
+
+    // 원본이 이미 작으면 늘리지 않는다. 확대한 썸네일은 원본보다 크면서 더 흐리다.
+    private byte[] toThumbnail(BufferedImage original, int maxWidth, String format)
+        throws IOException {
+        int width = Math.min(maxWidth, original.getWidth());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Thumbnails.of(original)
+            .width(width)
+            .keepAspectRatio(true)
+            .outputFormat(format)
+            .toOutputStream(out);
+        return out.toByteArray();
+    }
+}

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
@@ -2,14 +2,17 @@ package com.sssok.infrastructure.persistence.file;
 
 import com.sssok.application.port.out.FileRepository;
 import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.GeoPoint;
 import com.sssok.domain.file.MediaType;
 import com.sssok.domain.file.StorageKey;
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -78,6 +81,11 @@ public class FileRepositoryAdapter implements FileRepository {
             .toList();
     }
 
+    @Override
+    public List<Long> findStuckInProcessing(Instant stuckBefore, int limit) {
+        return jpaRepository.findStuckInProcessing(
+            UploadStatus.PROCESSING.name(), stuckBefore, Limit.of(limit));
+    }
 
     @Override
     public void deleteAllByRoomId(Long roomId) {
@@ -102,7 +110,13 @@ public class FileRepositoryAdapter implements FileRepository {
             file.getStatus().name(),
             file.getCreatedAt(),
             file.getReservedAt(),
-            file.getRetryCount()
+            file.getRetryCount(),
+            file.getThumbnailKey() == null ? null : file.getThumbnailKey().value(),
+            file.getWidth(),
+            file.getHeight(),
+            file.getTakenAt(),
+            file.getLocation() == null ? null : file.getLocation().latitude(),
+            file.getLocation() == null ? null : file.getLocation().longitude()
         );
     }
 
@@ -119,7 +133,12 @@ public class FileRepositoryAdapter implements FileRepository {
             UploadStatus.valueOf(entity.getStatus()),
             entity.getCreatedAt(),
             entity.getReservedAt(),
-            entity.getRetryCount()
+            entity.getRetryCount(),
+            entity.getThumbnailKey() == null ? null : new StorageKey(entity.getThumbnailKey()),
+            entity.getWidth(),
+            entity.getHeight(),
+            entity.getTakenAt(),
+            GeoPoint.ofNullable(entity.getLatitude(), entity.getLongitude())
         );
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -54,7 +55,10 @@ public class StoredFileJpaEntity extends BaseEntity {
     @Column(name = "retry_count", nullable = false)
     private int retryCount;
 
-    // 썸네일·최적화 워커가 채운다. 그 전까지는 비어 있다.
+    // 썸네일·최적화 워커가 채운다. 그 전까지는 비어 있고, 영상은 끝까지 비어 있다.
+    @Column(name = "thumbnail_key", length = 255)
+    private String thumbnailKey;
+
     @Column(name = "width")
     private Integer width;
 
@@ -64,9 +68,22 @@ public class StoredFileJpaEntity extends BaseEntity {
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
 
+    // 원본 EXIF 에서 읽는다. 카메라가 남기지 않았으면 비어 있다.
+    @Column(name = "taken_at")
+    private Instant takenAt;
+
+    // 소수점 자릿수가 정확도를 좌우해 부동소수로 두지 않는다.
+    @Column(name = "latitude", precision = 9, scale = 6)
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 9, scale = 6)
+    private BigDecimal longitude;
+
     public StoredFileJpaEntity(Long id, Long roomId, Long uploaderId, String originalFileName,
                                String mediaType, Long fileSizeBytes, String storageKey, Long folderId,
-                               String status, Instant createdAt, Instant reservedAt, int retryCount) {
+                               String status, Instant createdAt, Instant reservedAt, int retryCount,
+                               String thumbnailKey, Integer width, Integer height,
+                               Instant takenAt, BigDecimal latitude, BigDecimal longitude) {
         super(createdAt);
         this.id = id;
         this.roomId = roomId;
@@ -79,5 +96,11 @@ public class StoredFileJpaEntity extends BaseEntity {
         this.status = status;
         this.reservedAt = reservedAt;
         this.retryCount = retryCount;
+        this.thumbnailKey = thumbnailKey;
+        this.width = width;
+        this.height = height;
+        this.takenAt = takenAt;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaRepository.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/StoredFileJpaRepository.java
@@ -1,8 +1,12 @@
 package com.sssok.infrastructure.persistence.file;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoredFileJpaRepository extends JpaRepository<StoredFileJpaEntity, Long> {
 
@@ -14,6 +18,15 @@ public interface StoredFileJpaRepository extends JpaRepository<StoredFileJpaEnti
     List<StoredFileJpaEntity> findAllByRoomIdAndIdInAndStatusInOrderByCreatedAtDescIdDesc(
         Long roomId, Collection<Long> ids, Collection<String> statuses);
 
+    // 오래된 것부터 가져와, 밀린 작업이 뒤에서 계속 굶지 않게 한다.
+    @Query("""
+        select f.id from StoredFileJpaEntity f
+        where f.status = :status and f.createdAt < :stuckBefore
+        order by f.createdAt asc
+        """)
+    List<Long> findStuckInProcessing(@Param("status") String status,
+                                     @Param("stuckBefore") Instant stuckBefore,
+                                     Limit limit);
 
     void deleteAllByRoomId(Long roomId);
 }

--- a/backend/src/main/java/com/sssok/infrastructure/scheduler/ThumbnailSweeper.java
+++ b/backend/src/main/java/com/sssok/infrastructure/scheduler/ThumbnailSweeper.java
@@ -1,0 +1,39 @@
+package com.sssok.infrastructure.scheduler;
+
+import com.sssok.application.media.GenerateThumbnailService;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.infrastructure.config.ThumbnailProperties;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+// PROCESSING 에 갇힌 미디어를 다시 태우는 스케줄 배치.
+//
+// 썸네일은 등록 직후 비동기로 도는데, 그 사이 서버가 재시작되거나 스레드가 죽으면 작업이 사라진다.
+// 그러면 그 사진은 영영 썸네일이 없고, 영상은 다운로드까지 409 로 막힌다. 이 배치가 유일한 회수 경로다.
+//
+// 단일 인스턴스 전제로 분산 락이 없다 — PurgeBatch 와 같다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ThumbnailSweeper {
+
+    private final FileRepository fileRepository;
+    private final GenerateThumbnailService generateThumbnailService;
+    private final ThumbnailProperties properties;
+
+    @Scheduled(cron = "${media.thumbnail.sweep-cron:0 */5 * * * *}")
+    public void sweep() {
+        Instant stuckBefore = Instant.now().minus(properties.stuckAfter());
+        List<Long> stuck = fileRepository.findStuckInProcessing(
+            stuckBefore, properties.sweepBatchSize());
+        if (stuck.isEmpty()) {
+            return;
+        }
+        log.info("썸네일이 밀린 미디어 {}개를 다시 처리합니다", stuck.size());
+        stuck.forEach(generateThumbnailService::generate);
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaDownloadController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaDownloadController.java
@@ -1,6 +1,8 @@
 package com.sssok.presentation.api.media;
 
 import com.sssok.application.media.GetMediaDownloadUrlService;
+import com.sssok.application.media.GetOriginalUrlService;
+import com.sssok.application.media.GetThumbnailUrlService;
 import com.sssok.presentation.auth.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,6 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class MediaDownloadController {
 
     private final GetMediaDownloadUrlService getMediaDownloadUrlService;
+    private final GetThumbnailUrlService getThumbnailUrlService;
+    private final GetOriginalUrlService getOriginalUrlService;
 
     @Operation(
         summary = "단건 다운로드",
@@ -36,6 +40,42 @@ public class MediaDownloadController {
         @Parameter(description = "다운로드할 미디어 ID") @PathVariable Long mediaId
     ) {
         String url = getMediaDownloadUrlService.getUrl(roomId, mediaId);
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(url)).build();
+    }
+
+    @Operation(
+        summary = "썸네일 조회",
+        description = "목록 타일에 그릴 축소본을 내려받는다. 조회 응답의 thumbnailUrl이 가리키는 주소이며, "
+            + "유효기간 5분짜리 서명 URL로 302 리다이렉트한다. 원본과 달리 inline이라 브라우저가 "
+            + "그대로 표시한다 — img 태그에 바로 걸 수 있다. 서명 URL을 조회 응답에 직접 싣지 않고 "
+            + "이 경로를 거치게 한 것은, 목록을 캐싱해도 URL이 만료되지 않게 하고 방 참여자만 "
+            + "볼 수 있도록 하기 위해서다. 아직 워커가 만들지 않았거나 영상이라 썸네일이 없으면 404 "
+            + "THUMBNAIL_NOT_FOUND가 난다. 없는 mediaId나 다른 방의 미디어는 404 MEDIA_NOT_FOUND다."
+    )
+    @GetMapping("/{mediaId}/thumbnail")
+    public ResponseEntity<Void> thumbnail(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "썸네일을 볼 미디어 ID") @PathVariable Long mediaId
+    ) {
+        String url = getThumbnailUrlService.getUrl(roomId, mediaId);
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(url)).build();
+    }
+
+    @Operation(
+        summary = "원본 표시",
+        description = "원본을 화면에 크게 띄우기 위한 경로다. 조회 응답의 originalUrl이 가리킨다. "
+            + "단건 다운로드와 같은 파일을 가리키지만 inline으로 서명해 브라우저가 그대로 표시한다 — "
+            + "저장이 목적이면 /download를 쓴다. 유효기간 5분짜리 서명 URL로 302 리다이렉트한다. "
+            + "없는 mediaId나 다른 방의 미디어는 404, 아직 처리 중이면 409가 난다."
+    )
+    @GetMapping("/{mediaId}/original")
+    public ResponseEntity<Void> original(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
+        @Parameter(description = "표시할 미디어 ID") @PathVariable Long mediaId
+    ) {
+        String url = getOriginalUrlService.getUrl(roomId, mediaId);
         return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(url)).build();
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaFullResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaFullResponse.java
@@ -1,0 +1,41 @@
+package com.sssok.presentation.api.media;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.sssok.application.media.MediaFullDetail;
+import com.sssok.domain.file.GeoPoint;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+// 목록 항목과 같은 필드를 그대로 펼치고(JsonUnwrapped) 단건 전용 항목만 덧붙인다.
+// 따로 나열하면 목록과 단건의 공통 필드가 갈라져도 눈치채지 못한다.
+@Schema(description = "미디어 단건 상세")
+public record MediaFullResponse(
+    @JsonUnwrapped MediaResponse media,
+    @Schema(description = "EXIF 촬영 시각. 카메라가 남기지 않았으면 null") Instant takenAt,
+    @Schema(description = "EXIF 좌표. 위치 기록이 꺼져 있었으면 null") LocationResponse location,
+    @Schema(description = "요청자가 이 미디어를 지울 수 있는지. 올린 본인과 방장만 true")
+    boolean canDelete
+) {
+    public static MediaFullResponse from(MediaFullDetail detail) {
+        return new MediaFullResponse(
+            MediaResponse.from(detail.media()),
+            detail.takenAt(),
+            LocationResponse.from(detail.location()),
+            detail.canDelete());
+    }
+
+    @Schema(description = "촬영 위치")
+    public record LocationResponse(
+        BigDecimal latitude,
+        BigDecimal longitude,
+        @Schema(description = "지명. 역지오코딩이 붙기 전까지 null") String name
+    ) {
+        static LocationResponse from(GeoPoint location) {
+            if (location == null) {
+                return null;
+            }
+            return new LocationResponse(location.latitude(), location.longitude(), null);
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
@@ -43,17 +43,22 @@ public class MediaQueryController {
 
     @Operation(
         summary = "미디어 단건 조회",
-        description = "미디어 하나의 메타데이터를 반환한다. 응답 형태는 목록의 항목과 같다. "
+        description = "미디어 하나의 메타데이터를 반환한다. 목록 항목의 필드를 모두 포함하고 "
+            + "여기에 촬영 시각(takenAt)·촬영 위치(location)·삭제 권한(canDelete)이 더해진다. "
+            + "takenAt과 location은 원본 EXIF에서 읽으며, 카메라가 남기지 않았거나 위치 기록이 "
+            + "꺼져 있었으면 null이다. location.name은 역지오코딩이 붙기 전까지 null이다. "
+            + "canDelete는 보는 사람에 따라 달라져서 목록에는 싣지 않는다 — 올린 본인과 방장만 true다. "
             + "없는 mediaId, 다른 방의 미디어, 아직 실물이 없는 미디어는 모두 404가 난다 — "
             + "다른 방에 그 ID가 있는지 알 수 없도록 구분하지 않는다. "
             + "방 관련 실패 케이스(403/404/410)는 목록 조회와 동일하다."
     )
     @GetMapping("/{mediaId}")
-    public ApiResponse<MediaResponse> getMedia(
+    public ApiResponse<MediaFullResponse> getMedia(
         @Parameter(hidden = true) @AuthMember Long memberId,
         @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
         @Parameter(description = "조회할 미디어 ID") @PathVariable Long mediaId
     ) {
-        return ApiResponse.of(MediaResponse.from(getMediaService.get(roomId, mediaId)));
+        return ApiResponse.of(
+            MediaFullResponse.from(getMediaService.get(roomId, mediaId, memberId)));
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -55,6 +55,13 @@ media:
   resize-target-width: 1600
   # GIF는 애니메이션이 깨지므로 리사이즈/압축 대상에서 제외한다
   skip-formats: gif
+  thumbnail:
+    # 목록 타일 기준 너비. 고해상도 화면에서도 흐리지 않을 만큼만 크게 잡는다
+    max-width: 400
+    # 이 시간이 지나도 PROCESSING이면 재시작·실패로 작업이 사라진 것으로 보고 다시 태운다
+    stuck-after: 10m
+    sweep-batch-size: 50
+    sweep-cron: "0 */5 * * * *"
 
 download:
   # 단건 다운로드 리다이렉트 대상 서명 URL의 유효기간

--- a/backend/src/main/resources/db/migration/V17__add_media_thumbnail_key.sql
+++ b/backend/src/main/resources/db/migration/V17__add_media_thumbnail_key.sql
@@ -1,0 +1,4 @@
+-- 썸네일 워커가 만든 축소본의 스토리지 키.
+-- 완성된 URL 이 아니라 키를 저장한다. 도메인이나 서빙 방식이 바뀌어도 데이터를 고치지 않아도 된다.
+ALTER TABLE stored_file
+    ADD COLUMN thumbnail_key VARCHAR(255);

--- a/backend/src/main/resources/db/migration/V18__add_media_capture_metadata.sql
+++ b/backend/src/main/resources/db/migration/V18__add_media_capture_metadata.sql
@@ -1,0 +1,8 @@
+-- 촬영 정보. 워커가 원본 EXIF 에서 읽어 채운다.
+-- 카메라가 기록하지 않았거나 편집 과정에서 지워졌으면 비어 있다.
+ALTER TABLE stored_file
+    ADD COLUMN taken_at TIMESTAMPTZ,
+    -- 좌표는 소수점 이하 자릿수가 정확도를 좌우해 부동소수로 두지 않는다.
+    -- 위도 ±90, 경도 ±180 이라 정수부는 3자리면 충분하다.
+    ADD COLUMN latitude  NUMERIC(9, 6),
+    ADD COLUMN longitude NUMERIC(9, 6);

--- a/backend/src/test/java/com/sssok/application/media/GenerateThumbnailServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GenerateThumbnailServiceTest.java
@@ -1,0 +1,272 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.sssok.application.port.out.AbortableOutputStream;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StorageKey;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.Optional;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// Repository + Service 통합 테스트 (H2). 스토리지만 목으로 두고 실제로 이미지를 줄여본다.
+// 자동 기동(ThumbnailTrigger)은 test 프로파일에서 꺼져 있어, 여기서 직접 불러 결과를 확인한다.
+@SpringBootTest
+@ActiveProfiles("test")
+class GenerateThumbnailServiceTest {
+
+    private static final Long ROOM_ID = 720L;
+    private static final Long UPLOADER_ID = 720L;
+
+    @Autowired
+    GenerateThumbnailService generateThumbnailService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    private ByteArrayOutputStream uploaded;
+
+    @BeforeEach
+    void setUp() {
+        uploaded = new ByteArrayOutputStream();
+        given(fileStoragePort.openUploadStream(any(), anyString()))
+            .willReturn(new AbortableOutputStream() {
+                @Override
+                public void write(int b) {
+                    uploaded.write(b);
+                }
+
+                @Override
+                public void abort() {
+                }
+            });
+    }
+
+    @Test
+    void 썸네일을_만들어_올리고_READY로_넘긴다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        givenOriginal(file.getStorageKey(), image(1200, 900, "jpg"));
+
+        generateThumbnailService.generate(file.getId());
+
+        StoredFile after = reload(file);
+        assertThat(after.getStatus()).isEqualTo(UploadStatus.READY);
+        assertThat(after.getThumbnailKey()).isNotNull();
+        verify(fileStoragePort).openUploadStream(eq(after.getThumbnailKey()), eq("image/jpeg"));
+    }
+
+    // 클라이언트가 자리를 미리 잡는 데 쓰는 값이라, 썸네일이 아니라 원본 크기여야 한다.
+    @Test
+    void 썸네일이_아니라_원본의_크기를_저장한다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        givenOriginal(image(1200, 900, "jpg"));
+
+        generateThumbnailService.generate(file.getId());
+
+        StoredFile after = reload(file);
+        assertThat(after.getWidth()).isEqualTo(1200);
+        assertThat(after.getHeight()).isEqualTo(900);
+    }
+
+    @Test
+    void 썸네일은_원본보다_작다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        byte[] original = image(1200, 900, "jpg");
+        givenOriginal(original);
+
+        generateThumbnailService.generate(file.getId());
+
+        assertThat(widthOf(uploadedThumbnail())).isEqualTo(400);
+    }
+
+    // 확대한 썸네일은 원본보다 크면서 더 흐리기만 하다.
+    @Test
+    void 원본이_이미_작으면_늘리지_않는다() {
+        StoredFile file = processing("작은사진.jpg", "image/jpeg");
+        givenOriginal(image(120, 90, "jpg"));
+
+        generateThumbnailService.generate(file.getId());
+
+        assertThat(widthOf(uploadedThumbnail())).isEqualTo(120);
+    }
+
+    // PNG 를 JPEG 로 바꾸면 투명한 부분이 검게 나온다.
+    // 선언한 Content-Type 만 보면 안 된다 — PNG 라고 말하고 JPEG 바이트를 올려도 통과해버린다.
+    @Test
+    void 원본과_같은_형식으로_저장한다() {
+        StoredFile file = processing("사진.png", "image/png");
+        givenOriginal(image(800, 600, "png"));
+
+        generateThumbnailService.generate(file.getId());
+
+        verify(fileStoragePort).openUploadStream(any(), eq("image/png"));
+        assertThat(formatOf(uploadedThumbnail())).isEqualToIgnoringCase("png");
+    }
+
+    @Test
+    void JPEG_원본은_JPEG_썸네일이_된다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        givenOriginal(image(800, 600, "jpg"));
+
+        generateThumbnailService.generate(file.getId());
+
+        assertThat(formatOf(uploadedThumbnail())).isEqualToIgnoringCase("jpeg");
+    }
+
+    // 프레임을 뽑으려면 별도 도구가 필요하다. PROCESSING 에 두면 다운로드가 영영 409 로 막힌다.
+    @Test
+    void 영상은_썸네일_없이_READY로_넘긴다() {
+        StoredFile file = processing("영상.mp4", "video/mp4");
+
+        generateThumbnailService.generate(file.getId());
+
+        StoredFile after = reload(file);
+        assertThat(after.getStatus()).isEqualTo(UploadStatus.READY);
+        assertThat(after.getThumbnailKey()).isNull();
+        verify(fileStoragePort, never()).openDownloadStream(any());
+    }
+
+    // 다시 시도해도 결과가 같은 유일한 경우다.
+    @Test
+    void 이미지가_깨졌으면_FAILED로_확정한다() {
+        StoredFile file = processing("깨진사진.jpg", "image/jpeg");
+        givenOriginal("이건 이미지가 아니다".getBytes());
+
+        generateThumbnailService.generate(file.getId());
+
+        assertThat(reload(file).getStatus()).isEqualTo(UploadStatus.FAILED);
+    }
+
+    // 여기서 FAILED 로 내리면 멀쩡히 올라간 사진이 목록에서 사라진다. 회수 배치가 다시 태운다.
+    @Test
+    void 원본을_읽지_못하면_PROCESSING으로_남긴다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        given(fileStoragePort.openDownloadStream(any())).willThrow(new RuntimeException("없는 키"));
+
+        generateThumbnailService.generate(file.getId());
+
+        assertThat(reload(file).getStatus()).isEqualTo(UploadStatus.PROCESSING);
+    }
+
+    @Test
+    void 스토리지가_예외를_던져도_PROCESSING으로_남긴다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        given(fileStoragePort.openDownloadStream(any())).willThrow(new RuntimeException("R2 장애"));
+
+        generateThumbnailService.generate(file.getId());
+
+        assertThat(reload(file).getStatus()).isEqualTo(UploadStatus.PROCESSING);
+    }
+
+    // 회수 배치가 같은 미디어를 두 번 집어도 안전해야 한다.
+    @Test
+    void 이미_READY인_미디어는_건드리지_않는다() {
+        StoredFile file = processing("사진.jpg", "image/jpeg");
+        file.completeProcessing(new ProcessedMedia(file.getStorageKey().thumbnail(), 100, 100, null, null));
+        fileRepository.save(file);
+
+        generateThumbnailService.generate(file.getId());
+
+        verify(fileStoragePort, never()).openDownloadStream(any());
+        verify(fileStoragePort, never()).openUploadStream(any(), anyString());
+    }
+
+    @Test
+    void 없는_미디어면_아무것도_하지_않는다() {
+        generateThumbnailService.generate(999_999L);
+
+        verify(fileStoragePort, never()).openDownloadStream(any());
+    }
+
+    private StoredFile processing(String fileName, String mimeType) {
+        StoredFile file = StoredFile.reserve(
+            ROOM_ID, UPLOADER_ID, fileName, mimeType, new FileSize(1024), Instant.now());
+        file.startProcessing();
+        return fileRepository.save(file);
+    }
+
+    private StoredFile reload(StoredFile file) {
+        return fileRepository.findById(file.getId()).orElseThrow();
+    }
+
+    // 업로드 스트림에 실제로 써 넣은 바이트를 꺼낸다.
+    private byte[] uploadedThumbnail() {
+        return uploaded.toByteArray();
+    }
+
+    // 원본을 읽을 때마다 새 스트림을 줘야 한다. 같은 스트림을 재사용하면 두 번째 읽기가 빈 값이 된다.
+    private void givenOriginal(StorageKey key, byte[] content) {
+        given(fileStoragePort.openDownloadStream(key))
+            .willAnswer(call -> new ByteArrayInputStream(content));
+    }
+
+    private void givenOriginal(byte[] content) {
+        given(fileStoragePort.openDownloadStream(any()))
+            .willAnswer(call -> new ByteArrayInputStream(content));
+    }
+
+    private int widthOf(byte[] image) {
+        try {
+            return ImageIO.read(new ByteArrayInputStream(image)).getWidth();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // 바이트를 직접 열어 실제로 무슨 형식으로 인코딩됐는지 본다.
+    private String formatOf(byte[] image) {
+        try (ImageInputStream stream = ImageIO.createImageInputStream(
+            new ByteArrayInputStream(image))) {
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
+            assertThat(readers).hasNext();
+            return readers.next().getFormatName();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private byte[] image(int width, int height, String format) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(Color.RED);
+        graphics.fillRect(0, 0, width, height);
+        graphics.dispose();
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(image, format, out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/GetMediaServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GetMediaServiceTest.java
@@ -8,10 +8,13 @@ import com.sssok.application.port.out.FileRepository;
 import com.sssok.application.port.out.MemberRepository;
 import com.sssok.application.room.CreateRoomService;
 import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.GeoPoint;
+import com.sssok.domain.file.ProcessedMedia;
 import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.file.UploadStatus;
 import com.sssok.domain.member.Member;
 import com.sssok.domain.member.Nickname;
+import java.math.BigDecimal;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +63,7 @@ class GetMediaServiceTest {
     void 미디어_메타데이터를_반환한다() {
         StoredFile file = save(roomId, UploadStatus.READY);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId());
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
 
         assertThat(media.mediaId()).isEqualTo(file.getId());
         assertThat(media.fileName()).isEqualTo("사진.jpg");
@@ -73,17 +76,60 @@ class GetMediaServiceTest {
         assertThat(media.folderIds()).isEmpty();
     }
 
-
-
-
-
-
-    // 썸네일 워커가 붙기 전까지는 채울 수 없는 값들이다. 프론트가 null 을 전제로 만들어야 한다.
+    // 워커가 EXIF 에서 읽어 채운다. 카메라가 남기지 않았으면 비어 있다.
     @Test
-    void 워커가_채우는_값은_아직_비어_있다() {
+    void 촬영_시각과_위치를_반환한다() {
+        Instant takenAt = Instant.parse("2026-08-01T12:30:00Z");
+        GeoPoint seoul = new GeoPoint(
+            new BigDecimal("37.566500"), new BigDecimal("126.978000"));
+        StoredFile file = processed(roomId, takenAt, seoul);
+
+        MediaFullDetail full = getMediaService.get(roomId, file.getId(), uploaderId);
+
+        assertThat(full.takenAt()).isEqualTo(takenAt);
+        assertThat(full.location()).isEqualTo(seoul);
+    }
+
+    @Test
+    void 촬영_정보가_없으면_비어_있다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        MediaFullDetail full = getMediaService.get(roomId, file.getId(), uploaderId);
+
+        assertThat(full.takenAt()).isNull();
+        assertThat(full.location()).isNull();
+    }
+
+    @Test
+    void 올린_본인은_지울_수_있다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        assertThat(getMediaService.get(roomId, file.getId(), uploaderId).canDelete()).isTrue();
+    }
+
+    // 방을 관리하는 사람이라 남이 올린 사진도 내릴 수 있어야 한다.
+    @Test
+    void 방장은_남이_올린_것도_지울_수_있다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+
+        assertThat(getMediaService.get(roomId, file.getId(), hostId).canDelete()).isTrue();
+    }
+
+    @Test
+    void 남이_올린_사진은_지울_수_없다() {
+        StoredFile file = save(roomId, UploadStatus.READY);
+        Long other = memberRepository.save(
+            Member.register(new Nickname("의찬"), Instant.now())).getId();
+
+        assertThat(getMediaService.get(roomId, file.getId(), other).canDelete()).isFalse();
+    }
+
+    // 워커가 손대는 중이면 원본이 바뀌는 중일 수 있어 표시용 주소를 주지 않는다.
+    @Test
+    void 워커가_채우는_값은_처리_전까지_비어_있다() {
         StoredFile file = save(roomId, UploadStatus.PROCESSING);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId());
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
 
         assertThat(media.thumbnailUrl()).isNull();
         assertThat(media.originalUrl()).isNull();
@@ -92,10 +138,23 @@ class GetMediaServiceTest {
         assertThat(media.duration()).isNull();
     }
 
+    @Test
+    void 처리가_끝나면_썸네일과_원본_주소가_생긴다() {
+        StoredFile file = processed(roomId, null, null);
+
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
+
+        assertThat(media.thumbnailUrl())
+            .isEqualTo("/api/v1/rooms/%d/media/%d/thumbnail".formatted(roomId, file.getId()));
+        assertThat(media.originalUrl())
+            .isEqualTo("/api/v1/rooms/%d/media/%d/original".formatted(roomId, file.getId()));
+        assertThat(media.width()).isEqualTo(1200);
+        assertThat(media.height()).isEqualTo(900);
+    }
 
     @Test
     void 없는_mediaId면_404() {
-        assertThatThrownBy(() -> getMediaService.get(roomId, 999_999L))
+        assertThatThrownBy(() -> getMediaService.get(roomId, 999_999L, uploaderId))
             .isInstanceOf(MediaNotFoundException.class);
     }
 
@@ -104,7 +163,7 @@ class GetMediaServiceTest {
     void 다른_방의_mediaId면_404() {
         StoredFile file = save(OTHER_ROOM_ID, UploadStatus.READY);
 
-        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId()))
+        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId(), uploaderId))
             .isInstanceOf(MediaNotFoundException.class);
     }
 
@@ -113,7 +172,7 @@ class GetMediaServiceTest {
     void 실물이_없는_미디어면_404(UploadStatus status) {
         StoredFile file = save(roomId, status);
 
-        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId()))
+        assertThatThrownBy(() -> getMediaService.get(roomId, file.getId(), uploaderId))
             .isInstanceOf(MediaNotFoundException.class);
     }
 
@@ -122,7 +181,7 @@ class GetMediaServiceTest {
     void PROCESSING_상태도_조회된다() {
         StoredFile file = save(roomId, UploadStatus.PROCESSING);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId());
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
 
         assertThat(media.status()).isEqualTo("PROCESSING");
     }
@@ -132,7 +191,7 @@ class GetMediaServiceTest {
         StoredFile file = save(roomId, UploadStatus.READY);
         jdbcTemplate.update("DELETE FROM member WHERE id = ?", uploaderId);
 
-        MediaDetail media = getMediaService.get(roomId, file.getId());
+        MediaDetail media = getMediaService.get(roomId, file.getId(), uploaderId).media();
 
         assertThat(media.uploaderName()).isNull();
     }
@@ -153,4 +212,11 @@ class GetMediaServiceTest {
         return fileRepository.save(file);
     }
 
+    // 워커가 처리를 마친 상태. 썸네일 키와 크기, 촬영 정보가 채워져 있다.
+    private StoredFile processed(Long targetRoomId, Instant takenAt, GeoPoint location) {
+        StoredFile file = save(targetRoomId, UploadStatus.PROCESSING);
+        file.completeProcessing(new ProcessedMedia(
+            file.getStorageKey().thumbnail(), 1200, 900, takenAt, location));
+        return fileRepository.save(file);
+    }
 }

--- a/backend/src/test/java/com/sssok/application/media/GetThumbnailUrlServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/GetThumbnailUrlServiceTest.java
@@ -1,0 +1,106 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.ThumbnailNotFoundException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StoredFile;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class GetThumbnailUrlServiceTest {
+
+    private static final Long ROOM_ID = 730L;
+    private static final Long OTHER_ROOM_ID = 731L;
+    private static final String PRESIGNED = "https://storage.example.com/thumb";
+
+    @Autowired
+    GetThumbnailUrlService getThumbnailUrlService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    @BeforeEach
+    void setUp() {
+        given(fileStoragePort.presignGet(any(), anyString(), anyString(), any(Duration.class)))
+            .willReturn(PRESIGNED);
+    }
+
+    @Test
+    void 썸네일이_있으면_서명_URL을_반환한다() {
+        StoredFile file = withThumbnail(ROOM_ID);
+
+        String url = getThumbnailUrlService.getUrl(ROOM_ID, file.getId());
+
+        assertThat(url).isEqualTo(PRESIGNED);
+    }
+
+    // 목록 타일에 그리는 용도라 저장 대화상자가 뜨면 안 된다. 원본 다운로드는 attachment 다.
+    @Test
+    void inline로_서명한다() {
+        StoredFile file = withThumbnail(ROOM_ID);
+
+        getThumbnailUrlService.getUrl(ROOM_ID, file.getId());
+
+        verify(fileStoragePort).presignGet(
+            eq(file.getStorageKey().thumbnail()), eq("inline"), eq("image/jpeg"),
+            any(Duration.class));
+    }
+
+    // 미디어는 있는데 썸네일만 없는 경우다. 없는 미디어와 구분해서 알려준다.
+    @Test
+    void 아직_썸네일이_없으면_THUMBNAIL_NOT_FOUND() {
+        StoredFile file = processing(ROOM_ID);
+
+        assertThatThrownBy(() -> getThumbnailUrlService.getUrl(ROOM_ID, file.getId()))
+            .isInstanceOf(ThumbnailNotFoundException.class);
+    }
+
+    @Test
+    void 없는_미디어면_MEDIA_NOT_FOUND() {
+        assertThatThrownBy(() -> getThumbnailUrlService.getUrl(ROOM_ID, 999_999L))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 다른_방의_미디어면_MEDIA_NOT_FOUND() {
+        StoredFile file = withThumbnail(OTHER_ROOM_ID);
+
+        assertThatThrownBy(() -> getThumbnailUrlService.getUrl(ROOM_ID, file.getId()))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    private StoredFile processing(Long roomId) {
+        StoredFile file = StoredFile.reserve(
+            roomId, 1L, "사진.jpg", "image/jpeg", new FileSize(1024), Instant.now());
+        file.startProcessing();
+        return fileRepository.save(file);
+    }
+
+    private StoredFile withThumbnail(Long roomId) {
+        StoredFile file = processing(roomId);
+        file.completeProcessing(new ProcessedMedia(file.getStorageKey().thumbnail(), 1200, 900, null, null));
+        return fileRepository.save(file);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/room/PurgeRoomServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/room/PurgeRoomServiceTest.java
@@ -2,16 +2,23 @@ package com.sssok.application.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 
 import com.sssok.application.auth.AnonymousAuthService;
 import com.sssok.application.auth.IssueLinkCodeService;
 import com.sssok.application.auth.LinkCodeResult;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
 import com.sssok.application.port.out.LinkCodeRepository;
 import com.sssok.application.port.out.MemberRepository;
 import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.application.auth.exception.UnauthorizedException;
 import com.sssok.domain.auth.LinkCodeValue;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StorageKey;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StoredFile;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomMember;
 import com.sssok.domain.room.RoomCode;
@@ -29,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 // Repository + Service 통합 테스트 (H2)
 @SpringBootTest
@@ -71,6 +79,12 @@ class PurgeRoomServiceTest {
     RoomEventJpaRepository roomEventJpaRepository;
 
     @Autowired
+    FileRepository fileRepository;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    @Autowired
     EntityManager entityManager;
 
     private Long hostId;
@@ -80,6 +94,24 @@ class PurgeRoomServiceTest {
     void setUp() {
         hostId = anonymousAuthService.authenticate("가현").userId();
         guestId = anonymousAuthService.authenticate("민수").userId();
+    }
+
+    // 원본과 썸네일은 서로 다른 키다. 하나만 지우면 남은 쪽이 스토리지에 영영 남아 요금을 먹는다.
+    @Test
+    void 방을_지우면_원본과_썸네일을_모두_스토리지에서_지운다() {
+        Room room = 삭제된_방(Instant.now().minus(RETENTION).minus(Duration.ofDays(1)));
+        StoredFile file = StoredFile.reserve(room.getId(), hostId, "사진.jpg", "image/jpeg",
+            new FileSize(1024), Instant.now());
+        file.startProcessing();
+        StorageKey original = file.getStorageKey();
+        StorageKey thumbnail = original.thumbnail();
+        file.completeProcessing(new ProcessedMedia(thumbnail, 1200, 900, null, null));
+        fileRepository.save(file);
+
+        purgeRoomService.purgeAll(Instant.now());
+
+        verify(fileStoragePort).delete(original);
+        verify(fileStoragePort).delete(thumbnail);
     }
 
     @Test

--- a/backend/src/test/java/com/sssok/infrastructure/image/ExifFixture.java
+++ b/backend/src/test/java/com/sssok/infrastructure/image/ExifFixture.java
@@ -1,0 +1,101 @@
+package com.sssok.infrastructure.image;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+// EXIF 가 든 JPEG 을 만들어 주는 테스트 픽스처.
+//
+// EXIF 를 "쓰는" 라이브러리를 따로 들이지 않으려고 APP1 세그먼트를 직접 조립한다.
+// 읽기만 하는 metadata-extractor 로는 만들 수 없고, 실제 사진을 저장소에 넣으면 바이너리가
+// 커밋에 섞인다.
+final class ExifFixture {
+
+    // TIFF 헤더 기준 오프셋. 아래 배치를 그대로 옮긴 값이라 순서를 바꾸면 함께 고쳐야 한다.
+    //   0 TIFF 헤더(8) | 8 IFD0(2+12*2+4=30) | 38 Exif IFD(2+12+4=18)
+    //   56 GPS IFD(2+12*4+4=54) | 110 촬영시각 문자열(20) | 130 위도(24) | 154 경도(24)
+    private static final int IFD0_OFFSET = 8;
+    private static final int EXIF_IFD_OFFSET = 38;
+    private static final int GPS_IFD_OFFSET = 56;
+    private static final int DATETIME_OFFSET = 110;
+    private static final int LATITUDE_OFFSET = 130;
+    private static final int LONGITUDE_OFFSET = 154;
+
+    private static final short TYPE_ASCII = 2;
+    private static final short TYPE_LONG = 4;
+    private static final short TYPE_RATIONAL = 5;
+
+    private static final short TAG_EXIF_IFD_POINTER = (short) 0x8769;
+    private static final short TAG_GPS_IFD_POINTER = (short) 0x8825;
+    private static final short TAG_DATETIME_ORIGINAL = (short) 0x9003;
+    private static final short TAG_GPS_LATITUDE_REF = 0x0001;
+    private static final short TAG_GPS_LATITUDE = 0x0002;
+    private static final short TAG_GPS_LONGITUDE_REF = 0x0003;
+    private static final short TAG_GPS_LONGITUDE = 0x0004;
+
+    // 초 단위를 10배로 저장해 소수 좌표를 정수 분수로 정확히 표현한다.
+    private static final int SECONDS_DENOMINATOR = 10;
+
+    private ExifFixture() {
+    }
+
+    static byte[] app1Segment(String dateTimeOriginal, double latitude, double longitude) {
+        byte[] tiff = tiff(dateTimeOriginal, latitude, longitude);
+        ByteBuffer segment = ByteBuffer.allocate(4 + 6 + tiff.length);
+        segment.putShort((short) 0xFFE1);
+        // 길이 필드는 자기 자신(2바이트)부터 센다. 마커 2바이트는 제외다.
+        segment.putShort((short) (2 + 6 + tiff.length));
+        segment.put("Exif".getBytes(StandardCharsets.US_ASCII)).put((byte) 0).put((byte) 0);
+        segment.put(tiff);
+        return segment.array();
+    }
+
+    private static byte[] tiff(String dateTimeOriginal, double latitude, double longitude) {
+        ByteBuffer buffer = ByteBuffer.allocate(LONGITUDE_OFFSET + 24);
+
+        // 빅엔디언("MM") + 매직 42 + IFD0 위치
+        buffer.put((byte) 'M').put((byte) 'M').putShort((short) 42).putInt(IFD0_OFFSET);
+
+        buffer.putShort((short) 2);
+        entry(buffer, TAG_EXIF_IFD_POINTER, TYPE_LONG, 1, EXIF_IFD_OFFSET);
+        entry(buffer, TAG_GPS_IFD_POINTER, TYPE_LONG, 1, GPS_IFD_OFFSET);
+        buffer.putInt(0);
+
+        buffer.putShort((short) 1);
+        entry(buffer, TAG_DATETIME_ORIGINAL, TYPE_ASCII, 20, DATETIME_OFFSET);
+        buffer.putInt(0);
+
+        buffer.putShort((short) 4);
+        // 4바이트에 들어가는 값은 오프셋 자리에 그대로 넣는다("N\0" + 남는 자리 0).
+        entry(buffer, TAG_GPS_LATITUDE_REF, TYPE_ASCII, 2, 'N' << 24);
+        entry(buffer, TAG_GPS_LATITUDE, TYPE_RATIONAL, 3, LATITUDE_OFFSET);
+        entry(buffer, TAG_GPS_LONGITUDE_REF, TYPE_ASCII, 2, 'E' << 24);
+        entry(buffer, TAG_GPS_LONGITUDE, TYPE_RATIONAL, 3, LONGITUDE_OFFSET);
+        buffer.putInt(0);
+
+        buffer.put(ascii(dateTimeOriginal, 20));
+        degreesMinutesSeconds(buffer, latitude);
+        degreesMinutesSeconds(buffer, longitude);
+        return buffer.array();
+    }
+
+    private static void entry(ByteBuffer buffer, short tag, short type, int count, int value) {
+        buffer.putShort(tag).putShort(type).putInt(count).putInt(value);
+    }
+
+    // 도·분은 0 으로 두고 나머지를 전부 초로 표현한다. 분까지 쪼개면 반올림 오차가 생긴다.
+    private static void degreesMinutesSeconds(ByteBuffer buffer, double coordinate) {
+        int degrees = (int) coordinate;
+        long seconds = Math.round((coordinate - degrees) * 3600 * SECONDS_DENOMINATOR);
+        buffer.putInt(degrees).putInt(1);
+        buffer.putInt(0).putInt(1);
+        buffer.putInt((int) seconds).putInt(SECONDS_DENOMINATOR);
+    }
+
+    private static byte[] ascii(String value, int length) {
+        byte[] padded = new byte[length];
+        byte[] raw = value.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(raw, 0, padded, 0, Math.min(raw.length, length - 1));
+        return padded;
+    }
+}

--- a/backend/src/test/java/com/sssok/infrastructure/image/ThumbnailatorImageProcessorTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/image/ThumbnailatorImageProcessorTest.java
@@ -1,0 +1,77 @@
+package com.sssok.infrastructure.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sssok.application.port.out.ImageProcessorPort.CaptureInfo;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+
+// EXIF 추출은 라이브러리에 맡기지만, 없는 사진에서 터지지 않는지와 좌표 변환은 우리 책임이다.
+class ThumbnailatorImageProcessorTest {
+
+    private final ThumbnailatorImageProcessor processor = new ThumbnailatorImageProcessor();
+
+    // ImageIO 로 만든 이미지에는 EXIF 가 없다. 실제 업로드의 상당수가 이렇다.
+    @Test
+    void EXIF가_없는_이미지는_빈_값을_돌려준다() {
+        CaptureInfo capture = processor.readCaptureInfo(plainJpeg());
+
+        assertThat(capture.takenAt()).isNull();
+        assertThat(capture.location()).isNull();
+    }
+
+    // 사진 한 장이 깨졌다고 배치가 멈추면 안 된다.
+    @Test
+    void 이미지가_아니면_예외를_던지지_않는다() {
+        CaptureInfo capture = processor.readCaptureInfo("이건 이미지가 아니다".getBytes());
+
+        assertThat(capture.takenAt()).isNull();
+        assertThat(capture.location()).isNull();
+    }
+
+    @Test
+    void EXIF에_기록된_촬영_시각과_좌표를_읽는다() {
+        CaptureInfo capture = processor.readCaptureInfo(jpegWithExif());
+
+        assertThat(capture.takenAt()).isEqualTo(Instant.parse("2026-08-01T12:30:00Z"));
+        assertThat(capture.location()).isNotNull();
+        assertThat(capture.location().latitude())
+            .isEqualByComparingTo(new BigDecimal("37.566500"));
+        assertThat(capture.location().longitude())
+            .isEqualByComparingTo(new BigDecimal("126.978000"));
+    }
+
+    @Test
+    void 손상된_이미지는_축소하지_못하고_빈_값이_된다() {
+        assertThat(processor.shrink("이건 이미지가 아니다".getBytes(), 400, "jpg")).isEmpty();
+    }
+
+    private byte[] plainJpeg() {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(new BufferedImage(100, 80, BufferedImage.TYPE_INT_RGB), "jpg", out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // EXIF 를 쓰는 라이브러리를 더 들이지 않으려고 APP1 세그먼트를 직접 만들어 끼운다.
+    private byte[] jpegWithExif() {
+        byte[] exif = ExifFixture.app1Segment(
+            "2026:08:01 12:30:00", 37.5665, 126.978);
+        byte[] jpeg = plainJpeg();
+        byte[] result = new byte[jpeg.length + exif.length];
+        // SOI(2바이트) 바로 뒤에 APP1 을 넣는 것이 JPEG 규격이다.
+        System.arraycopy(jpeg, 0, result, 0, 2);
+        System.arraycopy(exif, 0, result, 2, exif.length);
+        System.arraycopy(jpeg, 2, result, 2 + exif.length, jpeg.length - 2);
+        return result;
+    }
+}

--- a/backend/src/test/java/com/sssok/infrastructure/scheduler/ThumbnailSweeperTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/scheduler/ThumbnailSweeperTest.java
@@ -1,0 +1,112 @@
+package com.sssok.infrastructure.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.sssok.application.port.out.AbortableOutputStream;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+// 서버가 재시작되거나 워커 스레드가 죽으면 그 사진은 영영 PROCESSING 에 남는다.
+// 이 배치가 유일한 회수 경로라, 실제로 회수되는지 확인해둔다.
+@SpringBootTest
+@ActiveProfiles("test")
+class ThumbnailSweeperTest {
+
+    private static final Long ROOM_ID = 740L;
+
+    @Autowired
+    ThumbnailSweeper thumbnailSweeper;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    // 원본을 읽을 때마다 새 스트림을 줘야 한다. 같은 스트림을 재사용하면 두 번째 읽기가 빈 값이 된다.
+    private void givenOriginal() {
+        byte[] content = image();
+        given(fileStoragePort.openDownloadStream(any()))
+            .willAnswer(call -> new ByteArrayInputStream(content));
+        given(fileStoragePort.openUploadStream(any(), anyString()))
+            .willReturn(new AbortableOutputStream() {
+                @Override
+                public void write(int b) {
+                }
+
+                @Override
+                public void abort() {
+                }
+            });
+    }
+
+    @Test
+    void 오래_PROCESSING에_남은_미디어를_다시_처리한다() {
+        StoredFile stuck = processing(Instant.now().minus(30, ChronoUnit.MINUTES));
+        givenOriginal();
+
+        thumbnailSweeper.sweep();
+
+        assertThat(reload(stuck).getStatus()).isEqualTo(UploadStatus.READY);
+    }
+
+    // 방금 등록된 것은 비동기 워커가 아직 처리 중일 수 있다. 배치가 끼어들면 같은 일을 두 번 한다.
+    @Test
+    void 방금_등록된_미디어는_건드리지_않는다() {
+        StoredFile fresh = processing(Instant.now());
+        givenOriginal();
+
+        thumbnailSweeper.sweep();
+
+        assertThat(reload(fresh).getStatus()).isEqualTo(UploadStatus.PROCESSING);
+    }
+
+    private StoredFile processing(Instant createdAt) {
+        StoredFile file = StoredFile.reserve(
+            ROOM_ID, 1L, "사진.jpg", "image/jpeg", new FileSize(1024), createdAt);
+        file.startProcessing();
+        StoredFile saved = fileRepository.save(file);
+        // BaseEntity 가 @PrePersist 로 지금 시각을 넣기 때문에, 오래된 행은 직접 만들어야 한다.
+        jdbcTemplate.update("UPDATE stored_file SET created_at = ? WHERE id = ?",
+            java.sql.Timestamp.from(createdAt), saved.getId());
+        return saved;
+    }
+
+    private StoredFile reload(StoredFile file) {
+        return fileRepository.findById(file.getId()).orElseThrow();
+    }
+
+    private byte[] image() {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(new BufferedImage(800, 600, BufferedImage.TYPE_INT_RGB), "jpg", out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaDownloadControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaDownloadControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sssok.application.media.GetMediaDownloadUrlService;
+import com.sssok.application.media.GetOriginalUrlService;
+import com.sssok.application.media.GetThumbnailUrlService;
 import com.sssok.application.media.exception.MediaNotFoundException;
 import com.sssok.application.media.exception.MediaNotReadyException;
 import com.sssok.application.port.out.RoomMemberRepository;
@@ -44,6 +46,12 @@ class MediaDownloadControllerTest {
 
     @MockitoBean
     GetMediaDownloadUrlService getMediaDownloadUrlService;
+
+    @MockitoBean
+    GetThumbnailUrlService getThumbnailUrlService;
+
+    @MockitoBean
+    GetOriginalUrlService getOriginalUrlService;
 
     @MockitoBean
     TokenProvider tokenProvider;

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryApiTest.java
@@ -145,6 +145,18 @@ class MediaQueryApiTest extends PostgresContainerSupport {
             .andExpect(jsonPath("$.data.folderIds[0]").value(folder.getId()));
     }
 
+    // 올린 본인이라 지울 수 있고, EXIF 가 없는 이미지라 촬영 정보는 비어 있다.
+    @Test
+    void 단건에는_촬영_정보와_삭제_권한이_함께_나온다() throws Exception {
+        Long mediaId = upload("a.jpg", null);
+
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, mediaId)
+                .header("Authorization", token))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.canDelete").value(true))
+            .andExpect(jsonPath("$.data.takenAt").doesNotExist())
+            .andExpect(jsonPath("$.data.location").doesNotExist());
+    }
 
     @Test
     void 없는_미디어를_조회하면_404() throws Exception {

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
@@ -15,10 +15,12 @@ import com.sssok.application.folder.exception.FolderNotFoundException;
 import com.sssok.application.media.GetMediaListService;
 import com.sssok.application.media.GetMediaService;
 import com.sssok.application.media.MediaDetail;
+import com.sssok.application.media.MediaFullDetail;
 import com.sssok.application.media.exception.MediaNotFoundException;
 import com.sssok.application.port.out.RoomMemberRepository;
 import com.sssok.application.port.out.RoomRepository;
 import com.sssok.application.port.out.TokenProvider;
+import com.sssok.domain.file.GeoPoint;
 import com.sssok.domain.room.Room;
 import com.sssok.domain.room.RoomCode;
 import com.sssok.domain.room.RoomExpiration;
@@ -26,6 +28,7 @@ import com.sssok.domain.room.RoomMember;
 import com.sssok.domain.room.RoomName;
 import com.sssok.domain.room.UploadPolicy;
 import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.List;
@@ -130,9 +133,10 @@ class MediaQueryControllerTest {
             .andExpect(jsonPath("$.code").value("FOLDER_NOT_FOUND"));
     }
 
+    // 목록 항목의 필드가 단건 응답에도 그대로 펼쳐져야 한다. 한 겹 더 감싸이면 프론트가 갈라진다.
     @Test
     void 단건을_조회하면_200과_미디어를_반환한다() throws Exception {
-        given(getMediaService.get(ROOM_ID, MEDIA_ID)).willReturn(media());
+        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(fullDetail());
 
         getMedia(MEDIA_ID)
             .andExpect(status().isOk())
@@ -141,17 +145,46 @@ class MediaQueryControllerTest {
             .andExpect(jsonPath("$.data.folderIds[0]").value(FOLDER_ID));
     }
 
+    @Test
+    void 단건에는_촬영_정보와_삭제_권한이_함께_나온다() throws Exception {
+        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(fullDetail());
 
+        getMedia(MEDIA_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.takenAt").value("2026-08-01T12:30:00Z"))
+            .andExpect(jsonPath("$.data.location.latitude").value(37.5665))
+            .andExpect(jsonPath("$.data.location.longitude").value(126.978))
+            .andExpect(jsonPath("$.data.location.name").doesNotExist())
+            .andExpect(jsonPath("$.data.canDelete").value(true));
+    }
+
+    // EXIF 가 없는 사진이 훨씬 많다. 그때도 응답 구조가 흔들리면 안 된다.
+    @Test
+    void 촬영_정보가_없으면_location이_통째로_비어_있다() throws Exception {
+        given(getMediaService.get(ROOM_ID, MEDIA_ID, MEMBER_ID))
+            .willReturn(new MediaFullDetail(media(), null, null, false));
+
+        getMedia(MEDIA_ID)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.takenAt").doesNotExist())
+            .andExpect(jsonPath("$.data.location").doesNotExist())
+            .andExpect(jsonPath("$.data.canDelete").value(false));
+    }
 
     @Test
     void 없는_미디어를_조회하면_404() throws Exception {
-        willThrow(new MediaNotFoundException()).given(getMediaService).get(anyLong(), anyLong());
+        willThrow(new MediaNotFoundException())
+            .given(getMediaService).get(anyLong(), anyLong(), anyLong());
 
         getMedia(MEDIA_ID)
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
     }
 
+    private MediaFullDetail fullDetail() {
+        return new MediaFullDetail(media(), Instant.parse("2026-08-01T12:30:00Z"),
+            new GeoPoint(new BigDecimal("37.566500"), new BigDecimal("126.978000")), true);
+    }
 
     private MediaDetail media() {
         return new MediaDetail(MEDIA_ID, "IMAGE", "사진.jpg", "image/jpeg", 1024L,

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -22,3 +22,9 @@ storage:
 # 테스트 전용 키. 운영 시크릿과 무관하며 실제 배포에는 쓰이지 않는다.
 jwt:
   secret: mvtcAhMGbXlhpJ4JuIvRWJVF+yMUju6PxRCb/FMojgA=
+
+# 등록 직후 자동으로 도는 썸네일 워커를 끈다. 협력 객체를 목으로 둔 테스트에서 워커 스레드가
+# 같은 목을 동시에 건드리면 검증이 간헐적으로 깨진다. 워커는 직접 호출해서 검증한다.
+media:
+  thumbnail:
+    auto-generate: false


### PR DESCRIPTION
## 작업 내용

미디어를 `PROCESSING` 에서 `READY` 로 넘기는 썸네일 워커를 구현하고, 조회 응답의 `thumbnailUrl`·`width`·`takenAt`·`location`·`canDelete` 를 실제로 채웠다.

**398KB 원본(1600×1200) → 17KB 썸네일(400×300), 전송량 96% 감소.** 등록 1초 안에 `READY` 로 넘어간다.

> **이 PR은 `feature/be-#107-media-query-api` 를 base 로 한다.**
> 그쪽이 먼저 머지돼야 diff 가 정확하게 보인다.

## 관련 이슈

#107 — 조회 API 자체는 base PR 이 닫는다. 이 PR 은 그 응답을 채우는 워커라 `Closes` 를 붙이지 않았다.

## 작업 영역

- [ ] Frontend
- [x] Backend

## 전체 그림에서 이 PR의 위치

```
① 업로드 URL 발급 → PUT → 완료 등록      #76 (머지 완료)
                              │  status = PROCESSING
                              ▼
② 썸네일 워커                            ← 이 PR
      원본 축소 · EXIF 추출 · READY 전이
                              │
                              ▼
③ 조회 API 가 thumbnailUrl 을 내려줌      base PR
```

## 동작 흐름

```
완료 등록 커밋
      │ MediaCreatedEvent (AFTER_COMMIT)
      ▼
ThumbnailTrigger  @Async
      │
      ▼
GenerateThumbnailService
      ├─ 영상인가            → 썸네일 없이 READY  (ffmpeg 없이는 프레임을 못 뽑는다)
      ├─ 원본 다운로드        → 실패 시 PROCESSING 유지 (회수 배치가 재시도)
      ├─ 400px 축소          → 못 읽으면 FAILED 확정
      ├─ 썸네일 업로드
      ├─ EXIF 촬영 시각·좌표
      └─ MediaFinisher → READY + SSE media.ready
                              │
ThumbnailSweeper  @Scheduled  ← 10분 넘게 PROCESSING 인 것 회수
```

## 변경 사항

### 영상이 영영 다운로드 불가가 될 뻔했다

썸네일을 못 만든다고 `PROCESSING` 에 두면, 다운로드 API가 `PROCESSING` 을 409로 막고 있어서 **영상은 영원히 받을 수 없다.** 썸네일 없이 `READY` 로 넘긴다.

원본을 내려받지도 않는다. **영상은 최대 1GB** 라, 길이 하나 읽자고 통째로 힙에 올리면 서버가 죽는다. `duration` 은 스트리밍으로 읽는 도구가 붙은 뒤에 채운다.

### 실패를 두 종류로 나눴다

처음엔 실패하면 전부 `FAILED` 로 내렸는데, 그러면 **R2가 잠깐 흔들릴 때 멀쩡히 올라간 사진이 목록에서 사라진다.**

| 실패 종류 | 처리 |
| --- | --- |
| 네트워크·스토리지 오류 | `PROCESSING` 유지 → 회수 배치가 재시도 |
| 원본이 안 보임 | `PROCESSING` 유지 → 일시적일 수 있다 |
| **이미지가 깨짐** | `FAILED` 확정 — 다시 해도 결과가 같은 유일한 경우 |

### 재시작하면 그 사진들이 영영 방치된다

비동기 작업은 메모리에만 있어서 서버가 죽으면 사라진다. `ThumbnailSweeper` 가 10분 넘게 `PROCESSING` 인 것을 5분마다 회수한다. **유일한 복구 경로라 테스트로 고정했다.**

### 썸네일을 API 경로로 서빙한다

```
"thumbnailUrl": "/api/v1/rooms/7/media/12/thumbnail"   → 302 → 서명 URL (inline)
"originalUrl":  "/api/v1/rooms/7/media/12/original"    → 302 → 서명 URL (inline)
```

**서명 URL을 응답에 직접 실으면 몇 분 뒤 만료된다.** 목록을 캐싱하거나 잠시 뒤에 그리면 깨진다. 경로는 만료되지 않고 방 참여자만 통과한다. 이슈의 "조회 응답에는 서명 URL을 포함하지 않는다"도 지킨다.

`originalUrl` 을 기존 `/download` 로 두지 않은 이유는 **`attachment` 라 저장 대화상자가 떠서** 크게 보기에 쓸 수 없어서다. 같은 파일을 `inline` 으로 서명하는 경로를 따로 뒀다.

### PNG 썸네일은 PNG로 저장한다

JPEG로 바꾸면 투명한 부분이 검게 나온다. 원본이 이미 400px보다 작으면 늘리지 않는다 — 확대한 썸네일은 원본보다 크면서 더 흐리기만 하다.

### EXIF 촬영 시각을 UTC로 읽는다

EXIF에는 시간대가 없다. 시스템 시간대로 읽으면 **서버를 옮길 때 같은 사진의 촬영 시각이 달라진다.**

좌표는 위도·경도가 둘 다 있을 때만 만든다. **한쪽만 남은 사진이 실제로 있고**, 한쪽만 내려주면 프론트가 엉뚱한 곳을 찍는다. `NUMERIC(9,6)` 으로 저장한다 — 부동소수는 자릿수가 흔들린다.

### canDelete 를 목록에 싣지 않았다

**보는 사람마다 값이 달라서다.** 목록에 넣으면 같은 방의 사진 목록을 사용자별로 따로 캐싱해야 한다. 단건에만 넣었다.

이미 있던 `FilePermissionPolicy.canDelete` 를 처음으로 사용한다.

### 발견한 기존 버그

**`RoomPurger` 가 원본만 지우고 썸네일을 R2에 남기고 있었다.** 원본과 썸네일은 서로 다른 키라 각각 지워야 한다. 남은 쪽이 영영 요금을 먹는다.

## 테스트

- [x] 단위 테스트 작성/통과 (`./gradlew test` 전체 통과, 4회 연속 그린)
- [x] 로컬 동작 확인 (실제 R2 업로드 → 썸네일 생성 → 다운로드까지)

| 테스트 | 개수 | 환경 | 검증 대상 |
| --- | --- | --- | --- |
| `GenerateThumbnailServiceTest` | 13 | H2 | 축소·형식 보존·영상 분기·실패 분류 |
| `ThumbnailatorImageProcessorTest` | 4 | 단위 | EXIF 추출과 깨진 입력 |
| `ThumbnailSweeperTest` | 2 | H2 | 회수 대상 판정 |
| `GetThumbnailUrlServiceTest` | 5 | H2 | inline 서명과 404 분기 |
| `GetMediaServiceTest` | +6 | H2 | 촬영 정보·삭제 권한 |
| `PurgeRoomServiceTest` | +1 | H2 | 썸네일까지 지우는지 |

**고친 부분을 되돌려 테스트가 깨지는지 확인했다:**

- 썸네일 삭제 제거 → `방을_지우면_원본과_썸네일을_모두_스토리지에서_지운다` FAILED
- 형식을 항상 JPEG로 → `원본과_같은_형식으로_저장한다` FAILED

**형식 테스트는 한 번 통과해버려서 강화했다.** `upload()` 에 넘긴 Content-Type만 보고 실제 바이트는 안 봐서, PNG라고 선언하고 JPEG를 올려도 통과했다. 인코딩된 형식을 직접 읽도록 고쳤다.

**실측 결과:**

| 확인 | 결과 |
| --- | --- |
| JPEG 원본 | READY, 썸네일 생성, `width/height` = 1600×1200 |
| PNG 원본 | READY, **PNG 썸네일** |
| MP4 영상 | READY, 썸네일 없음 |
| 영상 썸네일 요청 | 404 `THUMBNAIL_NOT_FOUND` |
| 미입장 사용자 | 403 `NOT_ROOM_MEMBER` |
| EXIF 있는 사진 | `takenAt` `2026-08-01T12:30:00Z`, 좌표 37.5665 / 126.978 |
| canDelete | 업로더 `true` / 방장 `true` / 제3자 `false` |

## 리뷰 요청 사항 (선택)

### 봐주셨으면 하는 부분

- **`spring.task.execution` 공용 워커 풀을 그대로 쓴다.** 설정에 "업로드 후 리사이즈/압축을 처리하는 @Async 워커"라고 적혀 있어 이 자리로 봤는데, zip 압축 워커(#84)와 풀을 공유하게 된다. **압축은 I/O, 축소는 CPU라 서로를 굶길 수 있는지 확인 부탁드린다.**
- **`ThumbnailSweeper` 에 분산 락이 없다.** `PurgeBatch` 와 같은 단일 인스턴스 전제다. 인스턴스를 늘리면 같은 미디어를 여러 번 처리한다.
- **`test` 프로파일에서 자동 기동을 껐다.** 협력 객체를 목으로 둔 테스트에서 워커 스레드가 같은 목을 동시에 건드려 검증이 간헐적으로 깨졌다. 워커 자체는 직접 호출해 검증한다. 더 나은 방법이 있으면 알려주시면 좋겠다.
- **`metadata-extractor` 의존성을 추가했다.** EXIF 읽기 전용 라이브러리이고, 쓰기가 필요한 테스트는 APP1 세그먼트를 직접 조립해 라이브러리를 더 들이지 않았다.

### 남은 것

- **`duration` 은 `null` 이다.** 영상 길이는 스트리밍으로 읽는 도구(ffprobe 등)가 있어야 채울 수 있다.
- **`location.name` 은 `null` 이다.** 좌표를 지명으로 바꾸려면 외부 역지오코딩 API가 필요하다.
- **원본 1600px 최적화는 하지 않았다.** #76 이슈에 있지만 **사용자 원본을 덮어쓰는 일**이라 따로 판단이 필요하다고 봤다.
- **영상 썸네일도 남았다.** ffmpeg 가 붙어야 한다.
- **미디어 삭제 API가 없다.** `canDelete` 는 버튼을 보일지 정하는 플래그일 뿐, 누르면 부를 API가 아직 없다.
