### PR TITLE
feat: 백엔드 API 서버 CORS 설정 추가 - #134

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           # CI 테스트 전용 키. 운영 시크릿과 무관하며 실제 배포에는 쓰이지 않는다.
           JWT_SECRET: 5SWYqRqL3JIuYo1c/ecWhbU6RTRd2nWPQfeaDjGJSd0=
+          # application-local.yml은 gitignore 대상이라 CI에는 없다. 로컬 기본값과 맞춰
+          # WebMvcTest(별도 @ActiveProfiles("test") 없이 도는 슬라이스)의 CORS 테스트가 통과하게 한다.
+          CORS_ALLOWED_ORIGINS: http://localhost:3000
 
       - name: 테스트 리포트 업로드
         if: always()

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -19,3 +19,7 @@ R2_ACCESS_KEY=
 R2_SECRET_KEY=
 R2_BUCKET=sssok-prod
 R2_PUBLIC_BASE_URL=
+
+# --- CORS ---
+# 브라우저에서 API를 호출할 프론트 오리진. 콤마로 여러 개 지정 가능 (예: https://sssok.com,https://www.sssok.com)
+CORS_ALLOWED_ORIGINS=

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -25,6 +25,7 @@ services:
       R2_SECRET_KEY: ${R2_SECRET_KEY}
       R2_BUCKET: ${R2_BUCKET}
       R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 10s

--- a/backend/src/main/java/com/sssok/infrastructure/config/CorsProperties.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/CorsProperties.java
@@ -1,0 +1,8 @@
+package com.sssok.infrastructure.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cors")
+public record CorsProperties(List<String> allowedOrigins) {
+}

--- a/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
+++ b/backend/src/main/java/com/sssok/infrastructure/config/WebConfig.java
@@ -4,14 +4,17 @@ import com.sssok.presentation.api.common.RoomMembershipInterceptor;
 import com.sssok.presentation.auth.AuthMemberArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(CorsProperties.class)
 public class WebConfig implements WebMvcConfigurer {
 
     // 실제 API 베이스 URL: https://api.ssssok.com/api/v1
@@ -22,6 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthMemberArgumentResolver authMemberArgumentResolver;
     private final RoomMembershipInterceptor roomMembershipInterceptor;
+    private final CorsProperties corsProperties;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -45,5 +49,16 @@ public class WebConfig implements WebMvcConfigurer {
                 API_PREFIX + "/rooms/*/media/**",
                 API_PREFIX + "/rooms/*/downloads",
                 API_PREFIX + "/rooms/*/downloads/**");
+    }
+
+    // 프론트가 API와 다른 오리진에서 서빙되므로 브라우저가 프리플라이트(OPTIONS)를 보낸다.
+    // 인증은 쿠키가 아니라 Authorization 헤더라 credentials는 필요 없다.
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping(API_PREFIX + "/**")
+            .allowedOrigins(corsProperties.allowedOrigins().toArray(new String[0]))
+            .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .maxAge(3600);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,6 +37,11 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-ttl: ${JWT_ACCESS_TOKEN_TTL:30d}
 
+cors:
+  # 브라우저에서 API를 호출할 수 있는 오리진. 콤마로 구분한다.
+  # 로컬 기본값은 application-local.yml, 운영값은 환경변수로 공급한다.
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
 room:
   code-length: 8
   default-ttl: 24h

--- a/backend/src/test/java/com/sssok/infrastructure/config/WebConfigCorsTest.java
+++ b/backend/src/test/java/com/sssok/infrastructure/config/WebConfigCorsTest.java
@@ -1,0 +1,108 @@
+package com.sssok.infrastructure.config;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sssok.application.port.out.RoomMemberRepository;
+import com.sssok.application.port.out.RoomRepository;
+import com.sssok.application.port.out.TokenProvider;
+import com.sssok.application.room.CreateRoomService;
+import com.sssok.application.room.DeleteRoomService;
+import com.sssok.application.room.GetRoomService;
+import com.sssok.application.room.JoinRoomService;
+import com.sssok.application.room.RoomDetail;
+import com.sssok.application.room.UpdateRoomService;
+import com.sssok.domain.room.Room;
+import com.sssok.domain.room.RoomCode;
+import com.sssok.domain.room.RoomExpiration;
+import com.sssok.domain.room.RoomName;
+import com.sssok.domain.room.UploadPolicy;
+import com.sssok.domain.room.roomstatus.RoomStatus;
+import com.sssok.presentation.api.room.RoomController;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+// WebConfig가 등록하는 CORS 설정을 검증한다. 특정 컨트롤러의 기능이 아니라 WebConfig 자체를
+// 확인하는 것이므로, 인증이 필요 없는 기존 엔드포인트(RoomController)에 붙여 테스트한다.
+@WebMvcTest(RoomController.class)
+class WebConfigCorsTest {
+
+    private static final String CODE = "A3F9K2M7";
+    // application-local.yml/application-test.yml에 설정된 기본 허용 오리진과 맞춘다.
+    private static final String ALLOWED_ORIGIN = "http://localhost:3000";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    GetRoomService getRoomService;
+
+    // RoomController 생성자가 요구하는 나머지 서비스. 이 테스트에서는 쓰지 않지만
+    // 컨텍스트가 뜨려면 빈으로 채워져야 한다.
+    @MockitoBean
+    CreateRoomService createRoomService;
+
+    @MockitoBean
+    UpdateRoomService updateRoomService;
+
+    @MockitoBean
+    DeleteRoomService deleteRoomService;
+
+    @MockitoBean
+    JoinRoomService joinRoomService;
+
+    @MockitoBean
+    TokenProvider tokenProvider;
+
+    @MockitoBean
+    RoomRepository roomRepository;
+
+    @MockitoBean
+    RoomMemberRepository roomMemberRepository;
+
+    @Test
+    void 허용된_오리진의_프리플라이트_요청은_허용_헤더를_받는다() throws Exception {
+        mockMvc.perform(options("/api/v1/rooms/{code}", CODE)
+                .header("Origin", ALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "GET"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN))
+            .andExpect(header().exists("Access-Control-Allow-Methods"));
+    }
+
+    @Test
+    void 허용되지_않은_오리진의_프리플라이트_요청은_거부된다() throws Exception {
+        mockMvc.perform(options("/api/v1/rooms/{code}", CODE)
+                .header("Origin", "https://evil.example.com")
+                .header("Access-Control-Request-Method", "GET"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 허용된_오리진의_실제_요청_응답에도_허용_헤더가_붙는다() throws Exception {
+        given(getRoomService.getByCode(eq(new RoomCode(CODE)), isNull())).willReturn(roomDetail());
+
+        mockMvc.perform(get("/api/v1/rooms/{code}", CODE)
+                .header("Origin", ALLOWED_ORIGIN))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN));
+    }
+
+    private RoomDetail roomDetail() {
+        Room room = Room.reconstruct(
+            10L, null, new RoomCode(CODE), new RoomName("우테코 회식"), RoomStatus.initial(),
+            new RoomExpiration(Instant.parse("2026-08-14T00:00:00Z")), UploadPolicy.ANYONE, 1L,
+            Instant.parse("2026-08-13T00:00:00Z"), null);
+        return new RoomDetail(room, "가현", false, 0, List.of());
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -22,3 +22,6 @@ storage:
 # 테스트 전용 키. 운영 시크릿과 무관하며 실제 배포에는 쓰이지 않는다.
 jwt:
   secret: mvtcAhMGbXlhpJ4JuIvRWJVF+yMUju6PxRCb/FMojgA=
+
+cors:
+  allowed-origins: http://localhost:3000

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -33,7 +33,7 @@ main  ──PR──▶  deploy  ──push 트리거──▶  GitHub Actions (
 
 | 파일 | 만드는 주체 | 설명 |
 | --- | --- | --- |
-| `.env` | **사람이 1회 수동 생성** | DB 접속 정보(RDS), JWT, R2 자격증명 |
+| `.env` | **사람이 1회 수동 생성** | DB 접속 정보(RDS), JWT, R2 자격증명, CORS 허용 오리진 |
 | `image.env` | CI가 배포마다 덮어씀 | `BACKEND_IMAGE=ghcr.io/...:<sha>` |
 | `image.env.prev` | CI가 자동 생성 | 롤백용 직전 태그 |
 | `docker-compose.prod.yml` | CI가 배포마다 전송 | 컨테이너 정의 |
@@ -94,6 +94,7 @@ R2_ACCESS_KEY=
 R2_SECRET_KEY=
 R2_BUCKET=sssok-prod
 R2_PUBLIC_BASE_URL=
+CORS_ALLOWED_ORIGINS=여기에_프론트_배포_오리진(콤마로_여러_개_가능)
 EOF
 chmod 600 .env
 ```
@@ -130,7 +131,7 @@ sudo ./svc.sh status   # active (running) 확인
 | --- | --- |
 | `DEPLOY_PATH` | `/home/ubuntu/app` |
 
-DB·JWT·R2 값은 서버 `.env` 에 있으므로 GitHub Secret으로 넣지 않는다. (SSH 기반이 아니므로 `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_SSH_KEY`/`DEPLOY_PORT` 는 더 이상 사용하지 않는다.)
+DB·JWT·R2·CORS 값은 서버 `.env` 에 있으므로 GitHub Secret으로 넣지 않는다. (SSH 기반이 아니므로 `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_SSH_KEY`/`DEPLOY_PORT` 는 더 이상 사용하지 않는다.)
 
 ### 7. GHCR 패키지 접근 권한
 


### PR DESCRIPTION
## 작업 내용
- 백엔드에 CORS 설정이 전혀 없어(WebConfig에 addCorsMappings 미구현) 프론트가 다른 오리진에서
  Authorization 헤더를 실어 호출하는 모든 요청이 브라우저 프리플라이트 단계에서 막히는 문제를
  고친다.
- `CorsProperties`(`cors.allowed-origins`)를 추가하고, `WebConfig.addCorsMappings`로
  `/api/v1/**`에 CORS를 등록한다 (Authorization 포함 모든 헤더 허용, GET/POST/PATCH/PUT/DELETE/OPTIONS,
  credentials는 안 씀 — 인증이 쿠키가 아니라 Authorization 헤더라 필요 없음).
- 오리진은 하드코딩하지 않고 환경변수(`CORS_ALLOWED_ORIGINS`)로 설정한다. 로컬 기본값은
  `http://localhost:3000`, 운영은 JWT_SECRET과 같은 패턴으로 필수 환경변수다
  (`docker-compose.prod.yml`/`.env.prod.example`/배포 문서에 반영).

## 관련 이슈
Closes #134
관련: #124 (그 이슈의 R2 버킷 CORS/명세 정합성/배포 항목은 이 PR 범위 밖)

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] feat(backend): `CorsProperties` 추가 및 `WebConfig`에 CORS 매핑 등록
- [x] chore(backend): `application.yml`/`application-test.yml`/배포 설정에 `cors.allowed-origins` 반영
- [x] test(backend): `WebConfigCorsTest` 추가 (허용 오리진 프리플라이트 통과, 비허용 오리진 거부,
  실요청 응답 헤더 확인)

## 테스트
- [x] 단위 테스트 작성/통과 (WebConfigCorsTest 3건 + 전체 백엔드 테스트 스위트 로컬 실행 —
  BUILD SUCCESSFUL, 리그레션 없음)
- [ ] 로컬 동작 확인 (프론트 실제 연동 확인은 안 함)

## 리뷰 요청 사항 (선택)
- `application-local.yml`은 gitignore 대상이라 이 PR에 포함되지 않습니다. 로컬에서 pull 받은 뒤
  본인 `application-local.yml`에 `cors: allowed-origins: http://localhost:3000` 한 줄을 추가해야
  로컬 서버가 뜹니다 (JWT_SECRET과 동일한 패턴).
- 운영 배포 시 서버 `.env`에 `CORS_ALLOWED_ORIGINS`(실제 프론트 배포 오리진)를 추가해야 합니다 —
  아직 안 채워져 있으면 운영 서버가 기동하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프론트엔드에서 API에 접근할 수 있도록 허용된 출처를 환경 변수로 설정할 수 있습니다.
  * 허용된 출처의 브라우저 요청과 사전 요청(Preflight)을 지원합니다.

* **문서**
  * 배포 시 CORS 허용 출처 설정 방법과 환경 변수 등록 절차를 추가했습니다.

* **테스트**
  * 허용된 출처와 허용되지 않은 출처에 대한 CORS 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->