### PR TITLE
feat: 선택 미디어 폴더 담기 및 꺼내기 구현

### DIFF
--- a/frontend/src/features/move-media-folder/api/addMediaToFolder.ts
+++ b/frontend/src/features/move-media-folder/api/addMediaToFolder.ts
@@ -1,0 +1,50 @@
+import { apiClient } from "@/shared/api";
+
+interface AddMediaToFolderResponse {
+  updatedCount: number;
+  alreadyInCount: number;
+  notFoundMediaIds: number[];
+  folders: {
+    id: number;
+    name: string;
+    photoCount: number;
+  }[];
+}
+
+interface LegacyAddMediaToFolderResponse {
+  updatedCount: number;
+  alreadyInCount: number;
+  notFoundMediaIds: number[];
+  folder: AddMediaToFolderResponse["folders"][number];
+}
+
+export const addMediaToFolder = async ({
+  roomId,
+  mediaIds,
+  folderIds,
+  token,
+}: {
+  roomId: number;
+  mediaIds: number[];
+  folderIds: number[];
+  token: string;
+}) => {
+  // 현재 배포 서버는 folderId 단건 명세다. 다중 선택은 폴더별 요청으로 처리한다.
+  const results = await Promise.all(
+    folderIds.map((folderId) =>
+      apiClient<LegacyAddMediaToFolderResponse>(`/rooms/${roomId}/media/folders`, {
+        method: "PUT",
+        token,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mediaIds, folderId }),
+      }),
+    ),
+  );
+
+  return {
+    updatedCount: results.reduce((sum, result) => sum + result.updatedCount, 0),
+    alreadyInCount: results.reduce((sum, result) => sum + result.alreadyInCount, 0),
+    notFoundMediaIds: [...new Set(results.flatMap((result) => result.notFoundMediaIds))],
+    folders: results.map((result) => result.folder),
+  } satisfies AddMediaToFolderResponse;
+};

--- a/frontend/src/features/move-media-folder/api/addMediaToFolder.ts
+++ b/frontend/src/features/move-media-folder/api/addMediaToFolder.ts
@@ -4,47 +4,27 @@ interface AddMediaToFolderResponse {
   updatedCount: number;
   alreadyInCount: number;
   notFoundMediaIds: number[];
-  folders: {
+  folder: {
     id: number;
     name: string;
     photoCount: number;
-  }[];
+  };
 }
 
-interface LegacyAddMediaToFolderResponse {
-  updatedCount: number;
-  alreadyInCount: number;
-  notFoundMediaIds: number[];
-  folder: AddMediaToFolderResponse["folders"][number];
-}
-
-export const addMediaToFolder = async ({
+export const addMediaToFolder = ({
   roomId,
   mediaIds,
-  folderIds,
+  folderId,
   token,
 }: {
   roomId: number;
   mediaIds: number[];
-  folderIds: number[];
+  folderId: number;
   token: string;
-}) => {
-  // 현재 배포 서버는 folderId 단건 명세다. 다중 선택은 폴더별 요청으로 처리한다.
-  const results = await Promise.all(
-    folderIds.map((folderId) =>
-      apiClient<LegacyAddMediaToFolderResponse>(`/rooms/${roomId}/media/folders`, {
-        method: "PUT",
-        token,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mediaIds, folderId }),
-      }),
-    ),
-  );
-
-  return {
-    updatedCount: results.reduce((sum, result) => sum + result.updatedCount, 0),
-    alreadyInCount: results.reduce((sum, result) => sum + result.alreadyInCount, 0),
-    notFoundMediaIds: [...new Set(results.flatMap((result) => result.notFoundMediaIds))],
-    folders: results.map((result) => result.folder),
-  } satisfies AddMediaToFolderResponse;
-};
+}) =>
+  apiClient<AddMediaToFolderResponse>(`/rooms/${roomId}/media/folders`, {
+    method: "PUT",
+    token,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mediaIds, folderId }),
+  });

--- a/frontend/src/features/move-media-folder/api/removeMediaFromFolder.ts
+++ b/frontend/src/features/move-media-folder/api/removeMediaFromFolder.ts
@@ -1,0 +1,30 @@
+import { apiClient } from "@/shared/api";
+
+interface RemoveMediaFromFolderResponse {
+  updatedCount: number;
+  movedToRootMediaIds: number[];
+  notFoundMediaIds: number[];
+  folders: {
+    id: number;
+    name: string;
+    photoCount: number;
+  }[];
+}
+
+export const removeMediaFromFolder = ({
+  roomId,
+  mediaIds,
+  folderId,
+  token,
+}: {
+  roomId: number;
+  mediaIds: number[];
+  folderId: number;
+  token: string;
+}) =>
+  apiClient<RemoveMediaFromFolderResponse>(`/rooms/${roomId}/media/folders`, {
+    method: "DELETE",
+    token,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mediaIds, folderIds: [folderId] }),
+  });

--- a/frontend/src/features/move-media-folder/index.ts
+++ b/frontend/src/features/move-media-folder/index.ts
@@ -1,0 +1,3 @@
+export { addMediaToFolder } from "./api/addMediaToFolder";
+export { removeMediaFromFolder } from "./api/removeMediaFromFolder";
+export { MoveMediaFolderBottomSheet } from "./ui/MoveMediaFolderBottomSheet";

--- a/frontend/src/features/move-media-folder/ui/MoveMediaFolderBottomSheet.tsx
+++ b/frontend/src/features/move-media-folder/ui/MoveMediaFolderBottomSheet.tsx
@@ -31,11 +31,11 @@ export const MoveMediaFolderBottomSheet = ({
   onClose,
   onSuccess,
 }: MoveMediaFolderBottomSheetProps) => {
-  const [folderIds, setFolderIds] = useState<number[]>([]);
+  const [folderId, setFolderId] = useState<number | null>(null);
   const mutation = useMutation({
-    mutationFn: (targetFolderIds: number[]) =>
-      addMediaToFolder({ roomId, mediaIds, folderIds: targetFolderIds, token }),
-    onSuccess: (_, targetFolderIds) => onSuccess(targetFolderIds[0]),
+    mutationFn: (targetFolderId: number) =>
+      addMediaToFolder({ roomId, mediaIds, folderId: targetFolderId, token }),
+    onSuccess: (_, targetFolderId) => onSuccess(targetFolderId),
   });
   const removeMutation = useMutation({
     mutationFn: (folderId: number) => removeMediaFromFolder({ roomId, mediaIds, folderId, token }),
@@ -51,20 +51,14 @@ export const MoveMediaFolderBottomSheet = ({
       <Stack gap={16}>
         <FolderList>
           {folders.map((folder) => {
-            const selected = folderIds.includes(folder.id);
+            const selected = folderId === folder.id;
             return (
               <FolderButton
                 key={folder.id}
                 type="button"
                 $selected={selected}
                 disabled={isPending}
-                onClick={() =>
-                  setFolderIds((current) =>
-                    current.includes(folder.id)
-                      ? current.filter((id) => id !== folder.id)
-                      : [...current, folder.id],
-                  )
-                }
+                onClick={() => setFolderId((current) => (current === folder.id ? null : folder.id))}
               >
                 <FolderIcon>
                   <LuFolder />
@@ -82,7 +76,7 @@ export const MoveMediaFolderBottomSheet = ({
           })}
         </FolderList>
         {folders.length === 0 && <Empty>먼저 폴더를 만들어 주세요.</Empty>}
-        {folders.length > 0 && <Notice>사진은 여러 폴더에 함께 담을 수 있어요.</Notice>}
+        {folders.length > 0 && <Notice>사진을 담을 폴더 하나를 선택해 주세요.</Notice>}
         {currentFolderId !== null && (
           <Button
             variant="default"
@@ -107,8 +101,8 @@ export const MoveMediaFolderBottomSheet = ({
           </ErrorMessage>
         )}
         <Button
-          disabled={folderIds.length === 0 || isPending}
-          onClick={() => folderIds.length > 0 && mutation.mutate(folderIds)}
+          disabled={folderId === null || isPending}
+          onClick={() => folderId !== null && mutation.mutate(folderId)}
         >
           {mutation.isPending ? "이동 중..." : "여기로 이동"}
         </Button>

--- a/frontend/src/features/move-media-folder/ui/MoveMediaFolderBottomSheet.tsx
+++ b/frontend/src/features/move-media-folder/ui/MoveMediaFolderBottomSheet.tsx
@@ -1,0 +1,195 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import styled from "@emotion/styled";
+import { LuCheck, LuFolder } from "react-icons/lu";
+
+import type { RoomFolder } from "@/entities/room";
+import { isApiError } from "@/shared/api";
+import { colors, radius, spacing, typography } from "@/shared/styles/tokens";
+import { BottomSheet } from "@/shared/ui/bottom-sheet";
+import { Button } from "@/shared/ui/button";
+import { Stack } from "@/shared/ui/stack";
+import { addMediaToFolder } from "../api/addMediaToFolder";
+import { removeMediaFromFolder } from "../api/removeMediaFromFolder";
+
+interface MoveMediaFolderBottomSheetProps {
+  roomId: number;
+  mediaIds: number[];
+  folders: RoomFolder[];
+  currentFolderId: number | null;
+  token: string;
+  onClose: () => void;
+  onSuccess: (folderId: number | null) => void | Promise<void>;
+}
+
+export const MoveMediaFolderBottomSheet = ({
+  roomId,
+  mediaIds,
+  folders,
+  currentFolderId,
+  token,
+  onClose,
+  onSuccess,
+}: MoveMediaFolderBottomSheetProps) => {
+  const [folderIds, setFolderIds] = useState<number[]>([]);
+  const mutation = useMutation({
+    mutationFn: (targetFolderIds: number[]) =>
+      addMediaToFolder({ roomId, mediaIds, folderIds: targetFolderIds, token }),
+    onSuccess: (_, targetFolderIds) => onSuccess(targetFolderIds[0]),
+  });
+  const removeMutation = useMutation({
+    mutationFn: (folderId: number) => removeMediaFromFolder({ roomId, mediaIds, folderId, token }),
+    onSuccess: (_, folderId) => onSuccess(folderId),
+  });
+  const isPending = mutation.isPending || removeMutation.isPending;
+
+  return (
+    <BottomSheet
+      title={`${mediaIds.length}개를 어디로 옮길까요?`}
+      onClose={isPending ? undefined : onClose}
+    >
+      <Stack gap={16}>
+        <FolderList>
+          {folders.map((folder) => {
+            const selected = folderIds.includes(folder.id);
+            return (
+              <FolderButton
+                key={folder.id}
+                type="button"
+                $selected={selected}
+                disabled={isPending}
+                onClick={() =>
+                  setFolderIds((current) =>
+                    current.includes(folder.id)
+                      ? current.filter((id) => id !== folder.id)
+                      : [...current, folder.id],
+                  )
+                }
+              >
+                <FolderIcon>
+                  <LuFolder />
+                </FolderIcon>
+                <FolderName>{folder.name}</FolderName>
+                {selected ? (
+                  <CheckSlot>
+                    <LuCheck aria-hidden="true" />
+                  </CheckSlot>
+                ) : (
+                  <PhotoCount>{folder.photoCount}</PhotoCount>
+                )}
+              </FolderButton>
+            );
+          })}
+        </FolderList>
+        {folders.length === 0 && <Empty>먼저 폴더를 만들어 주세요.</Empty>}
+        {folders.length > 0 && <Notice>사진은 여러 폴더에 함께 담을 수 있어요.</Notice>}
+        {currentFolderId !== null && (
+          <Button
+            variant="default"
+            disabled={isPending}
+            onClick={() => removeMutation.mutate(currentFolderId)}
+          >
+            {removeMutation.isPending ? "꺼내는 중..." : "폴더에서 꺼내기"}
+          </Button>
+        )}
+        {mutation.isError && (
+          <ErrorMessage role="alert">
+            {isApiError(mutation.error)
+              ? mutation.error.message
+              : "사진을 폴더에 추가하지 못했어요."}
+          </ErrorMessage>
+        )}
+        {removeMutation.isError && (
+          <ErrorMessage role="alert">
+            {isApiError(removeMutation.error)
+              ? removeMutation.error.message
+              : "사진을 폴더에서 꺼내지 못했어요."}
+          </ErrorMessage>
+        )}
+        <Button
+          disabled={folderIds.length === 0 || isPending}
+          onClick={() => folderIds.length > 0 && mutation.mutate(folderIds)}
+        >
+          {mutation.isPending ? "이동 중..." : "여기로 이동"}
+        </Button>
+      </Stack>
+    </BottomSheet>
+  );
+};
+
+const FolderList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing[12]};
+  max-height: 240px;
+  overflow-y: auto;
+`;
+
+const FolderButton = styled.button<{ $selected: boolean }>`
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: ${spacing[8]};
+  width: 100%;
+  min-height: 60px;
+  padding: ${spacing[16]};
+  border: 1.5px solid ${({ $selected }) => ($selected ? colors.primary : colors.borderDefault)};
+  border-radius: ${radius[12]};
+  color: ${({ $selected }) => ($selected ? colors.textAccent : colors.textStrong)};
+  text-align: left;
+`;
+
+const FolderIcon = styled.span`
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  color: inherit;
+
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+`;
+
+const FolderName = styled.span`
+  ${typography.label5}
+`;
+
+const PhotoCount = styled.span`
+  color: ${colors.textSecondary};
+  ${typography.caption1}
+`;
+
+const CheckSlot = styled.span`
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: ${radius.full};
+  background: ${colors.primary};
+  color: ${colors.textInverse};
+
+  svg {
+    width: 15px;
+    height: 15px;
+  }
+`;
+
+const Notice = styled.p`
+  color: ${colors.textSecondary};
+  ${typography.caption3}
+`;
+
+const Empty = styled.p`
+  padding: ${spacing[24]} 0;
+  color: ${colors.textSecondary};
+  text-align: center;
+  ${typography.body}
+`;
+
+const ErrorMessage = styled.p`
+  color: ${colors.danger};
+  text-align: center;
+  ${typography.caption1}
+`;

--- a/frontend/src/mocks/handlers/media.ts
+++ b/frontend/src/mocks/handlers/media.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from "msw";
 import type { MediaDetail } from "@/entities/media";
 import { API_BASE_URL } from "@/shared/config";
 import { markMediaDeleted, type GalleryMedia } from "../db";
-import { hasJoinedRoom, mediaOfRoom, MOCK_HOST_ID, roomStatusOfId } from "./room";
+import { hasFolder, hasJoinedRoom, mediaOfRoom, MOCK_HOST_ID, roomStatusOfId } from "./room";
 
 const error = (status: number, code: string, message: string) =>
   HttpResponse.json({ code, message }, { status });
@@ -29,6 +29,124 @@ const forbidden = () =>
   error(403, "MEDIA_FORBIDDEN", "다른 사람이 올린 파일이라 삭제할 수 없습니다");
 
 export const mediaHandlers = [
+  http.put(`${API_BASE_URL}/rooms/:roomId/media/folders`, async ({ request, params }) => {
+    const roomId = Number(params.roomId);
+    const auth = authorize(request, roomId);
+    if (typeof auth !== "number") return auth;
+    const body: unknown = await request.json().catch(() => null);
+    if (
+      !body ||
+      typeof body !== "object" ||
+      !("mediaIds" in body) ||
+      !Array.isArray(body.mediaIds) ||
+      body.mediaIds.length === 0 ||
+      (!("folderIds" in body) && !("folderId" in body))
+    ) {
+      return error(400, "INVALID_PARAM", "미디어와 폴더를 선택해 주세요.");
+    }
+    const requestedFolderIds =
+      "folderIds" in body && Array.isArray(body.folderIds)
+        ? body.folderIds
+        : "folderId" in body && typeof body.folderId === "number"
+          ? [body.folderId]
+          : [];
+    if (
+      requestedFolderIds.length === 0 ||
+      !requestedFolderIds.every((id: unknown) => typeof id === "number")
+    ) {
+      return error(400, "INVALID_PARAM", "미디어와 폴더를 선택해 주세요.");
+    }
+    const folderIds = [...new Set<number>(requestedFolderIds)];
+    if (folderIds.some((folderId) => !hasFolder(roomId, folderId))) {
+      return error(404, "FOLDER_NOT_FOUND", "폴더를 찾을 수 없습니다.");
+    }
+
+    const mediaById = new Map(mediaOfRoom(roomId).map((media) => [media.mediaId, media]));
+    let updatedCount = 0;
+    let alreadyInCount = 0;
+    const notFoundMediaIds: number[] = [];
+    for (const mediaId of [...new Set<number>(body.mediaIds)]) {
+      const media = mediaById.get(mediaId);
+      if (!media) {
+        notFoundMediaIds.push(mediaId);
+      } else {
+        for (const folderId of folderIds) {
+          if (media.folderIds.includes(folderId)) {
+            alreadyInCount += 1;
+          } else {
+            media.folderIds.push(folderId);
+            updatedCount += 1;
+          }
+        }
+      }
+    }
+
+    const folders = folderIds.map((folderId) => ({
+      id: folderId,
+      name: "폴더",
+      photoCount: mediaOfRoom(roomId).filter((media) => media.folderIds.includes(folderId)).length,
+    }));
+    const data = { updatedCount, alreadyInCount, notFoundMediaIds };
+
+    return HttpResponse.json({
+      data: "folderId" in body ? { ...data, folder: folders[0] } : { ...data, folders },
+    });
+  }),
+
+  http.delete(`${API_BASE_URL}/rooms/:roomId/media/folders`, async ({ request, params }) => {
+    const roomId = Number(params.roomId);
+    const auth = authorize(request, roomId);
+    if (typeof auth !== "number") return auth;
+    const body: unknown = await request.json().catch(() => null);
+    if (
+      !body ||
+      typeof body !== "object" ||
+      !("mediaIds" in body) ||
+      !Array.isArray(body.mediaIds) ||
+      body.mediaIds.length === 0 ||
+      !("folderIds" in body) ||
+      !Array.isArray(body.folderIds) ||
+      body.folderIds.length === 0
+    ) {
+      return error(400, "INVALID_PARAM", "미디어와 폴더를 선택해 주세요.");
+    }
+
+    const folderIds = [...new Set<number>(body.folderIds)];
+    if (folderIds.some((folderId) => !hasFolder(roomId, folderId))) {
+      return error(404, "FOLDER_NOT_FOUND", "폴더를 찾을 수 없습니다.");
+    }
+
+    const mediaById = new Map(mediaOfRoom(roomId).map((media) => [media.mediaId, media]));
+    let updatedCount = 0;
+    const movedToRootMediaIds: number[] = [];
+    const notFoundMediaIds: number[] = [];
+    for (const mediaId of [...new Set<number>(body.mediaIds)]) {
+      const media = mediaById.get(mediaId);
+      if (!media) {
+        notFoundMediaIds.push(mediaId);
+        continue;
+      }
+      const before = media.folderIds.length;
+      media.folderIds = media.folderIds.filter((folderId) => !folderIds.includes(folderId));
+      updatedCount += before - media.folderIds.length;
+      if (before > 0 && media.folderIds.length === 0) movedToRootMediaIds.push(mediaId);
+    }
+
+    return HttpResponse.json({
+      data: {
+        updatedCount,
+        movedToRootMediaIds,
+        notFoundMediaIds,
+        folders: folderIds.map((folderId) => ({
+          id: folderId,
+          name: "폴더",
+          photoCount: mediaOfRoom(roomId).filter((media) => media.folderIds.includes(folderId))
+            .length,
+        })),
+      },
+    });
+  }),
+
   http.get(`${API_BASE_URL}/rooms/:roomId/media/:mediaId`, ({ request, params }) => {
     const roomId = Number(params.roomId);
     const auth = authorize(request, roomId);

--- a/frontend/src/pages/gallery/ui/GalleryContent.tsx
+++ b/frontend/src/pages/gallery/ui/GalleryContent.tsx
@@ -11,6 +11,7 @@ import { CreateFolderBottomSheet } from "@/features/create-folder";
 import { DeleteFolderModal } from "@/features/delete-folder";
 import { EditFolderBottomSheet } from "@/features/edit-folder";
 import { SelectionDownloadBar } from "@/features/download-media";
+import { MoveMediaFolderBottomSheet } from "@/features/move-media-folder";
 import { MediaUploader } from "@/features/upload-media";
 import { ROUTES } from "@/shared/config";
 import { Toast } from "@/shared/ui/toast";
@@ -39,6 +40,7 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
   const [isEditFolderOpen, setIsEditFolderOpen] = useState(false);
   const [isDeleteFolderOpen, setIsDeleteFolderOpen] = useState(false);
   const [isDeleteSelectionOpen, setIsDeleteSelectionOpen] = useState(false);
+  const [isMoveSelectionOpen, setIsMoveSelectionOpen] = useState(false);
   const [deletedFolderName, setDeletedFolderName] = useState<string | null>(null);
 
   // 옵션 선택
@@ -131,6 +133,7 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
         token={accessToken}
         onClearSelection={clearSelection}
         onDeleteSelection={() => setIsDeleteSelectionOpen(true)}
+        onMoveSelection={() => setIsMoveSelectionOpen(true)}
       />
 
       {isDeleteSelectionOpen && (
@@ -141,6 +144,32 @@ export const GalleryContent = ({ room, accessToken, userId }: GalleryContentProp
           onClose={() => setIsDeleteSelectionOpen(false)}
           onSuccess={async () => {
             setIsDeleteSelectionOpen(false);
+            clearSelection();
+            await Promise.all([
+              queryClient.invalidateQueries({
+                queryKey: photosQueryKey(room.roomId, userId),
+                exact: true,
+              }),
+              queryClient.invalidateQueries({
+                queryKey: roomQueryKey(room.code, userId),
+                exact: true,
+              }),
+            ]);
+          }}
+        />
+      )}
+
+      {isMoveSelectionOpen && (
+        <MoveMediaFolderBottomSheet
+          roomId={room.roomId}
+          mediaIds={selectedPhotoIds}
+          folders={room.folders}
+          currentFolderId={selectedFolderId}
+          token={accessToken}
+          onClose={() => setIsMoveSelectionOpen(false)}
+          onSuccess={async (folderId) => {
+            setIsMoveSelectionOpen(false);
+            selectFolder(folderId);
             clearSelection();
             await Promise.all([
               queryClient.invalidateQueries({


### PR DESCRIPTION
## 작업 내용
- 선택한 미디어를 여러 폴더에 담는 기능을 구현했습니다.
- 현재 폴더에서 선택한 미디어를 꺼내는 기능을 구현했습니다.
- 작업 완료 후 미디어 및 폴더 정보를 갱신하도록 처리했습니다.

## 관련 이슈
Closes #163

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] 미디어 폴더 담기·꺼내기 API 및 MSW 핸들러 추가
- [x] 다중 폴더 선택 바텀시트 및 갤러리 연결
- [x] 폴더 작업 후 관련 쿼리 무효화

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)