### PR TITLE
feat: 미디어 단건·다건 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/sssok/application/media/DeleteMediaResult.java
+++ b/backend/src/main/java/com/sssok/application/media/DeleteMediaResult.java
@@ -1,0 +1,7 @@
+package com.sssok.application.media;
+
+import java.util.List;
+
+public record DeleteMediaResult(int deletedCount, List<Long> deletedMediaIds,
+                                List<Long> notFoundMediaIds) {
+}

--- a/backend/src/main/java/com/sssok/application/media/DeleteMediaService.java
+++ b/backend/src/main/java/com/sssok/application/media/DeleteMediaService.java
@@ -1,0 +1,77 @@
+package com.sssok.application.media;
+
+import com.sssok.application.media.exception.InvalidMediaDeleteParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.TooManyMediaException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.domain.file.FilePermissionPolicy;
+import com.sssok.domain.file.StoredFile;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMediaService {
+
+    private static final int MAX_MEDIA_COUNT = 500;
+
+    private final FileRepository fileRepository;
+    private final RoomPermissionPort roomPermissionPort;
+    private final MediaDeleter mediaDeleter;
+
+    public Long deleteOne(Long roomId, Long mediaId, Long requesterId) {
+        StoredFile file = fileRepository.findById(mediaId)
+            .filter(found -> found.getRoomId().equals(roomId))
+            .orElseThrow(MediaNotFoundException::new);
+        requireDeletePermission(roomId, requesterId, List.of(file));
+        mediaDeleter.delete(roomId, List.of(file));
+        return file.getId();
+    }
+
+    public DeleteMediaResult deleteAll(Long roomId, List<Long> mediaIds, Long requesterId) {
+        requireValid(mediaIds);
+        List<Long> distinctIds = mediaIds.stream().distinct().toList();
+        Map<Long, StoredFile> filesById = new LinkedHashMap<>();
+        fileRepository.findAllByIdIn(distinctIds).stream()
+            .filter(file -> file.getRoomId().equals(roomId))
+            .forEach(file -> filesById.put(file.getId(), file));
+
+        List<Long> notFoundIds = distinctIds.stream()
+            .filter(id -> !filesById.containsKey(id))
+            .toList();
+        List<StoredFile> files = distinctIds.stream()
+            .filter(filesById::containsKey)
+            .map(filesById::get)
+            .toList();
+
+        requireDeletePermission(roomId, requesterId, files);
+        if (!files.isEmpty()) {
+            mediaDeleter.delete(roomId, files);
+        }
+        List<Long> deletedIds = files.stream().map(StoredFile::getId).toList();
+        return new DeleteMediaResult(deletedIds.size(), deletedIds, notFoundIds);
+    }
+
+    private void requireValid(List<Long> mediaIds) {
+        if (mediaIds == null || mediaIds.isEmpty() || mediaIds.stream().anyMatch(id -> id == null)) {
+            throw new InvalidMediaDeleteParamException();
+        }
+        if (mediaIds.size() > MAX_MEDIA_COUNT) {
+            throw new TooManyMediaException(MAX_MEDIA_COUNT);
+        }
+    }
+
+    private void requireDeletePermission(Long roomId, Long requesterId, List<StoredFile> files) {
+        boolean isHost = roomPermissionPort.isHost(roomId, requesterId);
+        boolean canDeleteAll = files.stream()
+            .allMatch(file -> FilePermissionPolicy.canDelete(file, requesterId, isHost));
+        if (!canDeleteAll) {
+            throw new MediaForbiddenException();
+        }
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaDeletedEvent.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.sssok.application.media;
+
+import java.util.List;
+
+public record MediaDeletedEvent(Long roomId, List<Long> mediaIds) {
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaDeleter.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaDeleter.java
@@ -1,0 +1,36 @@
+package com.sssok.application.media;
+
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.domain.file.StoredFile;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MediaDeleter {
+
+    private final FileRepository fileRepository;
+    private final FolderMediaRepository folderMediaRepository;
+    private final FileStoragePort fileStoragePort;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void delete(Long roomId, List<StoredFile> files) {
+        for (StoredFile file : files) {
+            fileStoragePort.delete(file.getStorageKey());
+            if (file.getThumbnailKey() != null) {
+                fileStoragePort.delete(file.getThumbnailKey());
+            }
+        }
+
+        List<Long> mediaIds = files.stream().map(StoredFile::getId).toList();
+        folderMediaRepository.detachFromAllFolders(mediaIds);
+        fileRepository.deleteAllByIdIn(mediaIds);
+        eventPublisher.publishEvent(new MediaDeletedEvent(roomId, mediaIds));
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/MediaEventListener.java
+++ b/backend/src/main/java/com/sssok/application/media/MediaEventListener.java
@@ -29,4 +29,10 @@ public class MediaEventListener {
     public void handle(MediaReadyEvent event) {
         eventPublisher.publish(event.roomId(), "media.ready", event.media());
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MediaDeletedEvent event) {
+        eventPublisher.publish(event.roomId(), "media.deleted", event);
+    }
 }

--- a/backend/src/main/java/com/sssok/application/media/ThumbnailTrigger.java
+++ b/backend/src/main/java/com/sssok/application/media/ThumbnailTrigger.java
@@ -23,7 +23,7 @@ public class ThumbnailTrigger {
 
     private final GenerateThumbnailService generateThumbnailService;
 
-    @Async("thumbnailExecutor")
+    @Async("applicationTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onMediaCreated(MediaCreatedEvent event) {
         generateThumbnailService.generate(event.media().mediaId());

--- a/backend/src/main/java/com/sssok/application/media/exception/InvalidMediaDeleteParamException.java
+++ b/backend/src/main/java/com/sssok/application/media/exception/InvalidMediaDeleteParamException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.media.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class InvalidMediaDeleteParamException extends SssOkException {
+
+    public InvalidMediaDeleteParamException() {
+        super(ErrorCode.INVALID_PARAM, "삭제할 미디어가 없습니다");
+    }
+}

--- a/backend/src/main/java/com/sssok/application/media/exception/TooManyMediaException.java
+++ b/backend/src/main/java/com/sssok/application/media/exception/TooManyMediaException.java
@@ -1,0 +1,11 @@
+package com.sssok.application.media.exception;
+
+import com.sssok.common.exception.ErrorCode;
+import com.sssok.common.exception.SssOkException;
+
+public class TooManyMediaException extends SssOkException {
+
+    public TooManyMediaException(int maxCount) {
+        super(ErrorCode.TOO_MANY_FILES, maxCount);
+    }
+}

--- a/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
+++ b/backend/src/main/java/com/sssok/application/port/out/FileRepository.java
@@ -37,4 +37,6 @@ public interface FileRepository {
     List<Long> findStuckInProcessing(Instant stuckBefore, int limit);
 
     void deleteAllByRoomId(Long roomId);
+
+    void deleteAllByIdIn(List<Long> ids);
 }

--- a/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/sssok/common/exception/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
     EMPTY_PATCH(400, "변경할 항목을 하나 이상 보내주세요"),
     INVALID_REQUEST_BODY(400, "요청 본문 형식이 올바르지 않습니다"),
     INVALID_REQUEST_PARAMETER(400, "%s 값의 형식이 올바르지 않습니다"),
-    TOO_MANY_FILES(400, "한 번에 최대 %d개까지 다운로드할 수 있습니다"),
+    TOO_MANY_FILES(400, "한 번에 최대 %d개까지 처리할 수 있습니다"),
 
     // 401 Unauthorized
     UNAUTHORIZED(401, "%s"),

--- a/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
+++ b/backend/src/main/java/com/sssok/infrastructure/persistence/file/FileRepositoryAdapter.java
@@ -92,6 +92,13 @@ public class FileRepositoryAdapter implements FileRepository {
         jpaRepository.deleteAllByRoomId(roomId);
     }
 
+    @Override
+    public void deleteAllByIdIn(List<Long> ids) {
+        if (!ids.isEmpty()) {
+            jpaRepository.deleteAllByIdInBatch(ids);
+        }
+    }
+
     // 상태를 문자열 컬럼으로 저장하고 있어, 조회 조건도 이름으로 맞춰 넘긴다.
     private List<String> names(Collection<UploadStatus> statuses) {
         return statuses.stream().map(UploadStatus::name).toList();

--- a/backend/src/main/java/com/sssok/presentation/api/media/DeleteMediaRequest.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/DeleteMediaRequest.java
@@ -1,0 +1,6 @@
+package com.sssok.presentation.api.media;
+
+import java.util.List;
+
+public record DeleteMediaRequest(List<Long> mediaIds) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/DeleteMediaResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/DeleteMediaResponse.java
@@ -1,0 +1,13 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.DeleteMediaResult;
+import java.util.List;
+
+public record DeleteMediaResponse(int deletedCount, List<Long> deletedMediaIds,
+                                  List<Long> notFoundMediaIds) {
+
+    public static DeleteMediaResponse from(DeleteMediaResult result) {
+        return new DeleteMediaResponse(result.deletedCount(), result.deletedMediaIds(),
+            result.notFoundMediaIds());
+    }
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/DeleteSingleMediaResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/DeleteSingleMediaResponse.java
@@ -1,0 +1,4 @@
+package com.sssok.presentation.api.media;
+
+public record DeleteSingleMediaResponse(Long deletedMediaId) {
+}

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaDeleteController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaDeleteController.java
@@ -1,0 +1,48 @@
+package com.sssok.presentation.api.media;
+
+import com.sssok.application.media.DeleteMediaResult;
+import com.sssok.application.media.DeleteMediaService;
+import com.sssok.presentation.api.common.ApiResponse;
+import com.sssok.presentation.auth.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "미디어 삭제", description = "본인이 올린 미디어를 삭제하며 방장은 방의 모든 미디어를 삭제할 수 있다.")
+@RestController
+@RequestMapping("/rooms/{roomId}/media")
+@RequiredArgsConstructor
+public class MediaDeleteController {
+
+    private final DeleteMediaService deleteMediaService;
+
+    @Operation(summary = "미디어 단건 삭제")
+    @DeleteMapping("/{mediaId}")
+    public ApiResponse<DeleteSingleMediaResponse> deleteOne(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @PathVariable Long roomId,
+        @PathVariable Long mediaId
+    ) {
+        Long deletedId = deleteMediaService.deleteOne(roomId, mediaId, memberId);
+        return ApiResponse.of(new DeleteSingleMediaResponse(deletedId));
+    }
+
+    @Operation(summary = "미디어 다건 삭제")
+    @DeleteMapping
+    public ApiResponse<DeleteMediaResponse> deleteAll(
+        @Parameter(hidden = true) @AuthMember Long memberId,
+        @PathVariable Long roomId,
+        @RequestBody DeleteMediaRequest request
+    ) {
+        List<Long> mediaIds = request == null ? null : request.mediaIds();
+        DeleteMediaResult result = deleteMediaService.deleteAll(roomId, mediaIds, memberId);
+        return ApiResponse.of(DeleteMediaResponse.from(result));
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/DeleteMediaServiceTest.java
+++ b/backend/src/test/java/com/sssok/application/media/DeleteMediaServiceTest.java
@@ -1,0 +1,147 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.sssok.application.media.exception.InvalidMediaDeleteParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.TooManyMediaException;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.RoomPermissionPort;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.MediaType;
+import com.sssok.domain.file.StorageKey;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.file.UploadStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteMediaServiceTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long REQUESTER_ID = 2L;
+
+    @Mock
+    FileRepository fileRepository;
+
+    @Mock
+    RoomPermissionPort roomPermissionPort;
+
+    @Mock
+    MediaDeleter mediaDeleter;
+
+    DeleteMediaService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DeleteMediaService(fileRepository, roomPermissionPort, mediaDeleter);
+    }
+
+    @Test
+    void 올린_본인은_단건_삭제할_수_있다() {
+        StoredFile file = file(1L, ROOM_ID, REQUESTER_ID);
+        given(fileRepository.findById(file.getId())).willReturn(Optional.of(file));
+        given(roomPermissionPort.isHost(ROOM_ID, REQUESTER_ID)).willReturn(false);
+
+        assertThat(service.deleteOne(ROOM_ID, file.getId(), REQUESTER_ID)).isEqualTo(file.getId());
+        verify(mediaDeleter).delete(ROOM_ID, List.of(file));
+    }
+
+    @Test
+    void 방장은_다른_사람의_미디어도_삭제할_수_있다() {
+        StoredFile file = file(1L, ROOM_ID, 99L);
+        given(fileRepository.findById(file.getId())).willReturn(Optional.of(file));
+        given(roomPermissionPort.isHost(ROOM_ID, REQUESTER_ID)).willReturn(true);
+
+        service.deleteOne(ROOM_ID, file.getId(), REQUESTER_ID);
+
+        verify(mediaDeleter).delete(ROOM_ID, List.of(file));
+    }
+
+    @Test
+    void 다른_참여자는_삭제할_수_없다() {
+        StoredFile file = file(1L, ROOM_ID, 99L);
+        given(fileRepository.findById(file.getId())).willReturn(Optional.of(file));
+
+        assertThatThrownBy(() -> service.deleteOne(ROOM_ID, file.getId(), REQUESTER_ID))
+            .isInstanceOf(MediaForbiddenException.class);
+        verify(mediaDeleter, never()).delete(ROOM_ID, List.of(file));
+    }
+
+    @Test
+    void 없거나_다른_방의_미디어는_단건_삭제에서_404() {
+        StoredFile otherRoomFile = file(1L, 20L, REQUESTER_ID);
+        given(fileRepository.findById(1L)).willReturn(Optional.of(otherRoomFile));
+
+        assertThatThrownBy(() -> service.deleteOne(ROOM_ID, 1L, REQUESTER_ID))
+            .isInstanceOf(MediaNotFoundException.class);
+    }
+
+    @Test
+    void 다건_삭제는_유효한_항목만_삭제하고_나머지를_구분한다() {
+        StoredFile first = file(1L, ROOM_ID, REQUESTER_ID);
+        StoredFile second = file(2L, ROOM_ID, REQUESTER_ID);
+        StoredFile otherRoom = file(3L, 20L, REQUESTER_ID);
+        given(fileRepository.findAllByIdIn(List.of(1L, 999L, 2L, 3L)))
+            .willReturn(List.of(second, otherRoom, first));
+
+        DeleteMediaResult result = service.deleteAll(
+            ROOM_ID, List.of(1L, 999L, 2L, 1L, 3L), REQUESTER_ID);
+
+        assertThat(result.deletedMediaIds()).containsExactly(1L, 2L);
+        assertThat(result.notFoundMediaIds()).containsExactly(999L, 3L);
+        assertThat(result.deletedCount()).isEqualTo(2);
+        verify(mediaDeleter).delete(ROOM_ID, List.of(first, second));
+    }
+
+    @Test
+    void 다건에_남의_미디어가_섞이면_전체를_거부한다() {
+        StoredFile mine = file(1L, ROOM_ID, REQUESTER_ID);
+        StoredFile others = file(2L, ROOM_ID, 99L);
+        given(fileRepository.findAllByIdIn(List.of(1L, 2L))).willReturn(List.of(mine, others));
+
+        assertThatThrownBy(() -> service.deleteAll(ROOM_ID, List.of(1L, 2L), REQUESTER_ID))
+            .isInstanceOf(MediaForbiddenException.class);
+        verify(mediaDeleter, never()).delete(ROOM_ID, List.of(mine, others));
+    }
+
+    @Test
+    void 빈_목록은_거부한다() {
+        assertThatThrownBy(() -> service.deleteAll(ROOM_ID, List.of(), REQUESTER_ID))
+            .isInstanceOf(InvalidMediaDeleteParamException.class);
+    }
+
+    @Test
+    void null_ID가_섞인_목록은_거부한다() {
+        assertThatThrownBy(() -> service.deleteAll(
+            ROOM_ID, java.util.Arrays.asList(1L, null), REQUESTER_ID))
+            .isInstanceOf(InvalidMediaDeleteParamException.class);
+    }
+
+    @Test
+    void 최대_개수를_넘으면_거부한다() {
+        List<Long> ids = LongStream.rangeClosed(1, 501).boxed().toList();
+
+        assertThatThrownBy(() -> service.deleteAll(ROOM_ID, ids, REQUESTER_ID))
+            .isInstanceOf(TooManyMediaException.class);
+    }
+
+    private StoredFile file(Long id, Long roomId, Long uploaderId) {
+        Instant now = Instant.now();
+        return StoredFile.reconstruct(id, roomId, uploaderId, "사진.jpg", MediaType.JPEG,
+            new FileSize(1024), new StorageKey("rooms/%d/%d.jpg".formatted(roomId, id)), null,
+            UploadStatus.READY, now, now, 0, null, null, null, null, null);
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/MediaDeleterTest.java
+++ b/backend/src/test/java/com/sssok/application/media/MediaDeleterTest.java
@@ -1,0 +1,40 @@
+package com.sssok.application.media;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.domain.file.StoredFile;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.context.ApplicationEventPublisher;
+
+class MediaDeleterTest {
+
+    @Test
+    void 원본과_썸네일을_지운_뒤_관계와_행을_삭제하고_이벤트를_발행한다() {
+        FileRepository fileRepository = mock(FileRepository.class);
+        FolderMediaRepository folderMediaRepository = mock(FolderMediaRepository.class);
+        FileStoragePort fileStoragePort = mock(FileStoragePort.class);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        StoredFile file = mock(StoredFile.class);
+        var original = new com.sssok.domain.file.StorageKey("rooms/10/a.jpg");
+        var thumbnail = new com.sssok.domain.file.StorageKey("rooms/10/a_thumb.jpg");
+        org.mockito.Mockito.when(file.getId()).thenReturn(1L);
+        org.mockito.Mockito.when(file.getStorageKey()).thenReturn(original);
+        org.mockito.Mockito.when(file.getThumbnailKey()).thenReturn(thumbnail);
+
+        new MediaDeleter(fileRepository, folderMediaRepository, fileStoragePort, eventPublisher)
+            .delete(10L, List.of(file));
+
+        InOrder order = inOrder(fileStoragePort, folderMediaRepository, fileRepository, eventPublisher);
+        order.verify(fileStoragePort).delete(original);
+        order.verify(fileStoragePort).delete(thumbnail);
+        order.verify(folderMediaRepository).detachFromAllFolders(List.of(1L));
+        order.verify(fileRepository).deleteAllByIdIn(List.of(1L));
+        order.verify(eventPublisher).publishEvent(new MediaDeletedEvent(10L, List.of(1L)));
+    }
+}

--- a/backend/src/test/java/com/sssok/application/media/ThumbnailTriggerConfigurationTest.java
+++ b/backend/src/test/java/com/sssok/application/media/ThumbnailTriggerConfigurationTest.java
@@ -1,0 +1,18 @@
+package com.sssok.application.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Async;
+
+class ThumbnailTriggerConfigurationTest {
+
+    @Test
+    void 스프링부트가_제공하는_비동기_실행기를_사용한다() throws NoSuchMethodException {
+        Method listener = ThumbnailTrigger.class.getMethod("onMediaCreated", MediaCreatedEvent.class);
+
+        assertThat(listener.getAnnotation(Async.class).value())
+            .isEqualTo("applicationTaskExecutor");
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaDeleteApiTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaDeleteApiTest.java
@@ -1,0 +1,167 @@
+package com.sssok.presentation.api.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.auth.AnonymousAuthService;
+import com.sssok.application.auth.AuthResult;
+import com.sssok.application.folder.CreateFolderService;
+import com.sssok.application.port.out.FileRepository;
+import com.sssok.application.port.out.FileStoragePort;
+import com.sssok.application.port.out.FolderMediaRepository;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.application.room.JoinRoomService;
+import com.sssok.domain.file.FileSize;
+import com.sssok.domain.file.ProcessedMedia;
+import com.sssok.domain.file.StoredFile;
+import com.sssok.domain.folder.Folder;
+import com.sssok.domain.room.Room;
+import com.sssok.infrastructure.realtime.RoomEventJpaRepository;
+import com.sssok.support.PostgresContainerSupport;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+class MediaDeleteApiTest extends PostgresContainerSupport {
+
+    @Autowired
+    WebApplicationContext context;
+
+    @Autowired
+    AnonymousAuthService anonymousAuthService;
+
+    @Autowired
+    CreateRoomService createRoomService;
+
+    @Autowired
+    JoinRoomService joinRoomService;
+
+    @Autowired
+    CreateFolderService createFolderService;
+
+    @Autowired
+    FileRepository fileRepository;
+
+    @Autowired
+    FolderMediaRepository folderMediaRepository;
+
+    @Autowired
+    RoomEventJpaRepository roomEventJpaRepository;
+
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    FileStoragePort fileStoragePort;
+
+    MockMvc mockMvc;
+    Long roomId;
+    AuthResult host;
+    AuthResult uploader;
+    AuthResult other;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        host = anonymousAuthService.authenticate("방장");
+        uploader = anonymousAuthService.authenticate("가현");
+        other = anonymousAuthService.authenticate("의찬");
+        Room room = createRoomService.create(host.userId(), "우테코 회식", null, null).room();
+        roomId = room.getId();
+        joinRoomService.join(roomId, uploader.userId());
+        joinRoomService.join(roomId, other.userId());
+    }
+
+    @Test
+    void 업로더가_단건_삭제하면_R2와_폴더_관계와_DB_행이_모두_사라진다() throws Exception {
+        StoredFile file = saveReady(uploader.userId(), true);
+        Folder folder = createFolderService.create(roomId, "1일차");
+        transactionTemplate.executeWithoutResult(ignored ->
+            folderMediaRepository.attachToFolder(folder.getId(), List.of(file.getId())));
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, file.getId())
+                .header("Authorization", bearer(uploader)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.deletedMediaId").value(file.getId()));
+
+        assertThat(fileRepository.findById(file.getId())).isEmpty();
+        assertThat(folderMediaRepository.findMediaIdsByFolderId(folder.getId())).isEmpty();
+        verify(fileStoragePort).delete(file.getStorageKey());
+        verify(fileStoragePort).delete(file.getThumbnailKey());
+        assertThat(roomEventJpaRepository.findByRoomIdAndIdGreaterThanOrderById(roomId, 0L))
+            .anyMatch(event -> event.getEventType().equals("media.deleted")
+                && event.getPayload().contains(file.getId().toString()));
+    }
+
+    @Test
+    void 방장은_다른_사람이_올린_미디어를_삭제할_수_있다() throws Exception {
+        StoredFile file = saveReady(uploader.userId(), false);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, file.getId())
+                .header("Authorization", bearer(host)))
+            .andExpect(status().isOk());
+
+        assertThat(fileRepository.findById(file.getId())).isEmpty();
+    }
+
+    @Test
+    void 다른_참여자는_삭제할_수_없다() throws Exception {
+        StoredFile file = saveReady(uploader.userId(), false);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media/{mediaId}", roomId, file.getId())
+                .header("Authorization", bearer(other)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("MEDIA_FORBIDDEN"));
+
+        assertThat(fileRepository.findById(file.getId())).isPresent();
+    }
+
+    @Test
+    void 다건_삭제는_없는_ID를_분리하고_나머지를_삭제한다() throws Exception {
+        StoredFile first = saveReady(uploader.userId(), false);
+        StoredFile second = saveReady(uploader.userId(), false);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media", roomId)
+                .header("Authorization", bearer(uploader))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[%d,999999,%d,%d]}"
+                    .formatted(first.getId(), second.getId(), first.getId())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.deletedCount").value(2))
+            .andExpect(jsonPath("$.data.deletedMediaIds[0]").value(first.getId()))
+            .andExpect(jsonPath("$.data.deletedMediaIds[1]").value(second.getId()))
+            .andExpect(jsonPath("$.data.notFoundMediaIds[0]").value(999999));
+
+        assertThat(fileRepository.findAllByIdIn(List.of(first.getId(), second.getId()))).isEmpty();
+    }
+
+    private StoredFile saveReady(Long uploaderId, boolean withThumbnail) {
+        StoredFile file = StoredFile.reserve(roomId, uploaderId, "사진.jpg", "image/jpeg",
+            new FileSize(1024), Instant.now());
+        file.startProcessing();
+        if (withThumbnail) {
+            file.completeProcessing(new ProcessedMedia(
+                file.getStorageKey().thumbnail(), 1200, 900, null, null));
+        } else {
+            file.markReady();
+        }
+        return fileRepository.save(file);
+    }
+
+    private String bearer(AuthResult auth) {
+        return "Bearer " + auth.accessToken();
+    }
+}

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaDeleteControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaDeleteControllerTest.java
@@ -1,0 +1,161 @@
+package com.sssok.presentation.api.media;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.media.DeleteMediaResult;
+import com.sssok.application.media.DeleteMediaService;
+import com.sssok.application.media.exception.InvalidMediaDeleteParamException;
+import com.sssok.application.media.exception.MediaForbiddenException;
+import com.sssok.application.media.exception.MediaNotFoundException;
+import com.sssok.application.media.exception.TooManyMediaException;
+import com.sssok.application.port.out.RoomMemberRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomMember;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MediaDeleteController.class)
+class MediaDeleteControllerTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long MEMBER_ID = 2L;
+    private static final Long MEDIA_ID = 5012L;
+    private static final String BEARER = "Bearer valid-token";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    DeleteMediaService deleteMediaService;
+
+    @MockitoBean
+    TokenProvider tokenProvider;
+
+    @MockitoBean
+    RoomRepository roomRepository;
+
+    @MockitoBean
+    RoomMemberRepository roomMemberRepository;
+
+    @BeforeEach
+    void setUp() {
+        given(tokenProvider.parse("valid-token")).willReturn(MEMBER_ID);
+        given(roomRepository.findById(ROOM_ID)).willReturn(Optional.of(activeRoom()));
+        given(roomMemberRepository.findByRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+            .willReturn(Optional.of(RoomMember.reconstruct(1L, ROOM_ID, MEMBER_ID, Instant.now())));
+    }
+
+    @Test
+    void 단건을_삭제하면_삭제한_ID를_반환한다() throws Exception {
+        given(deleteMediaService.deleteOne(ROOM_ID, MEDIA_ID, MEMBER_ID)).willReturn(MEDIA_ID);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media/{mediaId}", ROOM_ID, MEDIA_ID)
+                .header("Authorization", BEARER))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.deletedMediaId").value(MEDIA_ID));
+    }
+
+    @Test
+    void 다건을_삭제하면_삭제와_미존재_ID를_나눠_반환한다() throws Exception {
+        given(deleteMediaService.deleteAll(ROOM_ID, List.of(1L, 2L, 999L), MEMBER_ID))
+            .willReturn(new DeleteMediaResult(2, List.of(1L, 2L), List.of(999L)));
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media", ROOM_ID)
+                .header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[1,2,999]}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.deletedCount").value(2))
+            .andExpect(jsonPath("$.data.deletedMediaIds[0]").value(1))
+            .andExpect(jsonPath("$.data.notFoundMediaIds[0]").value(999));
+    }
+
+    @Test
+    void 빈_목록이면_400_INVALID_PARAM() throws Exception {
+        willThrow(new InvalidMediaDeleteParamException())
+            .given(deleteMediaService).deleteAll(ROOM_ID, List.of(), MEMBER_ID);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media", ROOM_ID)
+                .header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[]}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_PARAM"));
+    }
+
+    @Test
+    void mediaIds를_누락하면_400_INVALID_PARAM() throws Exception {
+        willThrow(new InvalidMediaDeleteParamException())
+            .given(deleteMediaService).deleteAll(ROOM_ID, null, MEMBER_ID);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media", ROOM_ID)
+                .header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_PARAM"));
+    }
+
+    @Test
+    void 최대_개수를_넘으면_400_TOO_MANY_FILES() throws Exception {
+        willThrow(new TooManyMediaException(500))
+            .given(deleteMediaService).deleteAll(org.mockito.ArgumentMatchers.eq(ROOM_ID),
+                org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.eq(MEMBER_ID));
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media", ROOM_ID)
+                .header("Authorization", BEARER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"mediaIds\":[1]}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("TOO_MANY_FILES"));
+    }
+
+    @Test
+    void 없는_미디어면_404_MEDIA_NOT_FOUND() throws Exception {
+        willThrow(new MediaNotFoundException())
+            .given(deleteMediaService).deleteOne(ROOM_ID, MEDIA_ID, MEMBER_ID);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media/{mediaId}", ROOM_ID, MEDIA_ID)
+                .header("Authorization", BEARER))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("MEDIA_NOT_FOUND"));
+    }
+
+    @Test
+    void 삭제_권한이_없으면_403_MEDIA_FORBIDDEN() throws Exception {
+        willThrow(new MediaForbiddenException())
+            .given(deleteMediaService).deleteOne(ROOM_ID, MEDIA_ID, MEMBER_ID);
+
+        mockMvc.perform(delete("/api/v1/rooms/{roomId}/media/{mediaId}", ROOM_ID, MEDIA_ID)
+                .header("Authorization", BEARER))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("MEDIA_FORBIDDEN"));
+    }
+
+    private Room activeRoom() {
+        return Room.reconstruct(ROOM_ID, null, RoomCode.generate(new SecureRandom()),
+            new RoomName("우테코 회식"), RoomStatus.initial(),
+            new RoomExpiration(Instant.now().plusSeconds(3600)), UploadPolicy.ANYONE,
+            1L, Instant.now(), null);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 업로더 본인과 방장이 미디어를 단건·다건으로 삭제할 수 있는 API를 구현했습니다.
- 미디어 삭제 시 PostgreSQL 메타데이터뿐 아니라 R2 원본·썸네일과 폴더 연결 관계도 함께 정리합니다.
- 삭제 트랜잭션이 커밋된 뒤 `media.deleted` SSE 이벤트를 발행해 다른 참여자의 화면에도 반영할 수 있게 했습니다.

## 관련 이슈
Closes #108

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] `DELETE /api/v1/rooms/{roomId}/media/{mediaId}` 단건 삭제
- [x] `DELETE /api/v1/rooms/{roomId}/media` 다건 삭제
- [x] 업로더 본인 또는 방장 권한 검증
- [x] 다건 요청 최대 500개 및 입력값 검증
- [x] 없는 미디어 ID 부분 성공 처리
- [x] R2 원본·썸네일 삭제
- [x] `folder_media` 및 `stored_file` 삭제
- [x] 커밋 후 `media.deleted` SSE 발행
- [x] 실구동 중 발견한 썸네일 비동기 실행기 설정 오류 수정

## 테스트
- [x] 단위 테스트 작성/통과
- [x] PostgreSQL 인수 테스트 통과
- [x] 백엔드 전체 테스트 통과
- [x] Swagger 및 실제 R2 연동 확인

### 실제 R2 연동 확인
- 서명 URL로 합성 JPEG 3개 직접 PUT
- 3개 모두 썸네일 생성 후 `READY` 전환
- 단건 삭제 후 조회·R2 원본·R2 썸네일 모두 404 확인
- 다건 삭제 2개 성공 및 없는 ID를 `notFoundMediaIds`로 분리하는 것 확인
- 삭제 후 방 미디어 목록이 비어 있는 것 확인

## 리뷰 요청 사항 (선택)
- 다른 방의 미디어 ID는 존재 여부가 노출되지 않도록 `MEDIA_NOT_FOUND`로 처리합니다.
- 다건 요청에 권한 없는 미디어가 하나라도 포함되면 타인의 미디어가 부분 삭제되지 않도록 요청 전체를 `MEDIA_FORBIDDEN`으로 거부합니다.