### PR TITLE
test: 다운로드 UI 스토리북 스토리 추가

### DIFF
--- a/frontend/src/features/download-media/ui/DownloadFailureModal.stories.tsx
+++ b/frontend/src/features/download-media/ui/DownloadFailureModal.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { DownloadFailureModal } from "./DownloadFailureModal";
+
+const meta = {
+  title: "features/download-media/DownloadFailureModal",
+  component: DownloadFailureModal,
+  parameters: {
+    // 오버레이가 화면을 덮는 모달이다. 캔버스를 꽉 채워야 실제 비율이 보인다.
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof DownloadFailureModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 13 · 다운로드 실패 — 여러 장 중 일부만 못 받았고, 기다렸다 다시 누르면 되는 실패 */
+export const Default: Story = {
+  args: {
+    count: 2,
+    message: "아직 처리 중이에요",
+    isRetryable: true,
+    onRetry: () => {},
+    onClose: () => {},
+  },
+};
+
+/**
+ * 없는 사진이라 재시도가 빠진 상태.
+ *
+ * 버튼이 하나만 남는다. 다시 눌러도 결과가 같은 실패에 재시도를 내주면
+ * 사용자가 같은 벽에 반복해서 부딪힌다 (`downloadErrorMessage` 참고).
+ */
+export const NotRetryable: Story = {
+  args: {
+    count: 1,
+    message: "찾을 수 없어요",
+    isRetryable: false,
+    onRetry: () => {},
+    onClose: () => {},
+  },
+};
+
+/**
+ * 판 전체가 무너진 경우 — 압축 잡을 만들지도 못해 셀 장수가 없다.
+ *
+ * `count` 가 0 이면 제목이 장수를 말하지 않는다.
+ */
+export const WholeRunFailed: Story = {
+  args: {
+    count: 0,
+    message: "받는 중인 요청이 많아요",
+    isRetryable: true,
+    onRetry: () => {},
+    onClose: () => {},
+  },
+};
+
+/** 회선이 끊겨 고른 것이 통째로 깨진 경우. 세 자리 수에서도 제목이 한 줄에 들어가야 한다 */
+export const ManyFiles: Story = {
+  args: {
+    count: 128,
+    message: "네트워크 연결을 확인해주세요",
+    isRetryable: true,
+    onRetry: () => {},
+    onClose: () => {},
+  },
+};

--- a/frontend/src/features/download-media/ui/DownloadModeSheet.stories.tsx
+++ b/frontend/src/features/download-media/ui/DownloadModeSheet.stories.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { DownloadModeSheet } from "./DownloadModeSheet";
+
+/**
+ * 첫 항목이 기기에 따라 갈리는데(`prefersShareSheet` 참고), 스토리북은 데스크톱
+ * 브라우저에서 열려서 폰 쪽 분기를 볼 방법이 없다. 그래서 그 함수가 보는 두 신호 —
+ * **파일 공유 지원 여부와 터치 입력 여부** — 만 흉내 내 폰인 척하게 만든다.
+ *
+ * 컴포넌트가 렌더 중에 물어보므로 스토리가 그려지기 **전에** 갈아끼워야 하고,
+ * 다른 스토리로 넘어가면 원래대로 돌려놓아야 한다 — 전역을 건드리는 일이라 이 파일
+ * 밖으로 새면 안 된다.
+ */
+let restorePhone: (() => void) | null = null;
+
+const pretendToBePhone = () => {
+  // 이미 갈아끼운 상태다. 두 번 끼우면 되돌릴 원본을 잃는다.
+  if (restorePhone !== null) {
+    return;
+  }
+
+  const originalCanShare = navigator.canShare;
+  const originalMatchMedia = window.matchMedia;
+
+  navigator.canShare = () => true;
+  window.matchMedia = ((query: string) =>
+    query.includes("pointer: coarse")
+      ? // 우리 코드가 `matches` 만 보는 질의다. 나머지 질의는 원래 것에 그대로 넘긴다.
+        ({
+          matches: true,
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        } as unknown as MediaQueryList)
+      : originalMatchMedia.call(window, query)) as typeof window.matchMedia;
+
+  restorePhone = () => {
+    navigator.canShare = originalCanShare;
+    window.matchMedia = originalMatchMedia;
+    restorePhone = null;
+  };
+};
+
+const AsPhone = ({ children }: { children: ReactNode }) => {
+  // 초기화 함수는 자식이 그려지기 전에 돈다. 시트가 물어볼 때는 이미 폰이다.
+  useState(pretendToBePhone);
+  useEffect(() => () => restorePhone?.(), []);
+
+  return <>{children}</>;
+};
+
+const meta = {
+  title: "features/download-media/DownloadModeSheet",
+  component: DownloadModeSheet,
+  parameters: {
+    // 오버레이가 화면을 덮는 시트다. 캔버스를 꽉 채워야 실제 비율이 보인다.
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof DownloadModeSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 14 · 받는 방식 고르기 (데스크톱) — 첫 항목이 개별 저장이다.
+ *
+ * 고르는 것과 시작하는 것이 나뉘어 있다. 항목을 눌러도 선택만 바뀌고,
+ * 받기는 아래 버튼을 눌러야 시작한다.
+ */
+export const Desktop: Story = {
+  args: {
+    count: 7,
+    roomCode: "7K93QX2S",
+    onSubmit: () => {},
+    onClose: () => {},
+  },
+};
+
+/**
+ * 14 · 받는 방식 고르기 (폰) — 첫 항목이 사진첩 저장으로 바뀌고 안내 문구도 따라 바뀐다.
+ *
+ * 폰에서 낱장 저장은 첫 장만 받아져서 그 자리를 공유 시트가 대신한다.
+ * 실기기 없이는 볼 수 없는 분기라, 여기서만 기기 신호를 흉내 낸다.
+ */
+export const Phone: Story = {
+  args: {
+    count: 7,
+    roomCode: "7K93QX2S",
+    onSubmit: () => {},
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <AsPhone>
+        <Story />
+      </AsPhone>
+    ),
+  ],
+};
+
+/** 한 장만 골랐을 때. 한 장이어도 zip 이 기본이다 */
+export const SingleFile: Story = {
+  args: {
+    count: 1,
+    roomCode: "7K93QX2S",
+    onSubmit: () => {},
+    onClose: () => {},
+  },
+};
+
+/** 방 코드가 길어도 zip 파일명이 항목 안에서 잘리지 않아야 한다 */
+export const LongRoomCode: Story = {
+  args: {
+    count: 132,
+    roomCode: "WEDDING2026SPRING",
+    onSubmit: () => {},
+    onClose: () => {},
+  },
+};

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.stories.tsx
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.stories.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { MOCK_ROOM_ID, mediaOfRoom } from "@/mocks/handlers/room";
+import { API_BASE_URL } from "@/shared/config";
+import { Button } from "@/shared/ui/button";
+import { SelectionDownloadBar } from "./SelectionDownloadBar";
+import type { DownloadTarget } from "../model/types";
+
+const ROOM_CODE = "7K93QX2S";
+/** 목이 인정하는 형식의 토큰이다 (`mock-token-<memberId>`). */
+const TOKEN = "mock-token-10234";
+
+const targetOf = (mediaId: number): DownloadTarget => ({
+  mediaId,
+  fileName: `IMG_${mediaId}.jpg`,
+  size: 3 * 1024 * 1024,
+  mimeType: "image/jpeg",
+});
+
+const meta = {
+  title: "features/download-media/SelectionDownloadBar",
+  component: SelectionDownloadBar,
+  parameters: {
+    // 화면 하단에 고정되는 바다. 캔버스를 꽉 채워야 실제로 앉는 자리가 보인다.
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof SelectionDownloadBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 11 · 골라서 받기 — 한 장 골랐을 때.
+ *
+ * 다운로드를 누르면 방식 시트가 열린다. 거기서 다운로드까지 누르면 목을 상대로
+ * 실제 받기가 시작하는데, 이 스토리의 방·토큰은 목에 입장한 적이 없어 실패 모달로 끝난다.
+ * 끝까지 굴러가는 판은 아래 `LiveRun` 이다.
+ */
+export const Default: Story = {
+  args: {
+    targets: [targetOf(5000)],
+    roomId: MOCK_ROOM_ID,
+    roomCode: ROOM_CODE,
+    token: TOKEN,
+    onClearSelection: () => {},
+  },
+};
+
+/** 여러 장 골랐을 때. 장수가 세 자리가 되어도 바가 한 줄에 들어가야 한다 */
+export const ManySelected: Story = {
+  args: {
+    targets: Array.from({ length: 132 }, (_, index) => targetOf(5000 + index)),
+    roomId: MOCK_ROOM_ID,
+    roomCode: ROOM_CODE,
+    token: TOKEN,
+    onClearSelection: () => {},
+  },
+};
+
+/** 아무것도 안 골랐으면 바 자체를 그리지 않는다 — 평소에 화면을 차지하지 않기 위해서다 */
+export const NothingSelected: Story = {
+  args: {
+    targets: [],
+    roomId: MOCK_ROOM_ID,
+    roomCode: ROOM_CODE,
+    token: TOKEN,
+    onClearSelection: () => {},
+  },
+};
+
+/**
+ * 받는 중·압축 중·사진첩 준비됨 상태는 **props 로 만들 수 없다.** 받기 한 판을 굴리는
+ * 훅(`useMediaDownload`)이 안에서 들고 있는 상태라, 실제로 받아봐야 나온다.
+ *
+ * 그래서 여기서는 목(MSW)에 먼저 입장한 뒤 진짜 미디어를 대상으로 넘긴다.
+ * 목이 서버 워커 역할을 그대로 해서 — 원본을 받아 zip 을 조립하고 그동안 진행률이 오른다 —
+ * 시트부터 진행 바, 저장까지가 화면에서 그대로 굴러간다.
+ */
+/** 목이 들고 있는 진짜 미디어에서 받을 대상만 추린다. */
+const mockTargets = (): DownloadTarget[] =>
+  mediaOfRoom(MOCK_ROOM_ID)
+    .slice(0, 3)
+    .map(({ mediaId, fileName, size, mimeType }) => ({ mediaId, fileName, size, mimeType }));
+
+const LiveDownload = () => {
+  const [isJoined, setJoined] = useState(false);
+  const [targets, setTargets] = useState<DownloadTarget[]>([]);
+
+  useEffect(() => {
+    const join = async () => {
+      // 받기 API 는 입장한 방에서만 열린다. 목도 같은 검사를 한다.
+      await fetch(`${API_BASE_URL}/rooms/${MOCK_ROOM_ID}/members`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+
+      setTargets(mockTargets());
+      setJoined(true);
+    };
+
+    void join();
+  }, []);
+
+  if (!isJoined) {
+    return <p>목에 입장하는 중...</p>;
+  }
+
+  if (targets.length === 0) {
+    return <Button onClick={() => setTargets(mockTargets())}>다시 고르기</Button>;
+  }
+
+  return (
+    <SelectionDownloadBar
+      targets={targets}
+      roomId={MOCK_ROOM_ID}
+      roomCode={ROOM_CODE}
+      token={TOKEN}
+      onClearSelection={() => setTargets([])}
+    />
+  );
+};
+
+/** 11 · 골라서 받기 — 시트부터 진행 바, 저장까지 한 판 (실제로 파일이 받아집니다) */
+export const LiveRun: Story = {
+  args: {
+    targets: [],
+    roomId: MOCK_ROOM_ID,
+    roomCode: ROOM_CODE,
+    token: TOKEN,
+    onClearSelection: () => {},
+  },
+  render: () => <LiveDownload />,
+};


### PR DESCRIPTION
## 작업 내용
`features/download-media` 의 UI 컴포넌트 세 개에 스토리북 스토리를 추가했습니다.
업로드 기능에는 스토리가 있는데 다운로드에는 하나도 없어서, 시안 대조나 상태별 확인을 매번 앱을 띄우고 사진을 골라야만 할 수 있었습니다.

## 관련 이슈
Closes #159

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] `DownloadFailureModal.stories.tsx` — 일부 실패 / 재시도 불가(404) / 판 전체 실패(`count: 0`) / 대량 실패
- [x] `DownloadModeSheet.stories.tsx` — 데스크톱(개별로 저장) / 폰(사진첩에 저장) / 한 장 / 긴 방 코드
- [x] `SelectionDownloadBar.stories.tsx` — 선택 1개 / 대량 선택 / 선택 없음(아무것도 안 그림) / 목을 상대로 실제 한 판 굴리기

## 테스트
- [x] 단위 테스트 작성/통과 — 스토리라 새 테스트는 없고, 기존 71개 스위트·497개 테스트 통과
- [x] 로컬 동작 확인 — `pnpm storybook` 에서 네 그룹 모두 렌더링, 폰 분기 전환·복구, 진행 바(압축 중)와 취소까지 확인
- [x] `pnpm type-check` · `pnpm lint` · `pnpm format:check` 통과

## 리뷰 요청 사항 (선택)
.