### PR TITLE
feat: 미디어 조회 및 삭제 API 연동

### DIFF
--- a/frontend/src/entities/media/api/getMedia.ts
+++ b/frontend/src/entities/media/api/getMedia.ts
@@ -1,0 +1,11 @@
+import { apiClient } from "@/shared/api";
+import type { MediaDetail } from "../model/types";
+
+interface GetMediaParams {
+  roomId: number;
+  mediaId: number;
+  token: string;
+}
+
+export const getMedia = ({ roomId, mediaId, token }: GetMediaParams) =>
+  apiClient<MediaDetail>(`/rooms/${roomId}/media/${mediaId}`, { token });

--- a/frontend/src/entities/media/index.ts
+++ b/frontend/src/entities/media/index.ts
@@ -1,5 +1,15 @@
 export { getPhotos } from "./api/getPhotos";
+export { getMedia } from "./api/getMedia";
 export { mediaAssetUrl } from "./lib/mediaAssetUrl";
+export { mediaQueryKey, useMediaQuery } from "./model/useMediaQuery";
 export { photosQueryKey, usePhotosQuery } from "./model/usePhotosQuery";
-export type { Media, MediaItem, MediaList, MediaStatus, PhotoFilter } from "./model/types";
+export type {
+  Media,
+  MediaDetail,
+  MediaItem,
+  MediaList,
+  MediaStatus,
+  PhotoFilter,
+} from "./model/types";
 export { MediaCard } from "./ui/MediaCard";
+export { MediaImage } from "./ui/MediaImage";

--- a/frontend/src/entities/media/lib/resolveMediaSource.test.ts
+++ b/frontend/src/entities/media/lib/resolveMediaSource.test.ts
@@ -1,0 +1,38 @@
+import { resolveMediaSource } from "./resolveMediaSource";
+
+const base = "https://api.ssssok.com/api/v1";
+
+describe("resolveMediaSource", () => {
+  it.each(["/rooms/16/media/5012/thumbnail", "rooms/16/media/5012/thumbnail"])(
+    "상대 경로 %s에 API 베이스를 붙인다",
+    (path) => {
+      expect(resolveMediaSource(path, base)).toBe(`${base}/rooms/16/media/5012/thumbnail`);
+    },
+  );
+
+  it("이미 API 접두사가 있는 경로를 중복해서 붙이지 않는다", () => {
+    expect(resolveMediaSource("/api/v1/rooms/16/media/5012/original", `${base}/`)).toBe(
+      `${base}/rooms/16/media/5012/original`,
+    );
+  });
+
+  it("MSW의 상대 베이스 URL도 현재 origin으로 해석한다", () => {
+    expect(resolveMediaSource("/rooms/16/media/5012/thumbnail", "/api/v1")).toBe(
+      `${window.location.origin}/api/v1/rooms/16/media/5012/thumbnail`,
+    );
+  });
+
+  it.each([
+    `${base}/rooms/16/media/5012/original`,
+    "https://cdn.example.com/5012.jpg",
+    "//cdn.example.com/5012.jpg",
+    "blob:http://localhost:3000/abc",
+    "data:image/png;base64,abc",
+  ])("완성된 URL은 그대로 유지한다: %s", (url) => {
+    expect(resolveMediaSource(url, base)).toBe(url);
+  });
+
+  it("null은 이미지 요청을 만들지 않는다", () => {
+    expect(resolveMediaSource(null, base)).toBeUndefined();
+  });
+});

--- a/frontend/src/entities/media/lib/resolveMediaSource.ts
+++ b/frontend/src/entities/media/lib/resolveMediaSource.ts
@@ -1,0 +1,14 @@
+import { API_BASE_URL } from "@/shared/config";
+
+/** 완성된 URL은 유지하고, API 상대 경로에만 베이스 URL을 붙인다. */
+export const resolveMediaSource = (src: string | null | undefined, baseUrl = API_BASE_URL) => {
+  const value = src?.trim();
+  if (!value) return undefined;
+  if (/^(https?:\/\/|\/\/|blob:|data:)/i.test(value)) return value;
+
+  const base = new URL(baseUrl, window.location.origin);
+  const prefix = base.pathname.replace(/\/$/, "");
+  const path = value.startsWith("/") ? value : `/${value}`;
+  const withPrefix = path === prefix || path.startsWith(`${prefix}/`) ? path : `${prefix}${path}`;
+  return new URL(withPrefix, base.origin).href;
+};

--- a/frontend/src/entities/media/model/types.ts
+++ b/frontend/src/entities/media/model/types.ts
@@ -46,3 +46,14 @@ export interface MediaItem extends Media {
 export interface MediaList {
   items: MediaItem[];
 }
+
+/** 단일 조회에는 썸네일 대신 원본과 촬영 정보·삭제 권한이 내려온다. */
+export interface MediaDetail extends Omit<Media, "thumbnailUrl"> {
+  takenAt: string | null;
+  location: {
+    latitude: number;
+    longitude: number;
+    name: string;
+  } | null;
+  canDelete: boolean;
+}

--- a/frontend/src/entities/media/model/useMediaQuery.ts
+++ b/frontend/src/entities/media/model/useMediaQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getMedia } from "../api/getMedia";
+
+export const mediaQueryKey = (roomId: number, mediaId: number, userId: number) =>
+  ["media", roomId, mediaId, userId] as const;
+
+export const useMediaQuery = ({
+  roomId,
+  mediaId,
+  userId,
+  token,
+}: {
+  roomId: number;
+  mediaId: number;
+  userId: number;
+  token: string;
+}) => {
+  // 사용자별 캐시로 분리하되 토큰 자체는 캐시에 기록하지 않는다.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
+  return useQuery({
+    queryKey: mediaQueryKey(roomId, mediaId, userId),
+    queryFn: () => getMedia({ roomId, mediaId, token }),
+    retry: false,
+  });
+};

--- a/frontend/src/entities/media/ui/MediaImage.tsx
+++ b/frontend/src/entities/media/ui/MediaImage.tsx
@@ -1,0 +1,12 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { resolveMediaSource } from "../lib/resolveMediaSource";
+
+type MediaImageProps = Omit<ComponentPropsWithoutRef<"img">, "src" | "srcSet"> & {
+  src?: string | null;
+};
+
+/** 이미지 경로에 API 베이스 URL만 붙여 브라우저가 직접 요청하게 한다. */
+export const MediaImage = ({ src, alt, ...props }: MediaImageProps) => (
+  <img {...props} src={resolveMediaSource(src)} alt={alt} />
+);

--- a/frontend/src/features/delete-media/api/deleteMedia.ts
+++ b/frontend/src/features/delete-media/api/deleteMedia.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "@/shared/api";
+
+interface DeleteMediaParams {
+  roomId: number;
+  mediaId: number;
+  token: string;
+}
+
+export const deleteMedia = ({ roomId, mediaId, token }: DeleteMediaParams) =>
+  apiClient<void>(`/rooms/${roomId}/media/${mediaId}`, {
+    method: "DELETE",
+    token,
+    responseType: "empty",
+  });

--- a/frontend/src/features/delete-media/api/deleteMediaBatch.ts
+++ b/frontend/src/features/delete-media/api/deleteMediaBatch.ts
@@ -1,0 +1,24 @@
+import { apiClient } from "@/shared/api";
+
+export interface DeleteMediaBatchResponse {
+  deleted: number[];
+  skipped: { mediaId: number; code: string; message: string }[];
+  deletedCount: number;
+}
+
+/** 다중 삭제 UI를 붙일 때 사용할 API. 일부 실패도 성공 응답의 skipped로 내려온다. */
+export const deleteMediaBatch = ({
+  roomId,
+  mediaIds,
+  token,
+}: {
+  roomId: number;
+  mediaIds: number[];
+  token: string;
+}) =>
+  apiClient<DeleteMediaBatchResponse>(`/rooms/${roomId}/media`, {
+    method: "DELETE",
+    token,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mediaIds }),
+  });

--- a/frontend/src/features/delete-media/index.ts
+++ b/frontend/src/features/delete-media/index.ts
@@ -1,0 +1,3 @@
+export { deleteMedia } from "./api/deleteMedia";
+export { deleteMediaBatch, type DeleteMediaBatchResponse } from "./api/deleteMediaBatch";
+export { DeleteMediaModal } from "./ui/DeleteMediaModal";

--- a/frontend/src/features/delete-media/ui/DeleteMediaModal.tsx
+++ b/frontend/src/features/delete-media/ui/DeleteMediaModal.tsx
@@ -1,0 +1,75 @@
+import { useMutation } from "@tanstack/react-query";
+import styled from "@emotion/styled";
+
+import { isApiError } from "@/shared/api";
+import { Button } from "@/shared/ui/button";
+import { Modal } from "@/shared/ui/modal";
+import { Row } from "@/shared/ui/row";
+import { Stack } from "@/shared/ui/stack";
+import { colors, typography } from "@/shared/styles/tokens";
+import { deleteMedia } from "../api/deleteMedia";
+
+interface DeleteMediaModalProps {
+  roomId: number;
+  mediaId: number;
+  token: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export const DeleteMediaModal = ({
+  roomId,
+  mediaId,
+  token,
+  onClose,
+  onSuccess,
+}: DeleteMediaModalProps) => {
+  const mutation = useMutation({
+    mutationFn: () => deleteMedia({ roomId, mediaId, token }),
+    onSuccess,
+  });
+
+  return (
+    <Modal
+      onClose={() => {
+        if (!mutation.isPending) onClose();
+      }}
+      showClose={!mutation.isPending}
+    >
+      <Stack gap={20}>
+        <Title>사진을 삭제할까요?</Title>
+        <Description>삭제한 사진은 다시 복구할 수 없어요.</Description>
+        {mutation.isError && (
+          <ErrorMessage role="alert">
+            {isApiError(mutation.error)
+              ? mutation.error.message
+              : "사진을 삭제하지 못했어요. 다시 시도해 주세요."}
+          </ErrorMessage>
+        )}
+        <Row gap={12}>
+          <Button variant="default" disabled={mutation.isPending} onClick={onClose}>
+            취소
+          </Button>
+          <Button variant="danger" disabled={mutation.isPending} onClick={() => mutation.mutate()}>
+            {mutation.isPending ? "삭제 중…" : "삭제하기"}
+          </Button>
+        </Row>
+      </Stack>
+    </Modal>
+  );
+};
+
+const Title = styled.h2`
+  text-align: center;
+  ${typography.heading3}
+`;
+const Description = styled.p`
+  color: ${colors.textSecondary};
+  text-align: center;
+  ${typography.body}
+`;
+const ErrorMessage = styled.p`
+  color: ${colors.danger};
+  text-align: center;
+  ${typography.caption1}
+`;

--- a/frontend/src/mocks/db.ts
+++ b/frontend/src/mocks/db.ts
@@ -42,6 +42,18 @@ export const originalUrlOf = (mediaId: number, type: "IMAGE" | "VIDEO") =>
 
 /** 방 번호 → 이번 세션에 등록된 미디어. 최신이 앞이다. */
 const registeredByRoom = new Map<number, GalleryMedia[]>();
+const deletedIdsByRoom = new Map<number, Set<number>>();
+
+export const isDeletedMedia = (roomId: number, mediaId: number) =>
+  deletedIdsByRoom.get(roomId)?.has(mediaId) ?? false;
+
+export const markMediaDeleted = (roomId: number, mediaId: number) => {
+  const ids = deletedIdsByRoom.get(roomId) ?? new Set<number>();
+  ids.add(mediaId);
+  deletedIdsByRoom.set(roomId, ids);
+};
+
+export const resetDeletedMedia = () => deletedIdsByRoom.clear();
 
 /**
  * 완료 등록이 끝난 미디어를 목록에 올린다.

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,6 +1,13 @@
 import { authHandlers } from "./auth";
 import { downloadHandlers } from "./download";
+import { mediaHandlers } from "./media";
 import { roomHandlers } from "./room";
 import { uploadHandlers } from "./upload";
 
-export const handlers = [...authHandlers, ...roomHandlers, ...uploadHandlers, ...downloadHandlers];
+export const handlers = [
+  ...authHandlers,
+  ...roomHandlers,
+  ...uploadHandlers,
+  ...downloadHandlers,
+  ...mediaHandlers,
+];

--- a/frontend/src/mocks/handlers/media.test.ts
+++ b/frontend/src/mocks/handlers/media.test.ts
@@ -1,0 +1,94 @@
+import { getMedia, getPhotos } from "@/entities/media";
+import { deleteMedia, deleteMediaBatch } from "@/features/delete-media";
+import { API_BASE_URL } from "@/shared/config";
+import { MOCK_ROOM_CODES, MOCK_ROOM_ID } from "./room";
+
+const HOST = "mock-token-10234";
+const MEMBER = "mock-token-12";
+const join = (token: string) =>
+  fetch(`${API_BASE_URL}/rooms/${MOCK_ROOM_ID}/members`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+describe("미디어 단일 조회·삭제 및 다중 삭제 목", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("인증하지 않았거나 입장하지 않은 사용자는 거절한다", async () => {
+    const response = await fetch(`${API_BASE_URL}/rooms/${MOCK_ROOM_ID}/media/5012`);
+    expect(response.status).toBe(401);
+    await expect(
+      getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5012, token: MEMBER }),
+    ).rejects.toMatchObject({ code: "NOT_ROOM_MEMBER" });
+  });
+
+  it("단일 조회가 촬영 정보와 사용자별 삭제 권한을 반환한다", async () => {
+    await join(MEMBER);
+    const other = await getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5012, token: MEMBER });
+    expect(other).toMatchObject({
+      mediaId: 5012,
+      canDelete: false,
+      takenAt: "2026-08-17T14:02:11+09:00",
+      location: { name: "부산 해운대구" },
+    });
+    expect(other).not.toHaveProperty("thumbnailUrl");
+    const own = await getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5006, token: MEMBER });
+    expect(own.canDelete).toBe(true);
+    await join(HOST);
+    const host = await getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5006, token: HOST });
+    expect(host.canDelete).toBe(true);
+  });
+
+  it("단일 삭제 후 목록에서 빠지고 다시 조회하면 404를 반환한다", async () => {
+    await join(MEMBER);
+    await expect(
+      deleteMedia({ roomId: MOCK_ROOM_ID, mediaId: 5006, token: MEMBER }),
+    ).resolves.toBeUndefined();
+    const list = await getPhotos({ roomId: MOCK_ROOM_ID, token: MEMBER });
+    expect(list.items.some((item) => item.mediaId === 5006)).toBe(false);
+    await expect(
+      getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5006, token: MEMBER }),
+    ).rejects.toMatchObject({ code: "MEDIA_NOT_FOUND" });
+    const response = await fetch(`${API_BASE_URL}/rooms/${MOCK_ROOM_CODES.active}`);
+    const { data } = await response.json();
+    expect(data.photoCount).toBe(15);
+    expect(data.folders.find((folder: { id: number }) => folder.id === 32).photoCount).toBe(3);
+  });
+
+  it("권한 없는 단일 삭제는 사진을 유지한다", async () => {
+    await join(MEMBER);
+    await expect(
+      deleteMedia({ roomId: MOCK_ROOM_ID, mediaId: 5012, token: MEMBER }),
+    ).rejects.toMatchObject({ code: "MEDIA_FORBIDDEN" });
+    await expect(
+      getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5012, token: MEMBER }),
+    ).resolves.toMatchObject({ mediaId: 5012 });
+  });
+
+  it("다중 삭제는 중복을 한 번만 처리하고 권한 없는 항목과 없는 항목은 건너뛴다", async () => {
+    await join(MEMBER);
+    const result = await deleteMediaBatch({
+      roomId: MOCK_ROOM_ID,
+      mediaIds: [5006, 5006, 5012, 999999],
+      token: MEMBER,
+    });
+    expect(result).toMatchObject({
+      deleted: [5006],
+      deletedCount: 1,
+      skipped: [
+        { mediaId: 5012, code: "MEDIA_FORBIDDEN" },
+        { mediaId: 999999, code: "MEDIA_NOT_FOUND" },
+      ],
+    });
+    await expect(
+      getMedia({ roomId: MOCK_ROOM_ID, mediaId: 5006, token: MEMBER }),
+    ).rejects.toMatchObject({ code: "MEDIA_NOT_FOUND" });
+  });
+
+  it("빈 다중 삭제 목록은 거절한다", async () => {
+    await join(HOST);
+    await expect(
+      deleteMediaBatch({ roomId: MOCK_ROOM_ID, mediaIds: [], token: HOST }),
+    ).rejects.toMatchObject({ code: "INVALID_MEDIA_IDS" });
+  });
+});

--- a/frontend/src/mocks/handlers/media.ts
+++ b/frontend/src/mocks/handlers/media.ts
@@ -1,0 +1,113 @@
+import { http, HttpResponse } from "msw";
+
+import type { MediaDetail } from "@/entities/media";
+import { API_BASE_URL } from "@/shared/config";
+import { markMediaDeleted, type GalleryMedia } from "../db";
+import { hasJoinedRoom, mediaOfRoom, MOCK_HOST_ID, roomStatusOfId } from "./room";
+
+const error = (status: number, code: string, message: string) =>
+  HttpResponse.json({ code, message }, { status });
+
+const authorize = (request: Request, roomId: number) => {
+  const authorization = request.headers.get("Authorization");
+  const match = authorization?.match(/^Bearer mock-token-(\d+)$/);
+  if (!authorization || !match) return error(401, "UNAUTHORIZED", "인증이 필요합니다.");
+  const status = roomStatusOfId(roomId);
+  if (status === null) return error(404, "ROOM_NOT_FOUND", "존재하지 않는 방입니다.");
+  if (status !== "ACTIVE")
+    return error(410, "ROOM_ALREADY_DELETED", "이미 삭제되었거나 만료된 방입니다.");
+  if (!hasJoinedRoom(authorization, roomId))
+    return error(403, "NOT_ROOM_MEMBER", "입장한 방에서만 이용할 수 있습니다.");
+  return Number(match[1]);
+};
+
+// backend FilePermissionPolicy: 업로더 본인 또는 방장만 삭제할 수 있다.
+const canDelete = (media: GalleryMedia, memberId: number) =>
+  media.uploaderId === memberId || memberId === MOCK_HOST_ID;
+const notFound = () => error(404, "MEDIA_NOT_FOUND", "미디어를 찾을 수 없습니다.");
+const forbidden = () =>
+  error(403, "MEDIA_FORBIDDEN", "다른 사람이 올린 파일이라 삭제할 수 없습니다");
+
+export const mediaHandlers = [
+  http.get(`${API_BASE_URL}/rooms/:roomId/media/:mediaId`, ({ request, params }) => {
+    const roomId = Number(params.roomId);
+    const auth = authorize(request, roomId);
+    if (typeof auth !== "number") return auth;
+    const media = mediaOfRoom(roomId).find((item) => item.mediaId === Number(params.mediaId));
+    if (!media) return notFound();
+
+    const data: MediaDetail = {
+      mediaId: media.mediaId,
+      type: media.type,
+      fileName: media.fileName,
+      mimeType: media.mimeType,
+      size: media.size,
+      originalUrl: media.originalUrl,
+      width: media.width,
+      height: media.height,
+      duration: media.duration,
+      folderIds: media.folderIds,
+      uploaderId: media.uploaderId,
+      uploaderName: media.uploaderName,
+      status: media.status,
+      uploadedAt: media.uploadedAt,
+      takenAt: media.mediaId === 5012 ? "2026-08-17T14:02:11+09:00" : null,
+      location:
+        media.mediaId === 5012
+          ? { latitude: 35.1587, longitude: 129.1604, name: "부산 해운대구" }
+          : null,
+      canDelete: canDelete(media, auth),
+    };
+    return HttpResponse.json({ data });
+  }),
+
+  http.delete(`${API_BASE_URL}/rooms/:roomId/media/:mediaId`, ({ request, params }) => {
+    const roomId = Number(params.roomId);
+    const auth = authorize(request, roomId);
+    if (typeof auth !== "number") return auth;
+    const media = mediaOfRoom(roomId).find((item) => item.mediaId === Number(params.mediaId));
+    if (!media) return notFound();
+    if (!canDelete(media, auth)) return forbidden();
+    markMediaDeleted(roomId, media.mediaId);
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete(`${API_BASE_URL}/rooms/:roomId/media`, async ({ request, params }) => {
+    const roomId = Number(params.roomId);
+    const auth = authorize(request, roomId);
+    if (typeof auth !== "number") return auth;
+    const body: unknown = await request.json().catch(() => null);
+    if (
+      !body ||
+      typeof body !== "object" ||
+      !("mediaIds" in body) ||
+      !Array.isArray(body.mediaIds) ||
+      body.mediaIds.length === 0 ||
+      !body.mediaIds.every(
+        (id: unknown) => typeof id === "number" && Number.isSafeInteger(id) && id > 0,
+      )
+    ) {
+      return error(400, "INVALID_MEDIA_IDS", "삭제할 미디어 ID 목록을 확인해 주세요.");
+    }
+    const mediaIds = [...new Set<number>(body.mediaIds)];
+    const deleted: number[] = [];
+    const skipped: { mediaId: number; code: string; message: string }[] = [];
+    const mediaById = new Map(mediaOfRoom(roomId).map((media) => [media.mediaId, media]));
+    for (const mediaId of mediaIds) {
+      const media = mediaById.get(mediaId);
+      if (!media) {
+        skipped.push({ mediaId, code: "MEDIA_NOT_FOUND", message: "미디어를 찾을 수 없습니다." });
+      } else if (!canDelete(media, auth)) {
+        skipped.push({
+          mediaId,
+          code: "MEDIA_FORBIDDEN",
+          message: "다른 사람이 올린 파일이라 삭제할 수 없습니다",
+        });
+      } else {
+        markMediaDeleted(roomId, mediaId);
+        deleted.push(mediaId);
+      }
+    }
+    return HttpResponse.json({ data: { deleted, skipped, deletedCount: deleted.length } });
+  }),
+];

--- a/frontend/src/mocks/handlers/room.ts
+++ b/frontend/src/mocks/handlers/room.ts
@@ -1,7 +1,14 @@
 import { http, HttpResponse } from "msw";
 
 import { API_BASE_URL } from "@/shared/config";
-import { originalUrlOf, registeredMediaOf, thumbnailUrlOf, type GalleryMedia } from "../db";
+import {
+  isDeletedMedia,
+  originalUrlOf,
+  registeredMediaOf,
+  resetDeletedMedia,
+  thumbnailUrlOf,
+  type GalleryMedia,
+} from "../db";
 
 /**
  * 방 코드는 8자리다. 혼동하기 쉬운 0, 1, I, O 는 알파벳에서 빠져 있다.
@@ -127,6 +134,9 @@ export const roomStatusOfId = (roomId: number): RoomStatus | null => {
   if (code === MOCK_ROOM_CODES.purged) {
     return "PURGED";
   }
+  if (code === MOCK_ROOM_CODES.active && activeRoomOverrides.status) {
+    return activeRoomOverrides.status;
+  }
 
   return "ACTIVE";
 };
@@ -161,6 +171,19 @@ interface ActiveRoomOverrides {
 let activeRoomOverrides: ActiveRoomOverrides = {};
 
 const room = (code: string, status: RoomStatus, joined = false) => {
+  const roomId = ROOM_IDS[code];
+  const uploaded = registeredMediaOf(roomId);
+  const seeded = roomId === MOCK_ROOM_ID ? mediaItems : [];
+  const countChange = (folderId?: number) => {
+    const inFolder = (media: MockMedia) =>
+      folderId === undefined || media.folderIds.includes(folderId);
+    return (
+      uploaded.filter(inFolder).length -
+      [...seeded, ...uploaded].filter(
+        (media) => inFolder(media) && isDeletedMedia(roomId, media.mediaId),
+      ).length
+    );
+  };
   const response = {
     roomId: ROOM_IDS[code],
     code,
@@ -176,9 +199,15 @@ const room = (code: string, status: RoomStatus, joined = false) => {
         ? roomExpiresAt[code]
         : new Date(Date.now() - 24 * HOUR_IN_MILLISECONDS).toISOString(),
     /** 폴더 소속과 무관한 방 전체 사진 수. 갓 만든 방은 0 이다. */
-    photoCount: foldersOf(code).reduce((sum, folder) => sum + folder.photoCount, 0),
+    photoCount: Math.max(
+      0,
+      foldersOf(code).reduce((sum, folder) => sum + folder.photoCount, 0) + countChange(),
+    ),
     /** 생성 순 폴더 목록. 갓 만든 방은 빈 배열이다. */
-    folders: foldersOf(code),
+    folders: foldersOf(code).map((folder) => ({
+      ...folder,
+      photoCount: Math.max(0, folder.photoCount + countChange(folder.id)),
+    })),
   };
 
   return code === MOCK_ROOM_CODES.active ? { ...response, ...activeRoomOverrides } : response;
@@ -337,15 +366,17 @@ const joinKey = (token: string, roomId: number) => `${token}:${roomId}`;
  * 다운로드 목도 mediaId 로 원본을 찾을 때 이걸 쓴다.
  */
 export const mediaOfRoom = (roomId: number) =>
-  roomId === MOCK_ROOM_ID
+  (roomId === MOCK_ROOM_ID
     ? [...registeredMediaOf(roomId), ...mediaItems]
-    : registeredMediaOf(roomId);
+    : registeredMediaOf(roomId)
+  ).filter((media) => !isDeletedMedia(roomId, media.mediaId));
 
 /** 테스트끼리 입장 기록이 이어지지 않도록 되돌린다. */
 export const resetJoinedRooms = () => localStorage.removeItem(JOINED_ROOMS_KEY);
 
 export const resetRoomHandlers = () => {
   resetJoinedRooms();
+  resetDeletedMedia();
   activeRoomOverrides = {};
   roomExpiresAt = createRoomExpiresAt();
 };

--- a/frontend/src/shared/api/apiClient.test.ts
+++ b/frontend/src/shared/api/apiClient.test.ts
@@ -6,6 +6,48 @@ import { ApiError } from "./ApiError";
 import { apiClient } from "./apiClient";
 
 describe("apiClient", () => {
+  it.each([{ data: null }, {}, { success: true }])(
+    "삭제 성공 응답에 JSON 본문이 있어도 성공 처리한다: %j",
+    async (body) => {
+      server.use(http.delete(`${API_BASE_URL}/api-test`, () => HttpResponse.json(body)));
+      await expect(
+        apiClient<void>("/api-test", { method: "DELETE", responseType: "empty" }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("삭제의 403 응답은 계속 실패로 처리한다", async () => {
+    server.use(
+      http.delete(`${API_BASE_URL}/api-test`, () =>
+        HttpResponse.json(
+          { code: "MEDIA_FORBIDDEN", message: "삭제 권한이 없어요." },
+          { status: 403 },
+        ),
+      ),
+    );
+    await expect(
+      apiClient<void>("/api-test", { method: "DELETE", responseType: "empty" }),
+    ).rejects.toMatchObject({ status: 403, code: "MEDIA_FORBIDDEN" });
+  });
+
+  it.each([200, 204])("본문 없는 %s 삭제 응답을 처리한다", async (status) => {
+    server.use(http.delete(`${API_BASE_URL}/api-test`, () => new HttpResponse(null, { status })));
+    await expect(
+      apiClient<void>("/api-test", { method: "DELETE", responseType: "empty" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("빈 응답을 기대한 삭제 요청에 HTML이 오면 성공으로 처리하지 않는다", async () => {
+    server.use(
+      http.delete(`${API_BASE_URL}/api-test`, () =>
+        HttpResponse.html("<!doctype html><html></html>"),
+      ),
+    );
+    await expect(
+      apiClient<void>("/api-test", { method: "DELETE", responseType: "empty" }),
+    ).rejects.toMatchObject({ code: "INVALID_RESPONSE" });
+  });
+
   it("성공 응답에서 data 만 꺼내 돌려준다", async () => {
     server.use(
       http.get(`${API_BASE_URL}/api-test`, () => {

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -3,6 +3,7 @@ import { ApiError } from "./ApiError";
 
 interface ApiClientOptions extends RequestInit {
   token?: string;
+  responseType?: "json" | "empty";
 }
 
 interface ErrorResponse {
@@ -26,7 +27,7 @@ const getErrorResponse = async (response: Response): Promise<ErrorResponse> => {
 /** path 는 접두사를 뺀 경로다 — 접두사는 여기서 한 번만 붙인다. */
 export const apiClient = async <T>(
   path: string,
-  { token, headers, ...options }: ApiClientOptions = {},
+  { token, headers, responseType = "json", ...options }: ApiClientOptions = {},
 ): Promise<T> => {
   const requestHeaders = new Headers(headers);
 
@@ -53,6 +54,15 @@ export const apiClient = async <T>(
       error.code ?? "UNKNOWN_ERROR",
       error.message ?? "API 요청에 실패했습니다.",
     );
+  }
+
+  // 삭제는 성공 상태 코드로 판정한다. 서버가 빈 본문 대신 JSON을 보내도 무시한다.
+  if (responseType === "empty") {
+    // 개발 서버의 HTML fallback까지 삭제 성공으로 오인하지는 않는다.
+    if (response.headers.get("content-type")?.includes("text/html")) {
+      throw new ApiError(response.status, "INVALID_RESPONSE", "서버 응답을 이해하지 못했어요.");
+    }
+    return undefined as T;
   }
 
   const body: unknown = await response.json().catch(() => null);


### PR DESCRIPTION
## 작업 내용
- 갤러리의 미디어 조회 및 삭제 기능을 API와 연동했습니다.

## 관련 이슈
Closes #154 

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- 미디어 단건 조회 API 및 React Query 훅 추가
- 단건·다중 미디어 삭제 API 추가
- 미디어 삭제 확인 모달 추가
- 인증이 필요한 미디어 URL 처리 추가
- 빈 삭제 응답 처리 보완
- MSW 핸들러와 관련 테스트 추가

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 타입 검사 통과
- [x] 프로덕션 빌드 통과

## 리뷰 요청 사항 (선택)