### PR TITLE
feat: 선택 미디어 옵션 바 및 다중 삭제 구현

### DIFF
--- a/frontend/src/features/delete-media/index.ts
+++ b/frontend/src/features/delete-media/index.ts
@@ -1,3 +1,4 @@
 export { deleteMedia } from "./api/deleteMedia";
 export { deleteMediaBatch, type DeleteMediaBatchResponse } from "./api/deleteMediaBatch";
 export { DeleteMediaModal } from "./ui/DeleteMediaModal";
+export { DeleteSelectedMediaModal } from "./ui/DeleteSelectedMediaModal";

--- a/frontend/src/features/delete-media/ui/DeleteSelectedMediaModal.tsx
+++ b/frontend/src/features/delete-media/ui/DeleteSelectedMediaModal.tsx
@@ -1,0 +1,70 @@
+import { useMutation } from "@tanstack/react-query";
+import styled from "@emotion/styled";
+
+import { isApiError } from "@/shared/api";
+import { colors, typography } from "@/shared/styles/tokens";
+import { Button } from "@/shared/ui/button";
+import { Modal } from "@/shared/ui/modal";
+import { Row } from "@/shared/ui/row";
+import { Stack } from "@/shared/ui/stack";
+import { deleteMediaBatch, type DeleteMediaBatchResponse } from "../api/deleteMediaBatch";
+
+interface DeleteSelectedMediaModalProps {
+  roomId: number;
+  mediaIds: number[];
+  token: string;
+  onClose: () => void;
+  onSuccess: (result: DeleteMediaBatchResponse) => void | Promise<void>;
+}
+
+export const DeleteSelectedMediaModal = ({
+  roomId,
+  mediaIds,
+  token,
+  onClose,
+  onSuccess,
+}: DeleteSelectedMediaModalProps) => {
+  const mutation = useMutation({
+    mutationFn: () => deleteMediaBatch({ roomId, mediaIds, token }),
+    onSuccess,
+  });
+
+  return (
+    <Modal onClose={mutation.isPending ? () => undefined : onClose} showClose={!mutation.isPending}>
+      <Stack gap={20}>
+        <Title>{mediaIds.length}개의 사진을 삭제할까요?</Title>
+        <Description>삭제한 사진은 다시 복구할 수 없어요.</Description>
+        {mutation.isError && (
+          <ErrorMessage role="alert">
+            {isApiError(mutation.error)
+              ? mutation.error.message
+              : "사진을 삭제하지 못했어요. 다시 시도해 주세요."}
+          </ErrorMessage>
+        )}
+        <Row gap={12}>
+          <Button variant="default" disabled={mutation.isPending} onClick={onClose}>
+            취소
+          </Button>
+          <Button variant="danger" disabled={mutation.isPending} onClick={() => mutation.mutate()}>
+            {mutation.isPending ? "삭제 중…" : "삭제하기"}
+          </Button>
+        </Row>
+      </Stack>
+    </Modal>
+  );
+};
+
+const Title = styled.h2`
+  text-align: center;
+  ${typography.heading3}
+`;
+const Description = styled.p`
+  color: ${colors.textSecondary};
+  text-align: center;
+  ${typography.body}
+`;
+const ErrorMessage = styled.p`
+  color: ${colors.danger};
+  text-align: center;
+  ${typography.caption1}
+`;

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.styles.ts
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.styles.ts
@@ -37,6 +37,45 @@ export const Count = styled.span`
   color: ${colors.textStrong};
 `;
 
+export const SelectionLayout = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  width: 100%;
+  gap: ${spacing[16]};
+`;
+
+export const SelectionSummary = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing[8]};
+  justify-self: start;
+`;
+
+export const SelectionCheck = styled.span`
+  display: grid;
+  flex: none;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border-radius: ${radius.full};
+  background: ${colors.primary};
+  color: ${colors.textInverse};
+
+  svg {
+    width: 12px;
+    height: 12px;
+    stroke-width: 2.5;
+  }
+`;
+
+export const ActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 0;
+`;
+
 export const Status = styled.span`
   display: flex;
   align-items: center;
@@ -81,14 +120,16 @@ export const DownloadButton = styled.button`
   align-items: center;
   justify-content: center;
   gap: 6px;
-  flex: 1;
+  justify-self: center;
+  width: 132px;
   height: 40px;
-  padding: 0 ${spacing[12]};
+  padding: 0 ${spacing[16]};
   border-radius: ${radius[12]};
   /* 좁은 폭에서 "zip 다운로드" 가 두 줄로 갈라지면 바 높이가 통째로 흔들린다. */
   white-space: nowrap;
   background: ${colors.primary};
-  ${typography.caption2}
+  ${typography.label5}
+  font-size: 12px;
   color: ${colors.textInverse};
 
   &:hover,
@@ -98,14 +139,15 @@ export const DownloadButton = styled.button`
 
   svg {
     flex: none;
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
   }
 
   @media (max-width: 360px) {
     gap: ${spacing[4]};
+    width: 124px;
     padding-inline: ${spacing[8]};
-    font-size: 11px;
+    font-size: 12px;
   }
 `;
 

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.test.tsx
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.test.tsx
@@ -105,7 +105,7 @@ describe("SelectionDownloadBar", () => {
   it("고른 장수를 보여준다", () => {
     renderBar([targetOf(5000)]);
 
-    expect(screen.getByText("선택 1개")).toBeInTheDocument();
+    expect(screen.getByText("1개")).toBeInTheDocument();
   });
 
   it("다운로드를 누르면 시트가 열린다", async () => {

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.tsx
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.tsx
@@ -1,14 +1,33 @@
 import { useState } from "react";
-import { LuDownload, LuImageDown, LuLoaderCircle, LuX } from "react-icons/lu";
+import {
+  LuCheck,
+  LuDownload,
+  LuFolderInput,
+  LuImageDown,
+  LuLoaderCircle,
+  LuTrash2,
+  LuX,
+} from "react-icons/lu";
 
 import { FloatingBar } from "@/shared/ui/floating-bar";
+import { IconButton } from "@/shared/ui/icon-button";
 import { downloadMessageOfError } from "../lib/downloadErrorMessage";
 import { useDownloadFailure } from "../model/useDownloadFailure";
 import { useMediaDownload } from "../model/useMediaDownload";
 import type { DownloadMode, DownloadOutcome, DownloadTarget } from "../model/types";
 import { DownloadFailureModal } from "./DownloadFailureModal";
 import { DownloadModeSheet } from "./DownloadModeSheet";
-import { Count, DownloadButton, Dock, PlainButton, Status } from "./SelectionDownloadBar.styles";
+import {
+  ActionGroup,
+  Count,
+  DownloadButton,
+  Dock,
+  PlainButton,
+  SelectionCheck,
+  SelectionLayout,
+  SelectionSummary,
+  Status,
+} from "./SelectionDownloadBar.styles";
 
 /**
  * 사진을 하나라도 고르면 나타나는 바 (003-selection-download).
@@ -27,6 +46,8 @@ interface SelectionDownloadBarProps {
   roomCode: string;
   token: string;
   onClearSelection: () => void;
+  onDeleteSelection?: () => void;
+  onMoveSelection?: () => void;
   /** 한 판이 끝났을 때. 실패 안내는 부르는 쪽이 띄운다. */
   onSettled?: (outcome: DownloadOutcome) => void;
 }
@@ -47,6 +68,8 @@ export const SelectionDownloadBar = ({
   roomCode,
   token,
   onClearSelection,
+  onDeleteSelection,
+  onMoveSelection,
   onSettled,
 }: SelectionDownloadBarProps) => {
   const [isSheetOpen, setSheetOpen] = useState(false);
@@ -132,16 +155,35 @@ export const SelectionDownloadBar = ({
                 </PlainButton>
               </>
             ) : (
-              <>
-                <Count>선택 {targets.length}개</Count>
-                <PlainButton type="button" aria-label="선택 해제" onClick={onClearSelection}>
-                  <LuX />
-                </PlainButton>
+              <SelectionLayout>
+                <SelectionSummary>
+                  <SelectionCheck aria-hidden="true">
+                    <LuCheck />
+                  </SelectionCheck>
+                  <Count>{targets.length}개</Count>
+                </SelectionSummary>
                 <DownloadButton type="button" onClick={() => setSheetOpen(true)}>
                   <LuDownload />
                   다운로드
                 </DownloadButton>
-              </>
+                <ActionGroup>
+                  <IconButton
+                    size="sm"
+                    variant="danger"
+                    aria-label="선택한 사진 삭제"
+                    onClick={onDeleteSelection}
+                  >
+                    <LuTrash2 />
+                  </IconButton>
+                  <IconButton
+                    size="sm"
+                    aria-label="선택한 사진 폴더 이동"
+                    onClick={onMoveSelection}
+                  >
+                    <LuFolderInput />
+                  </IconButton>
+                </ActionGroup>
+              </SelectionLayout>
             )}
           </FloatingBar>
         </Dock>

--- a/frontend/src/pages/gallery/ui/GalleryContent.tsx
+++ b/frontend/src/pages/gallery/ui/GalleryContent.tsx
@@ -6,6 +6,7 @@ import { photosQueryKey } from "@/entities/media";
 import { roomQueryKey, type Room } from "@/entities/room";
 import { removeRoomSession } from "@/entities/session";
 import { DeleteRoomModal } from "@/features/delete-room";
+import { DeleteSelectedMediaModal } from "@/features/delete-media";
 import { CreateFolderBottomSheet } from "@/features/create-folder";
 import { DeleteFolderModal } from "@/features/delete-folder";
 import { EditFolderBottomSheet } from "@/features/edit-folder";
@@ -37,6 +38,7 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
   const [isEditFolderOpen, setIsEditFolderOpen] = useState(false);
   const [isDeleteFolderOpen, setIsDeleteFolderOpen] = useState(false);
+  const [isDeleteSelectionOpen, setIsDeleteSelectionOpen] = useState(false);
   const [deletedFolderName, setDeletedFolderName] = useState<string | null>(null);
 
   // 옵션 선택
@@ -128,7 +130,31 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
         roomCode={room.code}
         token={accessToken}
         onClearSelection={clearSelection}
+        onDeleteSelection={() => setIsDeleteSelectionOpen(true)}
       />
+
+      {isDeleteSelectionOpen && (
+        <DeleteSelectedMediaModal
+          roomId={room.roomId}
+          mediaIds={selectedPhotoIds}
+          token={accessToken}
+          onClose={() => setIsDeleteSelectionOpen(false)}
+          onSuccess={async () => {
+            setIsDeleteSelectionOpen(false);
+            clearSelection();
+            await Promise.all([
+              queryClient.invalidateQueries({
+                queryKey: photosQueryKey(room.roomId, userId),
+                exact: true,
+              }),
+              queryClient.invalidateQueries({
+                queryKey: roomQueryKey(room.code, userId),
+                exact: true,
+              }),
+            ]);
+          }}
+        />
+      )}
 
       {isDeleteModalOpen && (
         <DeleteRoomModal

--- a/frontend/src/shared/ui/bottom-sheet/BottomSheet.tsx
+++ b/frontend/src/shared/ui/bottom-sheet/BottomSheet.tsx
@@ -34,7 +34,7 @@ const Overlay = styled.div`
 
 const Sheet = styled.div`
   width: 100%;
-  padding: ${spacing[16]} ${spacing[24]} ${spacing[24]};
+  padding: ${spacing[12]} ${spacing[20]};
   background: ${colors.backgroundDefault};
   border-radius: ${radius[24]};
   box-shadow: ${shadow.sheet};

--- a/frontend/src/shared/ui/floating-bar/FloatingBar.tsx
+++ b/frontend/src/shared/ui/floating-bar/FloatingBar.tsx
@@ -16,10 +16,10 @@ const Bar = styled.div`
   display: flex;
   align-items: center;
   gap: ${spacing[8]};
-  min-height: 68px;
+  min-height: 76px;
   width: 100%;
   max-width: 520px;
-  padding: 13px 22px;
+  padding: 11px 28px;
   background: ${colors.backgroundDefault};
   border: 1.25px solid #e5ded1;
   border-radius: ${radius.full};
@@ -27,6 +27,7 @@ const Bar = styled.div`
 
   @media (max-width: 400px) {
     gap: 6px;
-    padding-inline: ${spacing[12]};
+    min-height: 68px;
+    padding: 10px ${spacing[16]};
   }
 `;


### PR DESCRIPTION
## 작업 내용
- 선택한 미디어의 개수와 액션을 보여주는 하단 옵션 바를 구현했습니다.
- 기존 개별·ZIP·모바일 사진첩 다운로드 기능을 유지했습니다.
- 선택한 미디어를 일괄 삭제할 수 있도록 연결했습니다.

## 관련 이슈
Closes #161

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] 선택 미디어 옵션 바 디자인 적용
- [x] 다운로드·삭제·폴더 액션 표시
- [x] 선택 미디어 다중 삭제 API 연동
- [x] 삭제 후 목록과 선택 상태 갱신

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)