### PR TITLE
feat: 갤러리 폴더 관리 기능 구현

### DIFF
--- a/frontend/src/features/create-folder/api/createFolder.test.ts
+++ b/frontend/src/features/create-folder/api/createFolder.test.ts
@@ -1,0 +1,21 @@
+import { MOCK_ROOM_ID } from "@/mocks/handlers/room";
+import { createFolder } from "./createFolder";
+
+describe("createFolder", () => {
+  it("이름을 보내 새 폴더를 만든다", async () => {
+    const folder = await createFolder({
+      roomId: MOCK_ROOM_ID,
+      accessToken: "mock-token",
+      name: "셋째 날",
+    });
+
+    expect(folder).toMatchObject({ name: "셋째 날", photoCount: 0 });
+    expect(folder.id).toEqual(expect.any(Number));
+  });
+
+  it("토큰이 없으면 생성하지 못한다", async () => {
+    await expect(
+      createFolder({ roomId: MOCK_ROOM_ID, accessToken: "", name: "셋째 날" }),
+    ).rejects.toMatchObject({ status: 401, code: "UNAUTHORIZED" });
+  });
+});

--- a/frontend/src/features/create-folder/api/createFolder.ts
+++ b/frontend/src/features/create-folder/api/createFolder.ts
@@ -1,0 +1,16 @@
+import type { RoomFolder } from "@/entities/room";
+import { apiClient } from "@/shared/api";
+
+interface CreateFolderParams {
+  roomId: number;
+  accessToken: string;
+  name: string;
+}
+
+export const createFolder = ({ roomId, accessToken, name }: CreateFolderParams) =>
+  apiClient<RoomFolder>(`/rooms/${roomId}/folders`, {
+    method: "POST",
+    token: accessToken,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });

--- a/frontend/src/features/create-folder/index.ts
+++ b/frontend/src/features/create-folder/index.ts
@@ -1,0 +1,2 @@
+export { createFolder } from "./api/createFolder";
+export { CreateFolderBottomSheet } from "./ui/CreateFolderBottomSheet";

--- a/frontend/src/features/create-folder/ui/CreateFolderBottomSheet.tsx
+++ b/frontend/src/features/create-folder/ui/CreateFolderBottomSheet.tsx
@@ -1,0 +1,70 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import type { RoomFolder } from "@/entities/room";
+import { isApiError } from "@/shared/api";
+import { BottomSheet } from "@/shared/ui/bottom-sheet";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Stack } from "@/shared/ui/stack";
+import { createFolder } from "../api/createFolder";
+
+interface CreateFolderBottomSheetProps {
+  roomId: number;
+  accessToken: string;
+  onClose: () => void;
+  onSuccess: (folder: RoomFolder) => void | Promise<void>;
+}
+
+const MAX_FOLDER_NAME_LENGTH = 12;
+
+export const CreateFolderBottomSheet = ({
+  roomId,
+  accessToken,
+  onClose,
+  onSuccess,
+}: CreateFolderBottomSheetProps) => {
+  const [name, setName] = useState("");
+  const mutation = useMutation({
+    mutationFn: (folderName: string) => createFolder({ roomId, accessToken, name: folderName }),
+    onSuccess,
+  });
+
+  const trimmedName = name.trim();
+  const errorMessage = mutation.isError
+    ? isApiError(mutation.error)
+      ? mutation.error.message
+      : "폴더를 만들지 못했어요."
+    : "";
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!trimmedName || mutation.isPending) return;
+    mutation.mutate(trimmedName);
+  };
+
+  return (
+    <BottomSheet title="새 폴더 만들기" onClose={onClose}>
+      <form onSubmit={submit}>
+        <Stack gap={16}>
+          <Input
+            autoFocus
+            label="폴더 이름"
+            placeholder="폴더 이름을 입력하세요"
+            value={name}
+            maxLength={MAX_FOLDER_NAME_LENGTH}
+            errorMessage={errorMessage}
+            disabled={mutation.isPending}
+            onValueChange={(value) => {
+              setName(value);
+              if (mutation.isError) mutation.reset();
+            }}
+          />
+          <Button type="submit" disabled={!trimmedName || mutation.isPending}>
+            {mutation.isPending ? "만드는 중..." : "만들기"}
+          </Button>
+        </Stack>
+      </form>
+    </BottomSheet>
+  );
+};

--- a/frontend/src/features/delete-folder/api/deleteFolder.test.ts
+++ b/frontend/src/features/delete-folder/api/deleteFolder.test.ts
@@ -1,0 +1,14 @@
+import { MOCK_FOLDER_IDS, MOCK_ROOM_ID } from "@/mocks/handlers/room";
+import { deleteFolder } from "./deleteFolder";
+
+describe("deleteFolder", () => {
+  it("선택한 폴더만 삭제하고 분리된 사진 수를 반환한다", async () => {
+    const result = await deleteFolder({
+      roomId: MOCK_ROOM_ID,
+      folderId: MOCK_FOLDER_IDS[0],
+      accessToken: "mock-token",
+    });
+
+    expect(result).toEqual({ deletedFolderId: MOCK_FOLDER_IDS[0], detachedPhotoCount: 12 });
+  });
+});

--- a/frontend/src/features/delete-folder/api/deleteFolder.ts
+++ b/frontend/src/features/delete-folder/api/deleteFolder.ts
@@ -1,0 +1,18 @@
+import { apiClient } from "@/shared/api";
+
+interface DeleteFolderParams {
+  roomId: number;
+  folderId: number;
+  accessToken: string;
+}
+
+export interface DeleteFolderResponse {
+  deletedFolderId: number;
+  detachedPhotoCount: number;
+}
+
+export const deleteFolder = ({ roomId, folderId, accessToken }: DeleteFolderParams) =>
+  apiClient<DeleteFolderResponse>(`/rooms/${roomId}/folders/${folderId}`, {
+    method: "DELETE",
+    token: accessToken,
+  });

--- a/frontend/src/features/delete-folder/index.ts
+++ b/frontend/src/features/delete-folder/index.ts
@@ -1,0 +1,3 @@
+export { deleteFolder } from "./api/deleteFolder";
+export type { DeleteFolderResponse } from "./api/deleteFolder";
+export { DeleteFolderModal } from "./ui/DeleteFolderModal";

--- a/frontend/src/features/delete-folder/model/useDeleteFolderMutation.ts
+++ b/frontend/src/features/delete-folder/model/useDeleteFolderMutation.ts
@@ -1,0 +1,21 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { deleteFolder } from "../api/deleteFolder";
+
+interface UseDeleteFolderMutationParams {
+  roomId: number;
+  folderId: number;
+  accessToken: string;
+  onSuccess: () => void | Promise<void>;
+}
+
+export const useDeleteFolderMutation = ({
+  roomId,
+  folderId,
+  accessToken,
+  onSuccess,
+}: UseDeleteFolderMutationParams) =>
+  useMutation({
+    mutationFn: () => deleteFolder({ roomId, folderId, accessToken }),
+    onSuccess,
+  });

--- a/frontend/src/features/delete-folder/ui/DeleteFolderModal.tsx
+++ b/frontend/src/features/delete-folder/ui/DeleteFolderModal.tsx
@@ -1,0 +1,83 @@
+import styled from "@emotion/styled";
+
+import deleteRoomImage from "@/features/delete-room/assets/delete-room.png";
+import { colors, typography } from "@/shared/styles/tokens";
+import { Button } from "@/shared/ui/button";
+import { Modal } from "@/shared/ui/modal";
+import { Row } from "@/shared/ui/row";
+import { Stack } from "@/shared/ui/stack";
+import { useDeleteFolderMutation } from "../model/useDeleteFolderMutation";
+
+interface DeleteFolderModalProps {
+  roomId: number;
+  folderId: number;
+  folderName: string;
+  accessToken: string;
+  onClose: () => void;
+  onSuccess: () => void | Promise<void>;
+}
+
+export const DeleteFolderModal = ({
+  roomId,
+  folderId,
+  folderName,
+  accessToken,
+  onClose,
+  onSuccess,
+}: DeleteFolderModalProps) => {
+  const mutation = useDeleteFolderMutation({ roomId, folderId, accessToken, onSuccess });
+
+  return (
+    <Modal onClose={onClose}>
+      <Stack gap={20}>
+        <DeleteFolderImage src={deleteRoomImage} alt="폴더 삭제 경고" />
+
+        <Stack gap={8}>
+          <Title>‘{folderName}’ 폴더를 삭제할까요?</Title>
+          <Description>
+            폴더만 삭제되고
+            <br />
+            사진은 그대로 유지돼요.
+          </Description>
+          {mutation.isError && <ErrorMessage>폴더를 삭제하지 못했어요.</ErrorMessage>}
+        </Stack>
+
+        <Row gap={12}>
+          <Button variant="default" onClick={onClose}>
+            취소
+          </Button>
+          <Button variant="danger" disabled={mutation.isPending} onClick={() => mutation.mutate()}>
+            삭제
+          </Button>
+        </Row>
+      </Stack>
+    </Modal>
+  );
+};
+
+const DeleteFolderImage = styled.img`
+  align-self: center;
+  width: 105px;
+  height: auto;
+`;
+
+const Title = styled.h2`
+  color: ${colors.textStrong};
+  text-align: center;
+
+  ${typography.heading3}
+`;
+
+const Description = styled.p`
+  color: ${colors.textSecondary};
+  text-align: center;
+
+  ${typography.body}
+`;
+
+const ErrorMessage = styled.p`
+  color: ${colors.danger};
+  text-align: center;
+
+  ${typography.caption1}
+`;

--- a/frontend/src/features/edit-folder/api/editFolder.test.ts
+++ b/frontend/src/features/edit-folder/api/editFolder.test.ts
@@ -1,0 +1,15 @@
+import { MOCK_FOLDER_IDS, MOCK_ROOM_ID } from "@/mocks/handlers/room";
+import { editFolder } from "./editFolder";
+
+describe("editFolder", () => {
+  it("선택한 폴더 이름을 수정한다", async () => {
+    const folder = await editFolder({
+      roomId: MOCK_ROOM_ID,
+      folderId: MOCK_FOLDER_IDS[0],
+      accessToken: "mock-token",
+      name: "여름",
+    });
+
+    expect(folder).toMatchObject({ id: MOCK_FOLDER_IDS[0], name: "여름", photoCount: 12 });
+  });
+});

--- a/frontend/src/features/edit-folder/api/editFolder.ts
+++ b/frontend/src/features/edit-folder/api/editFolder.ts
@@ -1,0 +1,17 @@
+import type { RoomFolder } from "@/entities/room";
+import { apiClient } from "@/shared/api";
+
+interface EditFolderParams {
+  roomId: number;
+  folderId: number;
+  accessToken: string;
+  name: string;
+}
+
+export const editFolder = ({ roomId, folderId, accessToken, name }: EditFolderParams) =>
+  apiClient<RoomFolder>(`/rooms/${roomId}/folders/${folderId}`, {
+    method: "PATCH",
+    token: accessToken,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });

--- a/frontend/src/features/edit-folder/index.ts
+++ b/frontend/src/features/edit-folder/index.ts
@@ -1,0 +1,2 @@
+export { editFolder } from "./api/editFolder";
+export { EditFolderBottomSheet } from "./ui/EditFolderBottomSheet";

--- a/frontend/src/features/edit-folder/ui/EditFolderBottomSheet.tsx
+++ b/frontend/src/features/edit-folder/ui/EditFolderBottomSheet.tsx
@@ -1,0 +1,73 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import type { RoomFolder } from "@/entities/room";
+import { isApiError } from "@/shared/api";
+import { BottomSheet } from "@/shared/ui/bottom-sheet";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Stack } from "@/shared/ui/stack";
+import { editFolder } from "../api/editFolder";
+
+interface EditFolderBottomSheetProps {
+  roomId: number;
+  folder: RoomFolder;
+  accessToken: string;
+  onClose: () => void;
+  onSuccess: (folder: RoomFolder) => void | Promise<void>;
+}
+
+const MAX_FOLDER_NAME_LENGTH = 12;
+
+export const EditFolderBottomSheet = ({
+  roomId,
+  folder,
+  accessToken,
+  onClose,
+  onSuccess,
+}: EditFolderBottomSheetProps) => {
+  const [name, setName] = useState(folder.name);
+  const mutation = useMutation({
+    mutationFn: (folderName: string) =>
+      editFolder({ roomId, folderId: folder.id, accessToken, name: folderName }),
+    onSuccess,
+  });
+
+  const trimmedName = name.trim();
+  const errorMessage = mutation.isError
+    ? isApiError(mutation.error)
+      ? mutation.error.message
+      : "폴더 이름을 수정하지 못했어요."
+    : "";
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!trimmedName || mutation.isPending) return;
+    mutation.mutate(trimmedName);
+  };
+
+  return (
+    <BottomSheet title="폴더 이름 수정" onClose={onClose}>
+      <form onSubmit={submit}>
+        <Stack gap={16}>
+          <Input
+            autoFocus
+            label="새 폴더 이름"
+            placeholder="폴더 이름을 입력하세요"
+            value={name}
+            maxLength={MAX_FOLDER_NAME_LENGTH}
+            errorMessage={errorMessage}
+            disabled={mutation.isPending}
+            onValueChange={(value) => {
+              setName(value);
+              if (mutation.isError) mutation.reset();
+            }}
+          />
+          <Button type="submit" disabled={!trimmedName || mutation.isPending}>
+            {mutation.isPending ? "수정 중..." : "수정하기"}
+          </Button>
+        </Stack>
+      </form>
+    </BottomSheet>
+  );
+};

--- a/frontend/src/mocks/handlers/room.ts
+++ b/frontend/src/mocks/handlers/room.ts
@@ -70,12 +70,18 @@ let roomExpiresAt = createRoomExpiresAt();
  * 방마다 가진 폴더. backend `RoomFolderResponse` 와 같은 모양이다.
  * 업로드 목이 발급 요청의 folderIds 를 이 목록과 대조한다.
  */
-const ROOM_FOLDERS: Record<string, { id: number; name: string; photoCount: number }[]> = {
-  [MOCK_ROOM_CODES.active]: [
-    { id: 31, name: "첫째 날", photoCount: 12 },
-    { id: 32, name: "둘째 날", photoCount: 4 },
-  ],
+const INITIAL_ROOM_FOLDERS = [
+  { id: 31, name: "첫째 날", createdAt: "2026-08-18T06:10:00Z", photoCount: 12 },
+  { id: 32, name: "둘째 날", createdAt: "2026-08-18T06:20:00Z", photoCount: 4 },
+];
+
+const ROOM_FOLDERS: Record<
+  string,
+  { id: number; name: string; createdAt: string; photoCount: number }[]
+> = {
+  [MOCK_ROOM_CODES.active]: [...INITIAL_ROOM_FOLDERS],
 };
+const DETACHED_PHOTO_COUNTS: Record<string, number> = {};
 
 const foldersOf = (code: string) => ROOM_FOLDERS[code] ?? [];
 
@@ -201,7 +207,9 @@ const room = (code: string, status: RoomStatus, joined = false) => {
     /** 폴더 소속과 무관한 방 전체 사진 수. 갓 만든 방은 0 이다. */
     photoCount: Math.max(
       0,
-      foldersOf(code).reduce((sum, folder) => sum + folder.photoCount, 0) + countChange(),
+      foldersOf(code).reduce((sum, folder) => sum + folder.photoCount, 0) +
+        (DETACHED_PHOTO_COUNTS[code] ?? 0) +
+        countChange(),
     ),
     /** 생성 순 폴더 목록. 갓 만든 방은 빈 배열이다. */
     folders: foldersOf(code).map((folder) => ({
@@ -379,6 +387,8 @@ export const resetRoomHandlers = () => {
   resetDeletedMedia();
   activeRoomOverrides = {};
   roomExpiresAt = createRoomExpiresAt();
+  ROOM_FOLDERS[MOCK_ROOM_CODES.active] = INITIAL_ROOM_FOLDERS.map((folder) => ({ ...folder }));
+  DETACHED_PHOTO_COUNTS[MOCK_ROOM_CODES.active] = 0;
 };
 
 const unauthorized = () =>
@@ -477,6 +487,99 @@ export const roomHandlers = [
       },
       { status: alreadyJoined ? 200 : 201 },
     );
+  }),
+
+  http.post(`${API_BASE_URL}/rooms/:roomId/folders`, async ({ request, params }) => {
+    if (request.headers.get("Authorization") === null) {
+      return unauthorized();
+    }
+
+    const roomId = Number(params.roomId);
+    const code = codeOfRoomId(roomId);
+    if (code === null || !isActiveRoomCode(code)) {
+      return roomNotFound();
+    }
+
+    const { name } = (await request.json().catch(() => ({}))) as { name?: string };
+    const trimmedName = name?.trim() ?? "";
+    if (!trimmedName || trimmedName.length > 12) {
+      return HttpResponse.json(
+        { code: "INVALID_FOLDER_NAME", message: "폴더 이름은 1자 이상 12자 이하여야 합니다." },
+        { status: 400 },
+      );
+    }
+
+    const folders = ROOM_FOLDERS[code] ?? (ROOM_FOLDERS[code] = []);
+    const folder = {
+      id: Math.max(500, ...folders.map(({ id }) => id)) + 1,
+      name: trimmedName,
+      createdAt: new Date().toISOString(),
+      photoCount: 0,
+    };
+    folders.push(folder);
+
+    return HttpResponse.json({ data: folder }, { status: 201 });
+  }),
+
+  http.patch(`${API_BASE_URL}/rooms/:roomId/folders/:folderId`, async ({ request, params }) => {
+    if (request.headers.get("Authorization") === null) {
+      return unauthorized();
+    }
+
+    const code = codeOfRoomId(Number(params.roomId));
+    if (code === null || !isActiveRoomCode(code)) {
+      return roomNotFound();
+    }
+
+    const folder = foldersOf(code).find(({ id }) => id === Number(params.folderId));
+    if (!folder) {
+      return HttpResponse.json(
+        { code: "FOLDER_NOT_FOUND", message: "존재하지 않는 폴더입니다." },
+        { status: 404 },
+      );
+    }
+
+    const { name } = (await request.json().catch(() => ({}))) as { name?: string };
+    const trimmedName = name?.trim() ?? "";
+    if (!trimmedName || trimmedName.length > 12) {
+      return HttpResponse.json(
+        { code: "INVALID_FOLDER_NAME", message: "폴더 이름은 1자 이상 12자 이하여야 합니다." },
+        { status: 400 },
+      );
+    }
+
+    folder.name = trimmedName;
+    return HttpResponse.json({ data: folder });
+  }),
+
+  http.delete(`${API_BASE_URL}/rooms/:roomId/folders/:folderId`, ({ request, params }) => {
+    if (request.headers.get("Authorization") === null) {
+      return unauthorized();
+    }
+
+    const code = codeOfRoomId(Number(params.roomId));
+    if (code === null || !isActiveRoomCode(code)) {
+      return roomNotFound();
+    }
+
+    const folders = foldersOf(code);
+    const folderIndex = folders.findIndex(({ id }) => id === Number(params.folderId));
+    if (folderIndex < 0) {
+      return HttpResponse.json(
+        { code: "FOLDER_NOT_FOUND", message: "존재하지 않는 폴더입니다." },
+        { status: 404 },
+      );
+    }
+
+    const [deletedFolder] = folders.splice(folderIndex, 1);
+    DETACHED_PHOTO_COUNTS[code] = (DETACHED_PHOTO_COUNTS[code] ?? 0) + deletedFolder.photoCount;
+
+    return HttpResponse.json({
+      data: {
+        deletedFolderId: deletedFolder.id,
+        detachedPhotoCount: deletedFolder.photoCount,
+      },
+    });
   }),
 
   http.post(`${API_BASE_URL}/rooms`, async ({ request }) => {

--- a/frontend/src/pages/gallery/ui/GalleryContent.tsx
+++ b/frontend/src/pages/gallery/ui/GalleryContent.tsx
@@ -3,12 +3,16 @@ import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { photosQueryKey } from "@/entities/media";
-import type { Room } from "@/entities/room";
+import { roomQueryKey, type Room } from "@/entities/room";
 import { removeRoomSession } from "@/entities/session";
 import { DeleteRoomModal } from "@/features/delete-room";
+import { CreateFolderBottomSheet } from "@/features/create-folder";
+import { DeleteFolderModal } from "@/features/delete-folder";
+import { EditFolderBottomSheet } from "@/features/edit-folder";
 import { SelectionDownloadBar } from "@/features/download-media";
 import { MediaUploader } from "@/features/upload-media";
 import { ROUTES } from "@/shared/config";
+import { Toast } from "@/shared/ui/toast";
 import { FolderFilter } from "@/widgets/folder-filter";
 import { GalleryOptions } from "@/widgets/gallery-options";
 import { PhotoGallery } from "@/widgets/photo-gallery";
@@ -30,9 +34,14 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
 
   // 모달
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
+  const [isEditFolderOpen, setIsEditFolderOpen] = useState(false);
+  const [isDeleteFolderOpen, setIsDeleteFolderOpen] = useState(false);
+  const [deletedFolderName, setDeletedFolderName] = useState<string | null>(null);
 
   // 옵션 선택
   const { selectedFolderId, selectedOption, selectFolder, selectOption } = useGalleryFilter();
+  const selectedFolder = room.folders.find((folder) => folder.id === selectedFolderId) ?? null;
 
   // 사진 조회
   const { photos, isPending, isError } = useGalleryPhotos({
@@ -66,8 +75,13 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
         hostId={room.hostId}
         expiresAt={room.expiresAt}
         roomName={room.name}
+        isHost={userId === room.hostId}
+        hasSelectedFolder={selectedFolderId !== null}
         onOpenSettings={() => navigate(ROUTES.roomSettings(room.code))}
         onDeleteRoom={() => setIsDeleteModalOpen(true)}
+        onAddFolder={() => setIsCreateFolderOpen(true)}
+        onEditFolder={() => setIsEditFolderOpen(true)}
+        onDeleteFolder={() => setIsDeleteFolderOpen(true)}
       />
       <FolderFilter
         totalCount={room.photoCount}
@@ -77,6 +91,7 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
           selectFolder(folderId);
           clearSelection();
         }}
+        onAddFolder={() => setIsCreateFolderOpen(true)}
       />
       <GalleryOptions
         selectedOption={selectedOption}
@@ -126,6 +141,73 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
             queryClient.removeQueries({ queryKey: ["photos", room.roomId] });
             navigate(ROUTES.home, { replace: true });
           }}
+        />
+      )}
+
+      {isCreateFolderOpen && (
+        <CreateFolderBottomSheet
+          roomId={room.roomId}
+          accessToken={accessToken}
+          onClose={() => setIsCreateFolderOpen(false)}
+          onSuccess={async (folder) => {
+            setIsCreateFolderOpen(false);
+            selectFolder(folder.id);
+            clearSelection();
+            await queryClient.invalidateQueries({
+              queryKey: roomQueryKey(room.code, userId),
+              exact: true,
+            });
+          }}
+        />
+      )}
+
+      {isEditFolderOpen && selectedFolder && (
+        <EditFolderBottomSheet
+          roomId={room.roomId}
+          folder={selectedFolder}
+          accessToken={accessToken}
+          onClose={() => setIsEditFolderOpen(false)}
+          onSuccess={async () => {
+            setIsEditFolderOpen(false);
+            await queryClient.invalidateQueries({
+              queryKey: roomQueryKey(room.code, userId),
+              exact: true,
+            });
+          }}
+        />
+      )}
+
+      {isDeleteFolderOpen && selectedFolder && (
+        <DeleteFolderModal
+          roomId={room.roomId}
+          folderId={selectedFolder.id}
+          folderName={selectedFolder.name}
+          accessToken={accessToken}
+          onClose={() => setIsDeleteFolderOpen(false)}
+          onSuccess={async () => {
+            const folderName = selectedFolder.name;
+            setIsDeleteFolderOpen(false);
+            selectFolder(null);
+            clearSelection();
+            await Promise.all([
+              queryClient.invalidateQueries({
+                queryKey: roomQueryKey(room.code, userId),
+                exact: true,
+              }),
+              queryClient.invalidateQueries({
+                queryKey: photosQueryKey(room.roomId, userId),
+                exact: true,
+              }),
+            ]);
+            setDeletedFolderName(folderName);
+          }}
+        />
+      )}
+
+      {deletedFolderName && (
+        <Toast
+          message={`‘${deletedFolderName}’ 폴더를 삭제했어요.`}
+          onClose={() => setDeletedFolderName(null)}
         />
       )}
     </Page>

--- a/frontend/src/shared/ui/dropdown-menu/DropdownMenu.tsx
+++ b/frontend/src/shared/ui/dropdown-menu/DropdownMenu.tsx
@@ -36,6 +36,13 @@ export const DropdownMenuItem = ({
   );
 };
 
+export const DropdownMenuDivider = styled.hr`
+  width: 100%;
+  margin: ${spacing[8]} 0;
+  border: 0;
+  border-top: 1px solid ${colors.borderDefault};
+`;
+
 const Overlay = styled.div`
   position: fixed;
   inset: 0;
@@ -81,5 +88,11 @@ const Item = styled.button<{ $tone: "default" | "danger" }>`
         ? `color-mix(in srgb, ${colors.danger} 10%, white)`
         : colors.primarySubtle};
     color: ${({ $tone }) => ($tone === "danger" ? colors.danger : colors.primary)};
+  }
+
+  &:disabled {
+    background: transparent;
+    color: ${colors.disabled};
+    cursor: not-allowed;
   }
 `;

--- a/frontend/src/shared/ui/dropdown-menu/index.ts
+++ b/frontend/src/shared/ui/dropdown-menu/index.ts
@@ -1,2 +1,2 @@
-export { DropdownMenu, DropdownMenuItem } from "./DropdownMenu";
+export { DropdownMenu, DropdownMenuDivider, DropdownMenuItem } from "./DropdownMenu";
 export type { DropdownMenuProps } from "./DropdownMenu";

--- a/frontend/src/widgets/folder-filter/ui/FolderFilter.styles.ts
+++ b/frontend/src/widgets/folder-filter/ui/FolderFilter.styles.ts
@@ -2,6 +2,32 @@ import styled from "@emotion/styled";
 
 import { colors, radius, spacing, typography } from "@/shared/styles/tokens";
 
+export const FolderScrollArea = styled.div`
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+
+  &::before,
+  &::after {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+    width: ${spacing[16]};
+    background: ${colors.backgroundDefault};
+    content: "";
+    pointer-events: none;
+  }
+
+  &::before {
+    left: 0;
+  }
+
+  &::after {
+    right: 0;
+  }
+`;
+
 export const FolderList = styled.div`
   display: flex;
   flex: none;
@@ -25,11 +51,16 @@ export const FolderList = styled.div`
   }
 `;
 
+export const AddFolderButtonItem = styled.div`
+  display: flex;
+  flex: none;
+`;
+
 export const FolderButton = styled.button<{ $active: boolean }>`
   display: inline-flex;
   flex: none;
   align-items: center;
-  gap: ${spacing[8]};
+  gap: ${spacing[4]};
   padding: ${spacing[4]};
   color: ${({ $active }) => ($active ? colors.textStrong : colors.textSecondary)};
   white-space: nowrap;

--- a/frontend/src/widgets/folder-filter/ui/FolderFilter.test.tsx
+++ b/frontend/src/widgets/folder-filter/ui/FolderFilter.test.tsx
@@ -29,4 +29,22 @@ describe("FolderFilter", () => {
 
     expect(onSelectFolder).toHaveBeenCalledWith(501);
   });
+
+  it("추가 버튼을 누르면 폴더 생성 동작을 호출한다", async () => {
+    const user = userEvent.setup();
+    const onAddFolder = jest.fn();
+
+    render(
+      <FolderFilter
+        totalCount={13}
+        folders={folders}
+        selectedFolderId={null}
+        onSelectFolder={jest.fn()}
+        onAddFolder={onAddFolder}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "폴더 추가" }));
+    expect(onAddFolder).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/widgets/folder-filter/ui/FolderFilter.tsx
+++ b/frontend/src/widgets/folder-filter/ui/FolderFilter.tsx
@@ -1,14 +1,22 @@
+import { useEffect, useRef } from "react";
 import { HiPlus } from "react-icons/hi2";
 
 import type { RoomFolder } from "@/entities/room";
 import { IconButton } from "@/shared/ui/icon-button";
-import { Count, FolderButton, FolderList } from "./FolderFilter.styles";
+import {
+  AddFolderButtonItem,
+  Count,
+  FolderButton,
+  FolderList,
+  FolderScrollArea,
+} from "./FolderFilter.styles";
 
 interface FolderFilterProps {
   totalCount: number;
   folders: RoomFolder[];
   selectedFolderId: number | null;
   onSelectFolder: (folderId: number | null) => void;
+  onAddFolder?: () => void;
 }
 
 export const FolderFilter = ({
@@ -16,35 +24,57 @@ export const FolderFilter = ({
   folders,
   selectedFolderId,
   onSelectFolder,
+  onAddFolder,
 }: FolderFilterProps) => {
+  const folderListRef = useRef<HTMLDivElement>(null);
+  const previousFolderCountRef = useRef(folders.length);
+
+  useEffect(() => {
+    const folderList = folderListRef.current;
+    const hasNewFolder = folders.length > previousFolderCountRef.current;
+
+    previousFolderCountRef.current = folders.length;
+
+    if (!folderList || !hasNewFolder) return;
+
+    const frameId = requestAnimationFrame(() => {
+      folderList.scrollTo({ left: folderList.scrollWidth, behavior: "smooth" });
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [folders.length]);
+
   return (
-    <FolderList>
-      <FolderButton
-        type="button"
-        $active={selectedFolderId === null}
-        onClick={() => onSelectFolder(null)}
-      >
-        전체 <Count $active={selectedFolderId === null}>{totalCount}</Count>
-      </FolderButton>
+    <FolderScrollArea>
+      <FolderList ref={folderListRef}>
+        <FolderButton
+          type="button"
+          $active={selectedFolderId === null}
+          onClick={() => onSelectFolder(null)}
+        >
+          전체 <Count $active={selectedFolderId === null}>{totalCount}</Count>
+        </FolderButton>
 
-      {folders.map((folder) => {
-        const isSelected = selectedFolderId === folder.id;
+        {folders.map((folder) => {
+          const isSelected = selectedFolderId === folder.id;
 
-        return (
-          <FolderButton
-            key={folder.id}
-            type="button"
-            $active={isSelected}
-            onClick={() => onSelectFolder(folder.id)}
-          >
-            {folder.name} <Count $active={isSelected}>{folder.photoCount}</Count>
-          </FolderButton>
-        );
-      })}
-
-      <IconButton type="button" size="sm" aria-label="폴더 추가">
-        <HiPlus />
-      </IconButton>
-    </FolderList>
+          return (
+            <FolderButton
+              key={folder.id}
+              type="button"
+              $active={isSelected}
+              onClick={() => onSelectFolder(folder.id)}
+            >
+              {folder.name} <Count $active={isSelected}>{folder.photoCount}</Count>
+            </FolderButton>
+          );
+        })}
+        <AddFolderButtonItem>
+          <IconButton type="button" size="sm" aria-label="폴더 추가" onClick={onAddFolder}>
+            <HiPlus />
+          </IconButton>
+        </AddFolderButtonItem>
+      </FolderList>
+    </FolderScrollArea>
   );
 };

--- a/frontend/src/widgets/room-summary/ui/RoomMenuButton.test.tsx
+++ b/frontend/src/widgets/room-summary/ui/RoomMenuButton.test.tsx
@@ -8,7 +8,7 @@ describe("RoomMenuButton", () => {
     const user = userEvent.setup();
     const onOpenSettings = jest.fn();
 
-    render(<RoomMenuButton onOpenSettings={onOpenSettings} />);
+    render(<RoomMenuButton isHost onOpenSettings={onOpenSettings} />);
 
     await user.click(screen.getByRole("button", { name: "방 메뉴 열기" }));
 
@@ -19,6 +19,19 @@ describe("RoomMenuButton", () => {
 
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("button", { name: "방 설정" })).not.toBeInTheDocument();
+  });
+
+  it("일반 참여자에게는 폴더 메뉴만 보여준다", async () => {
+    const user = userEvent.setup();
+    render(<RoomMenuButton />);
+
+    await user.click(screen.getByRole("button", { name: "방 메뉴 열기" }));
+
+    expect(screen.queryByRole("button", { name: "방 설정" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "방 삭제" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "폴더 추가" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "폴더 설정" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "폴더 삭제" })).toBeDisabled();
   });
 
   it("메뉴 바깥을 누르면 닫는다", async () => {

--- a/frontend/src/widgets/room-summary/ui/RoomMenuButton.tsx
+++ b/frontend/src/widgets/room-summary/ui/RoomMenuButton.tsx
@@ -1,16 +1,36 @@
 import { useState } from "react";
-import { HiAdjustmentsHorizontal, HiEllipsisHorizontal, HiTrash } from "react-icons/hi2";
+import {
+  HiAdjustmentsHorizontal,
+  HiEllipsisHorizontal,
+  HiFolderMinus,
+  HiFolderPlus,
+  HiPencilSquare,
+  HiTrash,
+} from "react-icons/hi2";
 import styled from "@emotion/styled";
 
-import { DropdownMenu, DropdownMenuItem } from "@/shared/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuDivider, DropdownMenuItem } from "@/shared/ui/dropdown-menu";
 import { IconButton } from "@/shared/ui/icon-button";
 
 interface RoomMenuButtonProps {
+  isHost?: boolean;
+  hasSelectedFolder?: boolean;
   onOpenSettings?: () => void;
   onDeleteRoom?: () => void;
+  onAddFolder?: () => void;
+  onEditFolder?: () => void;
+  onDeleteFolder?: () => void;
 }
 
-export const RoomMenuButton = ({ onOpenSettings, onDeleteRoom }: RoomMenuButtonProps) => {
+export const RoomMenuButton = ({
+  isHost = false,
+  hasSelectedFolder = false,
+  onOpenSettings,
+  onDeleteRoom,
+  onAddFolder,
+  onEditFolder,
+  onDeleteFolder,
+}: RoomMenuButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const selectMenu = (action?: () => void) => {
@@ -26,18 +46,40 @@ export const RoomMenuButton = ({ onOpenSettings, onDeleteRoom }: RoomMenuButtonP
 
       {isOpen && (
         <DropdownMenu onClose={() => setIsOpen(false)}>
-          <DropdownMenuItem
-            icon={<HiAdjustmentsHorizontal />}
-            onClick={() => selectMenu(onOpenSettings)}
-          >
-            방 설정
+          {isHost && (
+            <>
+              <DropdownMenuItem
+                icon={<HiAdjustmentsHorizontal />}
+                onClick={() => selectMenu(onOpenSettings)}
+              >
+                방 설정
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                icon={<HiTrash />}
+                tone="danger"
+                onClick={() => selectMenu(onDeleteRoom)}
+              >
+                방 삭제
+              </DropdownMenuItem>
+              <DropdownMenuDivider />
+            </>
+          )}
+          <DropdownMenuItem icon={<HiFolderPlus />} onClick={() => selectMenu(onAddFolder)}>
+            폴더 추가
           </DropdownMenuItem>
           <DropdownMenuItem
-            icon={<HiTrash />}
-            tone="danger"
-            onClick={() => selectMenu(onDeleteRoom)}
+            icon={<HiPencilSquare />}
+            disabled={!hasSelectedFolder || !onEditFolder}
+            onClick={() => selectMenu(onEditFolder)}
           >
-            방 삭제
+            폴더 설정
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            icon={<HiFolderMinus />}
+            disabled={!hasSelectedFolder || !onDeleteFolder}
+            onClick={() => selectMenu(onDeleteFolder)}
+          >
+            폴더 삭제
           </DropdownMenuItem>
         </DropdownMenu>
       )}

--- a/frontend/src/widgets/room-summary/ui/RoomSummary.tsx
+++ b/frontend/src/widgets/room-summary/ui/RoomSummary.tsx
@@ -11,8 +11,13 @@ interface RoomSummaryProps {
   hostId: number;
   expiresAt: string;
   roomName: string;
+  isHost?: boolean;
+  hasSelectedFolder?: boolean;
   onOpenSettings?: () => void;
   onDeleteRoom?: () => void;
+  onAddFolder?: () => void;
+  onEditFolder?: () => void;
+  onDeleteFolder?: () => void;
 }
 
 export const RoomSummary = ({
@@ -20,8 +25,13 @@ export const RoomSummary = ({
   hostId,
   expiresAt,
   roomName,
+  isHost = false,
+  hasSelectedFolder = false,
   onOpenSettings,
   onDeleteRoom,
+  onAddFolder,
+  onEditFolder,
+  onDeleteFolder,
 }: RoomSummaryProps) => {
   return (
     <Header>
@@ -35,7 +45,15 @@ export const RoomSummary = ({
           <RoomTitle>{roomName}</RoomTitle>
           <Row align="center" gap={4}>
             <RoomShareButton roomCode={roomCode} />
-            <RoomMenuButton onOpenSettings={onOpenSettings} onDeleteRoom={onDeleteRoom} />
+            <RoomMenuButton
+              isHost={isHost}
+              hasSelectedFolder={hasSelectedFolder}
+              onOpenSettings={onOpenSettings}
+              onDeleteRoom={onDeleteRoom}
+              onAddFolder={onAddFolder}
+              onEditFolder={onEditFolder}
+              onDeleteFolder={onDeleteFolder}
+            />
           </Row>
         </Row>
       </Stack>


### PR DESCRIPTION
## 작업 내용
- 갤러리에서 폴더를 생성·수정·삭제할 수 있도록 구현했습니다.
- 폴더 필터와 관리 메뉴를 연결했습니다.
- 폴더 생성 후 해당 폴더로 이동하도록 처리했습니다.

## 관련 이슈
Closes #159

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] 폴더 생성·수정·삭제 API 연동
- [x] 폴더 관리 바텀시트 및 삭제 모달 구현
- [x] 폴더 필터와 관리 메뉴 연결
- [x] 폴더 변경 후 목록 갱신

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
