### PR TITLE
fix: 썸네일 URL 쿼리 토큰 인증 지원

### DIFF
--- a/backend/src/main/java/com/sssok/presentation/api/common/RoomMembershipInterceptor.java
+++ b/backend/src/main/java/com/sssok/presentation/api/common/RoomMembershipInterceptor.java
@@ -8,6 +8,7 @@ import com.sssok.application.room.exception.NotRoomMemberException;
 import com.sssok.application.room.exception.RoomExpiredException;
 import com.sssok.application.room.exception.RoomNotFoundException;
 import com.sssok.domain.room.Room;
+import com.sssok.presentation.auth.AuthMember;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Instant;
@@ -37,7 +38,7 @@ public class RoomMembershipInterceptor implements HandlerInterceptor {
         }
 
         Long roomId = extractRoomId(request);
-        Long memberId = extractMemberId(request);
+        Long memberId = extractMemberId(request, (HandlerMethod) handler);
 
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new RoomNotFoundException(roomId));
@@ -57,11 +58,30 @@ public class RoomMembershipInterceptor implements HandlerInterceptor {
         return Long.valueOf(pathVariables.get("roomId"));
     }
 
-    private Long extractMemberId(HttpServletRequest request) {
+    private Long extractMemberId(HttpServletRequest request, HandlerMethod handler) {
         String authorizationHeader = request.getHeader("Authorization");
-        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-            throw new UnauthorizedException("다시 접속해주세요");
+        if (authorizationHeader != null && !authorizationHeader.isBlank()) {
+            if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+                throw new UnauthorizedException("다시 접속해주세요");
+            }
+            return tokenProvider.parse(authorizationHeader.substring(BEARER_PREFIX.length()));
         }
-        return tokenProvider.parse(authorizationHeader.substring(BEARER_PREFIX.length()));
+        if (allowsQueryToken(handler)) {
+            String token = request.getParameter("token");
+            if (token != null && !token.isBlank()) {
+                return tokenProvider.parse(token);
+            }
+        }
+        throw new UnauthorizedException("다시 접속해주세요");
+    }
+
+    private boolean allowsQueryToken(HandlerMethod handler) {
+        for (var parameter : handler.getMethodParameters()) {
+            AuthMember authMember = parameter.getParameterAnnotation(AuthMember.class);
+            if (authMember != null && authMember.allowQueryToken()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaFullResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaFullResponse.java
@@ -17,9 +17,9 @@ public record MediaFullResponse(
     @Schema(description = "요청자가 이 미디어를 지울 수 있는지. 올린 본인과 방장만 true")
     boolean canDelete
 ) {
-    public static MediaFullResponse from(MediaFullDetail detail) {
+    public static MediaFullResponse from(MediaFullDetail detail, String accessToken) {
         return new MediaFullResponse(
-            MediaResponse.from(detail.media()),
+            MediaResponse.from(detail.media(), accessToken),
             detail.takenAt(),
             LocationResponse.from(detail.location()),
             detail.canDelete());

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaListResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaListResponse.java
@@ -9,7 +9,9 @@ import java.util.List;
 public record MediaListResponse(
     @Schema(description = "최신순으로 정렬된 미디어 목록") List<MediaResponse> items
 ) {
-    public static MediaListResponse from(List<MediaDetail> details) {
-        return new MediaListResponse(details.stream().map(MediaResponse::from).toList());
+    public static MediaListResponse from(List<MediaDetail> details, String accessToken) {
+        return new MediaListResponse(details.stream()
+            .map(detail -> MediaResponse.from(detail, accessToken))
+            .toList());
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaQueryController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "미디어 조회", description = "방에 올라온 미디어의 메타데이터와, 화면에 그릴 썸네일·원본을 읽는다. 저장 목적의 다운로드는 다운로드 API가 맡는다.")
@@ -41,11 +42,13 @@ public class MediaQueryController {
     @GetMapping
     public ApiResponse<MediaListResponse> getMediaList(
         @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(hidden = true) @RequestHeader("Authorization") String authorization,
         @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
         @Parameter(description = "이 폴더에 담긴 미디어만 조회한다. 생략하면 방 전체")
         @RequestParam(required = false) Long folderId
     ) {
-        return ApiResponse.of(MediaListResponse.from(getMediaListService.list(roomId, folderId)));
+        return ApiResponse.of(MediaListResponse.from(
+            getMediaListService.list(roomId, folderId), accessToken(authorization)));
     }
 
     @Operation(
@@ -62,16 +65,19 @@ public class MediaQueryController {
     @GetMapping("/{mediaId}")
     public ApiResponse<MediaFullResponse> getMedia(
         @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(hidden = true) @RequestHeader("Authorization") String authorization,
         @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
         @Parameter(description = "조회할 미디어 ID") @PathVariable Long mediaId
     ) {
         return ApiResponse.of(
-            MediaFullResponse.from(getMediaService.get(roomId, mediaId, memberId)));
+            MediaFullResponse.from(
+                getMediaService.get(roomId, mediaId, memberId), accessToken(authorization)));
     }
 
     @Operation(
         summary = "썸네일 표시",
         description = "목록 타일에 그릴 축소본이다. 조회 응답의 thumbnailUrl이 가리키는 주소이며, "
+            + "브라우저 img 태그를 위해 이 경로에서만 token 쿼리 파라미터 인증을 허용한다. "
             + "유효기간 5분짜리 서명 URL로 302 리다이렉트한다. inline이라 브라우저가 그대로 표시하므로 "
             + "img 태그에 바로 걸 수 있다. 서명 URL을 조회 응답에 직접 싣지 않고 이 경로를 거치게 한 것은, "
             + "목록을 캐싱해도 URL이 만료되지 않게 하고 방 참여자만 볼 수 있도록 하기 위해서다. "
@@ -80,7 +86,7 @@ public class MediaQueryController {
     )
     @GetMapping("/{mediaId}/thumbnail")
     public ResponseEntity<Void> thumbnail(
-        @Parameter(hidden = true) @AuthMember Long memberId,
+        @Parameter(hidden = true) @AuthMember(allowQueryToken = true) Long memberId,
         @Parameter(description = "방 조회 응답의 roomId") @PathVariable Long roomId,
         @Parameter(description = "썸네일을 볼 미디어 ID") @PathVariable Long mediaId
     ) {
@@ -107,5 +113,9 @@ public class MediaQueryController {
     // 서버가 바이트를 프록시하지 않고 스토리지 서명 URL 로 넘긴다.
     private ResponseEntity<Void> redirectTo(String url) {
         return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(url)).build();
+    }
+
+    private String accessToken(String authorization) {
+        return authorization.substring("Bearer ".length());
     }
 }

--- a/backend/src/main/java/com/sssok/presentation/api/media/MediaResponse.java
+++ b/backend/src/main/java/com/sssok/presentation/api/media/MediaResponse.java
@@ -2,6 +2,8 @@ package com.sssok.presentation.api.media;
 
 import com.sssok.application.media.MediaDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 
@@ -12,7 +14,8 @@ public record MediaResponse(
     String fileName,
     String mimeType,
     long size,
-    @Schema(description = "워커가 만들기 전까지 null") String thumbnailUrl,
+    @Schema(description = "워커가 만들기 전까지 null. img 태그에서 바로 쓸 수 있도록 인증 토큰을 포함한다")
+    String thumbnailUrl,
     @Schema(description = "워커가 만들기 전까지 null") String originalUrl,
     Integer width,
     Integer height,
@@ -24,9 +27,24 @@ public record MediaResponse(
     Instant uploadedAt
 ) {
     public static MediaResponse from(MediaDetail detail) {
+        return from(detail, null);
+    }
+
+    public static MediaResponse from(MediaDetail detail, String accessToken) {
         return new MediaResponse(detail.mediaId(), detail.type(), detail.fileName(),
-            detail.mimeType(), detail.size(), detail.thumbnailUrl(), detail.originalUrl(),
+            detail.mimeType(), detail.size(), withToken(detail.thumbnailUrl(), accessToken),
+            detail.originalUrl(),
             detail.width(), detail.height(), detail.duration(), detail.folderIds(),
             detail.uploaderId(), detail.uploaderName(), detail.status(), detail.uploadedAt());
+    }
+
+    private static String withToken(String url, String accessToken) {
+        if (url == null) {
+            return null;
+        }
+        if (accessToken == null) {
+            return url;
+        }
+        return url + "?token=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
     }
 }

--- a/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
+++ b/backend/src/test/java/com/sssok/presentation/api/media/MediaQueryControllerTest.java
@@ -89,7 +89,7 @@ class MediaQueryControllerTest {
 
     @Test
     void 목록을_조회하면_200과_items_를_반환한다() throws Exception {
-        given(getMediaListService.list(anyLong(), any())).willReturn(List.of(media()));
+        given(getMediaListService.list(anyLong(), any())).willReturn(List.of(mediaWithThumbnail()));
 
         getMediaList("")
             .andExpect(status().isOk())
@@ -102,7 +102,8 @@ class MediaQueryControllerTest {
             .andExpect(jsonPath("$.data.items[0].uploaderId").value(7))
             .andExpect(jsonPath("$.data.items[0].uploaderName").value("가현"))
             .andExpect(jsonPath("$.data.items[0].folderIds[0]").value(FOLDER_ID))
-            .andExpect(jsonPath("$.data.items[0].thumbnailUrl").doesNotExist())
+            .andExpect(jsonPath("$.data.items[0].thumbnailUrl")
+                .value("/api/v1/rooms/10/media/5012/thumbnail?token=valid-token"))
             .andExpect(jsonPath("$.data.items[0].uploadedAt").exists());
     }
 
@@ -153,6 +154,8 @@ class MediaQueryControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.mediaId").value(MEDIA_ID))
             .andExpect(jsonPath("$.data.fileName").value("사진.jpg"))
+            .andExpect(jsonPath("$.data.thumbnailUrl")
+                .value("/api/v1/rooms/10/media/5012/thumbnail?token=valid-token"))
             .andExpect(jsonPath("$.data.folderIds[0]").value(FOLDER_ID));
     }
 
@@ -193,7 +196,7 @@ class MediaQueryControllerTest {
     }
 
     private MediaFullDetail fullDetail() {
-        return new MediaFullDetail(media(), Instant.parse("2026-08-01T12:30:00Z"),
+        return new MediaFullDetail(mediaWithThumbnail(), Instant.parse("2026-08-01T12:30:00Z"),
             new GeoPoint(new BigDecimal("37.566500"), new BigDecimal("126.978000")), true);
     }
 
@@ -207,6 +210,25 @@ class MediaQueryControllerTest {
                 .header("Authorization", BEARER))
             .andExpect(status().isFound())
             .andExpect(header().string("Location", "https://storage.example.com/thumb"));
+    }
+
+    @Test
+    void 썸네일은_쿼리_토큰으로도_요청할_수_있다() throws Exception {
+        given(getThumbnailUrlService.getUrl(ROOM_ID, MEDIA_ID))
+            .willReturn("https://storage.example.com/thumb");
+
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}/thumbnail", ROOM_ID, MEDIA_ID)
+                .param("token", "valid-token"))
+            .andExpect(status().isFound())
+            .andExpect(header().string("Location", "https://storage.example.com/thumb"));
+    }
+
+    @Test
+    void 잘못된_Authorization_헤더가_있으면_쿼리_토큰으로_대체하지_않는다() throws Exception {
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/media/{mediaId}/thumbnail", ROOM_ID, MEDIA_ID)
+                .header("Authorization", "Basic invalid-token")
+                .param("token", "valid-token"))
+            .andExpect(status().isUnauthorized());
     }
 
     // 미디어는 있는데 썸네일만 없는 경우다. 없는 미디어와 코드로 구분된다.
@@ -246,6 +268,13 @@ class MediaQueryControllerTest {
     private MediaDetail media() {
         return new MediaDetail(MEDIA_ID, "IMAGE", "사진.jpg", "image/jpeg", 1024L,
             null, null, null, null, null, List.of(FOLDER_ID), 7L, "가현", "READY", Instant.now());
+    }
+
+    private MediaDetail mediaWithThumbnail() {
+        return new MediaDetail(MEDIA_ID, "IMAGE", "사진.jpg", "image/jpeg", 1024L,
+            "/api/v1/rooms/10/media/5012/thumbnail",
+            "/api/v1/rooms/10/media/5012/original", 1200, 900, null,
+            List.of(FOLDER_ID), 7L, "가현", "READY", Instant.now());
     }
 
     private ResultActions getMediaList(String query) throws Exception {


### PR DESCRIPTION
## 작업 내용
- 프론트의 img 태그가 Authorization 헤더를 추가하지 못해 썸네일 요청이 401로 실패하는 문제를 수정했습니다.
- 미디어 조회 응답의 thumbnailUrl에 현재 액세스 토큰을 포함하고, 썸네일 엔드포인트에서만 쿼리 토큰 인증을 허용합니다.

## 관련 이슈
Closes #144

## 작업 영역
- [ ] Frontend
- [x] Backend

## 변경 사항
- [x] 목록·단건 조회의 thumbnailUrl에 token 쿼리 파라미터 추가
- [x] 썸네일 조회 API의 쿼리 토큰 인증 지원
- [x] 잘못된 Authorization 헤더의 쿼리 토큰 우회 방지
- [x] 응답 및 인증 테스트 추가

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
- 프론트 수정 전까지 img 태그에서 썸네일을 표시하기 위한 대응입니다. 쿼리 토큰은 접근 로그나 브라우저 기록에 남을 수 있어, 이후 짧은 수명의 미디어 전용 토큰 또는 인증 fetch 방식으로 교체가 필요합니다.
