### PR TITLE
fix: 401 을 만나도 세션이 안 지워지고 재인증으로 안 보내는 문제 해결

### DIFF
--- a/frontend/src/app/RoomMediaLayout.tsx
+++ b/frontend/src/app/RoomMediaLayout.tsx
@@ -2,9 +2,15 @@ import { Outlet, useParams } from "react-router-dom";
 
 import { readValidRoomSession } from "@/entities/session";
 import { PhotoSelectionProvider } from "@/features/select-media";
+import { useUnauthorizedRecovery } from "./useUnauthorizedRecovery";
 
 export const RoomMediaLayout = () => {
   const { code = "" } = useParams();
+
+  // 토큰을 들고 부르는 화면은 모두 이 아래에 있다. 여기 한 번 걸어두면 갤러리·상세·설정이
+  // 각자 401 을 알아볼 필요가 없다 (#149).
+  useUnauthorizedRecovery();
+
   const session = readValidRoomSession(code);
 
   return (

--- a/frontend/src/app/routes.test.tsx
+++ b/frontend/src/app/routes.test.tsx
@@ -12,6 +12,12 @@ import { API_BASE_URL, ROUTES } from "@/shared/config";
 import { routes } from "./routes";
 
 const ROOM_CODE = "7K93QX2S";
+/** 다른 방 세션까지 함께 지우지 않는지 보는 데 쓴다. */
+const OTHER_ROOM_CODE = "QRST6789";
+
+/** 토큰이 만료됐거나 서명이 맞지 않을 때 서버가 주는 응답이다. */
+const unauthorized = () =>
+  HttpResponse.json({ code: "UNAUTHORIZED", message: "다시 접속해주세요" }, { status: 401 });
 
 const renderAt = (path: string) => {
   const router = createMemoryRouter(routes, { initialEntries: [path] });
@@ -229,6 +235,65 @@ describe("라우트", () => {
 
     expect(await screen.findByRole("heading", { name: "제주 여행" })).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(ROUTES.gallery("7K93QX2S"));
+  });
+
+  /**
+   * 세션은 아직 살아 있어 보이는데 서버가 토큰을 거절한다 (#149) — 만료됐거나 서명이
+   * 맞지 않는 경우다. 손상된 세션을 그대로 두면 다음 요청도 같은 토큰으로 나가 401 만
+   * 되풀이하고, 갤러리는 에러 문구만 띄운 채 돌아갈 길을 내주지 않는다.
+   *
+   * 이름만 다시 받으면 이어갈 수 있으니, 세션을 지우고 그 방 입장 화면까지 데려다준다.
+   */
+  it("방 조회가 401 이면 그 방 세션을 지우고 입장 화면으로 되돌린다", async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/rooms/${ROOM_CODE}`, ({ request }) =>
+        request.headers.get("Authorization") === null ? undefined : unauthorized(),
+      ),
+    );
+    const router = renderAtGallery();
+
+    expect(
+      await screen.findByRole("heading", { name: "표시할 이름을 입력해주세요" }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(ROUTES.roomEntry(ROOM_CODE));
+    expect(getRoomSession(ROOM_CODE)).toBeNull();
+  });
+
+  /**
+   * 방은 멀쩡히 조회되고 사진 목록만 401 인 경우다. 화면에는 "사진을 불러오지 못했어요" 로
+   * 다른 실패와 똑같이 보이지만, 여기서 사용자가 할 수 있는 일은 다시 입장하는 것뿐이다.
+   */
+  it("사진 목록이 401 이어도 실패 문구 대신 입장 화면으로 되돌린다", async () => {
+    server.use(http.get(`${API_BASE_URL}/rooms/${MOCK_ROOM_ID}/media`, unauthorized));
+    const router = renderAtGallery();
+
+    expect(
+      await screen.findByRole("heading", { name: "표시할 이름을 입력해주세요" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("사진을 불러오지 못했어요.")).not.toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(ROUTES.roomEntry(ROOM_CODE));
+    expect(getRoomSession(ROOM_CODE)).toBeNull();
+  });
+
+  // 방마다 세션이 따로 있다. 한 방이 401 이라고 다른 방까지 이름부터 다시 묻게 하면 안 된다.
+  it("401 을 만나도 다른 방 세션은 그대로 둔다", async () => {
+    saveRoomSession(OTHER_ROOM_CODE, {
+      accessToken: "mock-token-10235",
+      userId: 10235,
+      nickname: "지은",
+      expiresAt: "2099-01-01T00:00:00Z",
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/rooms/${ROOM_CODE}`, ({ request }) =>
+        request.headers.get("Authorization") === null ? undefined : unauthorized(),
+      ),
+    );
+    renderAtGallery();
+
+    expect(
+      await screen.findByRole("heading", { name: "표시할 이름을 입력해주세요" }),
+    ).toBeInTheDocument();
+    expect(getRoomSession(OTHER_ROOM_CODE)).not.toBeNull();
   });
 
   it("알 수 없는 주소는 홈으로 보낸다", () => {

--- a/frontend/src/app/useUnauthorizedRecovery.ts
+++ b/frontend/src/app/useUnauthorizedRecovery.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { findRoomCodeByToken, removeRoomSession } from "@/entities/session";
+import { setUnauthorizedHandler } from "@/shared/api";
+import { ROUTES } from "@/shared/config";
+
+/**
+ * 401 을 만나면 그 방 세션을 버리고 입장 화면으로 되돌린다 (#149).
+ *
+ * **한 곳에서만 한다.** 화면마다 401 을 알아보게 두면 하나씩 빠뜨리고, 빠뜨린 화면은
+ * 무효한 토큰을 들고 그 자리에 갇힌다 — 다음 요청도 같은 토큰으로 나가 401 만 되풀이한다.
+ * 그래서 판단은 `apiClient` 가 하고(모든 요청이 지나는 길목이다) 뒷정리만 여기서 받는다.
+ *
+ * 세션을 지우는 것까지가 반이다. 지우기만 하면 사용자는 "코드로 입장" 을 스스로 다시
+ * 찾아야 해서, 이름만 다시 받으면 이어갈 수 있는 입장 화면까지 데려다준다.
+ */
+export const useUnauthorizedRecovery = () => {
+  const navigate = useNavigate();
+
+  useEffect(
+    () =>
+      setUnauthorizedHandler((token) => {
+        const roomCode = findRoomCodeByToken(token);
+
+        // 이미 지운 세션의 토큰이다. 같이 나갔던 다른 요청이 뒤늦게 401 로 돌아온 것이라
+        // 다시 옮길 화면이 없다 — 여기서 또 이동하면 사용자가 방금 연 화면을 밀어낸다.
+        if (roomCode === null) return;
+
+        removeRoomSession(roomCode);
+        // 되돌아갈 자리가 아니다. 뒤로 가기로 다시 들어와도 세션이 없어 그대로 튕긴다.
+        navigate(ROUTES.roomEntry(roomCode), { replace: true });
+      }),
+    [navigate],
+  );
+};

--- a/frontend/src/entities/session/index.ts
+++ b/frontend/src/entities/session/index.ts
@@ -1,5 +1,10 @@
 export { createAnonymous } from "./api/createAnonymous";
-export { getRoomSession, removeRoomSession, saveRoomSession } from "./lib/roomSessionStorage";
+export {
+  findRoomCodeByToken,
+  getRoomSession,
+  removeRoomSession,
+  saveRoomSession,
+} from "./lib/roomSessionStorage";
 export { readValidRoomSession } from "./lib/readValidRoomSession";
 export { RoomSessionBadge } from "./ui/RoomSessionBadge";
 export type { AnonymousSession, CreateAnonymousRequest } from "./model/types";

--- a/frontend/src/entities/session/lib/roomSessionStorage.test.ts
+++ b/frontend/src/entities/session/lib/roomSessionStorage.test.ts
@@ -1,5 +1,10 @@
 import type { AnonymousSession } from "../model/types";
-import { getRoomSession, removeRoomSession, saveRoomSession } from "./roomSessionStorage";
+import {
+  findRoomCodeByToken,
+  getRoomSession,
+  removeRoomSession,
+  saveRoomSession,
+} from "./roomSessionStorage";
 
 const session: AnonymousSession = {
   accessToken: "mock-access-token",
@@ -25,5 +30,32 @@ describe("roomSessionStorage", () => {
     removeRoomSession("7K93QX2S");
 
     expect(getRoomSession("7K93QX2S")).toBeNull();
+  });
+
+  /*
+   * 401 을 받으면 그 토큰이 든 방 하나만 지운다 (#149).
+   * 화면이 알려주는 방 코드로 지우지 않는 이유는, 응답이 늦게 오면 그 사이 다른 방으로
+   * 넘어가 있을 수 있어서다.
+   */
+  describe("findRoomCodeByToken", () => {
+    it("그 토큰을 들고 있는 방 코드를 찾는다", () => {
+      saveRoomSession("7K93QX2S", session);
+      saveRoomSession("QRST6789", { ...session, accessToken: "another-token", userId: 10235 });
+
+      expect(findRoomCodeByToken("another-token")).toBe("QRST6789");
+    });
+
+    it("어느 방 세션에도 없는 토큰이면 null 이다", () => {
+      saveRoomSession("7K93QX2S", session);
+
+      expect(findRoomCodeByToken("이미-지운-세션의-토큰")).toBeNull();
+    });
+
+    // 우리 키만 본다. 목이 남긴 값(`sssok.mock.*`)까지 세션으로 읽으면 안 된다.
+    it("세션이 아닌 저장소 항목은 보지 않는다", () => {
+      localStorage.setItem("sssok.mock.nextUserId", "10234");
+
+      expect(findRoomCodeByToken("10234")).toBeNull();
+    });
   });
 });

--- a/frontend/src/entities/session/lib/roomSessionStorage.ts
+++ b/frontend/src/entities/session/lib/roomSessionStorage.ts
@@ -5,7 +5,9 @@ import type { AnonymousSession } from "../model/types";
  * 방마다 익명 인증을 새로 하므로 방마다 다른 member(다른 userId·nickname)가 된다.
  * 한 번에 한 항목만 건드리므로, 탭 두 개에서 서로 다른 방에 입장해도 세션이 덮이지 않는다.
  */
-const getRoomSessionKey = (roomCode: string) => `sssok.auth:${roomCode}`;
+const ROOM_SESSION_KEY_PREFIX = "sssok.auth:";
+
+const getRoomSessionKey = (roomCode: string) => `${ROOM_SESSION_KEY_PREFIX}${roomCode}`;
 
 export const saveRoomSession = (roomCode: string, session: AnonymousSession) => {
   localStorage.setItem(getRoomSessionKey(roomCode), JSON.stringify(session));
@@ -28,4 +30,25 @@ export const getRoomSession = (roomCode: string): AnonymousSession | null => {
 /** 이 방 세션만 지운다. 다른 방 세션은 그대로 둔다. */
 export const removeRoomSession = (roomCode: string) => {
   localStorage.removeItem(getRoomSessionKey(roomCode));
+};
+
+/**
+ * 이 토큰을 들고 있는 방을 찾는다. 어느 방 것도 아니면 null 이다.
+ *
+ * 401 은 "요청에 실린 토큰이 죽었다" 는 뜻이라, 지워야 할 세션도 그 토큰이 든 방 하나다.
+ * 지금 보고 있는 화면의 방 코드로 지우지 않는 이유는 **응답이 늦게 올 수 있기 때문**이다 —
+ * 그 사이 다른 방으로 넘어갔다면 멀쩡한 세션을 대신 지우게 된다.
+ *
+ * 이미 지운 뒤에 도착한 401 도 여기서 null 로 걸러진다. 한 판에 함께 나간 요청들이
+ * 줄줄이 401 로 돌아오는데, 그때마다 세션을 지우고 화면을 옮기면 사용자가 다시 입장해
+ * 만든 새 세션까지 뒤늦은 응답이 밀어낸다.
+ */
+export const findRoomCodeByToken = (token: string): string | null => {
+  // 훑는 도중에 `getRoomSession` 이 손상된 항목을 지울 수 있다. 열쇠부터 떠 두지 않으면
+  // 그때 뒤 항목들의 자리가 당겨져 하나씩 건너뛴다.
+  const roomCodes = Object.keys(localStorage)
+    .filter((key) => key.startsWith(ROOM_SESSION_KEY_PREFIX))
+    .map((key) => key.slice(ROOM_SESSION_KEY_PREFIX.length));
+
+  return roomCodes.find((roomCode) => getRoomSession(roomCode)?.accessToken === token) ?? null;
 };

--- a/frontend/src/mocks/handlers/room.test.ts
+++ b/frontend/src/mocks/handlers/room.test.ts
@@ -134,9 +134,22 @@ describe("GET /rooms/{code} 목 핸들러", () => {
   it("입장 기록은 토큰마다 따로다 — 다른 토큰은 joined 가 false 다", async () => {
     await joinRoom(TOKEN);
 
-    const body = await (await getRoom(MOCK_ROOM_CODES.active, "Bearer other-token")).json();
+    const body = await (await getRoom(MOCK_ROOM_CODES.active, "Bearer mock-token-99999")).json();
 
     expect(body.data.joined).toBe(false);
+  });
+
+  /*
+   * 실제 서버는 토큰을 보냈는데 형식이 틀리면 401 이다 (`AuthMemberArgumentResolver`).
+   * 목이 이걸 흉내 내야 개발자도구에서 `sssok.auth:{방코드}` 를 망가뜨려
+   * 세션 만료 처리를 손으로 확인할 수 있다 (#149).
+   */
+  it("형식이 틀린 토큰은 401 UNAUTHORIZED 로 내려준다", async () => {
+    const response = await getRoom(MOCK_ROOM_CODES.active, "Bearer broken-token");
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.code).toBe("UNAUTHORIZED");
   });
 
   it("입장했어도 토큰 없는 조회는 joined 가 false 다", async () => {
@@ -222,6 +235,14 @@ describe("GET /rooms/{roomId}/media 목 핸들러", () => {
 
     expect(response.status).toBe(401);
     expect(body.code).toBe("UNAUTHORIZED");
+  });
+
+  it("형식이 틀린 토큰도 401 을 내려준다", async () => {
+    const response = await fetch(`${API_BASE_URL}/rooms/${MOCK_ROOM_ID}/media`, {
+      headers: { Authorization: "Bearer broken-token" },
+    });
+
+    expect(response.status).toBe(401);
   });
 });
 

--- a/frontend/src/mocks/handlers/room.ts
+++ b/frontend/src/mocks/handlers/room.ts
@@ -394,6 +394,20 @@ export const resetRoomHandlers = () => {
 const unauthorized = () =>
   HttpResponse.json({ code: "UNAUTHORIZED", message: "인증이 필요합니다." }, { status: 401 });
 
+/** 목 인증(`POST /auth/anonymous`)이 내주는 토큰 모양. */
+const TOKEN_PATTERN = /^Bearer mock-token-\d+$/;
+
+/**
+ * 헤더는 보냈는데 형식이 틀린 토큰이면 401 이다 — 실제 서버와 같다
+ * (`AuthMemberArgumentResolver`). 이게 있어야 개발자도구에서 `sssok.auth:{방코드}` 의
+ * 토큰을 망가뜨려 세션 만료 처리를 손으로 확인할 수 있다 (#149).
+ *
+ * 헤더가 아예 없는 것은 여기서 가리지 않는다. 방 조회처럼 비로그인도 부를 수 있는 API 가 있어
+ * "안 보낸 것" 과 "잘못 보낸 것" 의 처리가 다르다.
+ */
+const isBrokenToken = (authorization: string | null) =>
+  authorization !== null && !TOKEN_PATTERN.test(authorization);
+
 const roomNotFound = () =>
   HttpResponse.json(
     { code: "ROOM_NOT_FOUND", message: "존재하지 않는 방입니다." },
@@ -409,6 +423,10 @@ export const roomHandlers = [
   http.get(`${API_BASE_URL}/rooms/:code`, ({ request, params }) => {
     const code = String(params.code);
     const token = request.headers.get("Authorization");
+
+    if (isBrokenToken(token)) {
+      return unauthorized();
+    }
 
     if (!ROOM_CODE_PATTERN.test(code)) {
       return HttpResponse.json(
@@ -441,7 +459,9 @@ export const roomHandlers = [
   }),
 
   http.get(`${API_BASE_URL}/rooms/:roomId/media`, ({ request, params }) => {
-    if (request.headers.get("Authorization") === null) {
+    const token = request.headers.get("Authorization");
+
+    if (token === null || isBrokenToken(token)) {
       return unauthorized();
     }
 

--- a/frontend/src/pages/room-entry/ui/RoomEntryPage.test.tsx
+++ b/frontend/src/pages/room-entry/ui/RoomEntryPage.test.tsx
@@ -14,7 +14,7 @@ const FUTURE = "2099-01-01T00:00:00Z";
 const PAST = "2020-01-01T00:00:00Z";
 
 const session = (expiresAt: string) => ({
-  accessToken: "abc",
+  accessToken: "mock-token-99999",
   userId: 10234,
   nickname: "민수",
   expiresAt,
@@ -146,7 +146,10 @@ describe("RoomEntryPage", () => {
 
       expect(await screen.findByText(GALLERY_TEXT)).toBeInTheDocument();
       // 방마다 인증을 새로 하므로 방마다 다른 member 가 방 코드별로 나란히 쌓인다
-      expect(getRoomSession("ABCD2345")).toMatchObject({ accessToken: "abc", nickname: "민수" });
+      expect(getRoomSession("ABCD2345")).toMatchObject({
+        accessToken: "mock-token-99999",
+        nickname: "민수",
+      });
       expect(getRoomSession(MOCK_ROOM_CODES.active)).toMatchObject({
         accessToken: "mock-token-10234",
         nickname: "해니",

--- a/frontend/src/shared/api/apiClient.test.ts
+++ b/frontend/src/shared/api/apiClient.test.ts
@@ -4,6 +4,10 @@ import { server } from "@/mocks/server";
 import { API_BASE_URL } from "@/shared/config";
 import { ApiError } from "./ApiError";
 import { apiClient } from "./apiClient";
+import { setUnauthorizedHandler } from "./unauthorized";
+
+const unauthorizedResponse = () =>
+  HttpResponse.json({ code: "UNAUTHORIZED", message: "다시 접속해주세요" }, { status: 401 });
 
 describe("apiClient", () => {
   it.each([{ data: null }, {}, { success: true }])(
@@ -102,5 +106,78 @@ describe("apiClient", () => {
         message: "방을 만들 수 없습니다.",
       }),
     );
+  });
+
+  /*
+   * 401 은 화면이 아니라 여기서 알아본다 (#149). 인증이 깨진 요청은 어느 화면에서 나갔든
+   * 같은 뒷정리가 필요해서, 화면마다 알아보게 두면 하나씩 빠뜨린다.
+   */
+  describe("401 알림", () => {
+    let dispose: (() => void) | null = null;
+
+    const listen = () => {
+      const handler = jest.fn();
+
+      dispose = setUnauthorizedHandler(handler);
+
+      return handler;
+    };
+
+    // 등록은 모듈에 남는다. 지우지 않으면 다음 테스트의 요청까지 이 핸들러가 받는다.
+    afterEach(() => {
+      dispose?.();
+      dispose = null;
+    });
+
+    it("401 을 만나면 요청에 실었던 토큰을 알린다", async () => {
+      const onUnauthorized = listen();
+      server.use(http.get(`${API_BASE_URL}/api-test`, unauthorizedResponse));
+
+      await expect(apiClient("/api-test", { token: "dead-token" })).rejects.toMatchObject({
+        status: 401,
+      });
+
+      expect(onUnauthorized).toHaveBeenCalledWith("dead-token");
+    });
+
+    it("401 이라도 ApiError 는 그대로 던진다 — 알림은 뒷정리일 뿐이다", async () => {
+      listen();
+      server.use(http.get(`${API_BASE_URL}/api-test`, unauthorizedResponse));
+
+      await expect(apiClient("/api-test", { token: "dead-token" })).rejects.toMatchObject({
+        status: 401,
+        code: "UNAUTHORIZED",
+        message: "다시 접속해주세요",
+      });
+    });
+
+    // 토큰 없이 부른 요청의 401 은 "로그인이 필요하다" 는 뜻이라 지울 세션이 없다.
+    it("토큰 없이 받은 401 은 알리지 않는다", async () => {
+      const onUnauthorized = listen();
+      server.use(http.get(`${API_BASE_URL}/api-test`, unauthorizedResponse));
+
+      await expect(apiClient("/api-test")).rejects.toMatchObject({ status: 401 });
+
+      expect(onUnauthorized).not.toHaveBeenCalled();
+    });
+
+    // 403 은 인증이 아니라 인가 문제다. 세션은 멀쩡하므로 지우면 안 된다 (#148).
+    it("403 은 알리지 않는다", async () => {
+      const onUnauthorized = listen();
+      server.use(
+        http.get(`${API_BASE_URL}/api-test`, () =>
+          HttpResponse.json(
+            { code: "UPLOAD_NOT_ALLOWED", message: "방장만 업로드할 수 있는 방입니다" },
+            { status: 403 },
+          ),
+        ),
+      );
+
+      await expect(apiClient("/api-test", { token: "live-token" })).rejects.toMatchObject({
+        status: 403,
+      });
+
+      expect(onUnauthorized).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from "@/shared/config";
 import { ApiError } from "./ApiError";
+import { notifyUnauthorized } from "./unauthorized";
 
 interface ApiClientOptions extends RequestInit {
   token?: string;
@@ -48,6 +49,17 @@ export const apiClient = async <T>(
 
   if (!response.ok) {
     const error = await getErrorResponse(response);
+
+    /*
+     * 인증 자체가 깨졌다 — 토큰이 만료됐거나 서명이 맞지 않거나 형식이 틀렸다.
+     * 이 토큰으로는 무엇을 불러도 같은 답이 오므로, 던지기 전에 한 번 알린다 (#149).
+     *
+     * 화면마다 알아보게 두면 하나씩 빠뜨린다. 인가 실패(403)와 달리 401 은 사용자가
+     * 그 화면에서 할 수 있는 일이 없어서, 판단이 갈릴 여지도 없다.
+     */
+    if (response.status === 401 && token) {
+      notifyUnauthorized(token);
+    }
 
     throw new ApiError(
       response.status,

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,2 +1,3 @@
 export { ApiError, isApiError } from "./ApiError";
 export { apiClient } from "./apiClient";
+export { setUnauthorizedHandler } from "./unauthorized";

--- a/frontend/src/shared/api/unauthorized.ts
+++ b/frontend/src/shared/api/unauthorized.ts
@@ -1,0 +1,29 @@
+/**
+ * 401 을 만났을 때 부를 자리 하나 (#149).
+ *
+ * 세션을 지우고 입장 화면으로 되돌리는 일은 여기서 할 수 없다 — 세션(entities)도
+ * 라우터(app)도 shared 보다 위 레이어라 import 할 수 없다. 그래서 자리만 비워두고
+ * 앱이 뜰 때 위에서 채운다 (`useUnauthorizedRecovery`).
+ *
+ * 방 코드가 아니라 **토큰**을 넘긴다. 401 은 "요청에 실린 토큰이 죽었다" 는 뜻인데
+ * `apiClient` 는 그 요청이 어느 방 것인지 모른다. 토큰으로 방을 되짚는 일은 세션을
+ * 들고 있는 쪽(`findRoomCodeByToken`)의 몫이다.
+ */
+type UnauthorizedHandler = (token: string) => void;
+
+let handler: UnauthorizedHandler | null = null;
+
+/** 등록하고 정리 함수를 돌려준다. effect 의 cleanup 으로 그대로 쓴다. */
+export const setUnauthorizedHandler = (next: UnauthorizedHandler) => {
+  handler = next;
+
+  return () => {
+    // 그 사이 다른 핸들러가 자리를 넘겨받았다면 그것까지 지우지는 않는다.
+    if (handler === next) {
+      handler = null;
+    }
+  };
+};
+
+/** 등록된 핸들러가 없으면 아무 일도 하지 않는다 — 인증을 쓰지 않는 화면도 있다. */
+export const notifyUnauthorized = (token: string) => handler?.(token);


### PR DESCRIPTION
## 작업 내용

서버가 토큰 만료·서명 불일치·형식 오류에 401(`UNAUTHORIZED`)을 주는데, 프론트는 이걸
다른 실패와 구분 없이 `ApiError` 로만 다뤘습니다. 그래서 무효한 토큰이 `localStorage` 에
남아 다음 요청도 같은 토큰으로 나가고, 화면은 에러 문구만 띄운 채 돌아갈 길을 내주지
않았습니다.

**401 판정을 `apiClient` 한 곳으로 모았습니다.** 모든 요청이 지나는 유일한 길목이라,
화면마다 알아보게 두면 반드시 하나씩 빠뜨리고 빠뜨린 화면이 곧 갇히는 화면이 됩니다.
403(인가)과 달리 401 은 사용자가 그 화면에서 할 수 있는 일이 없어서, 화면마다 판단이
갈릴 여지도 없습니다.

흐름은 이렇습니다.

    apiClient (401 감지) → 토큰으로 방 되짚기 → 그 방 세션만 삭제 → 입장 화면으로 이동

세션을 지우는 것까지가 반입니다. 지우기만 하면 사용자가 "코드로 입장" 을 스스로 다시
찾아야 해서, 이름만 다시 받으면 이어갈 수 있는 입장 화면까지 데려다줍니다.

## 관련 이슈

Closes #149

## 작업 영역

- [x] Frontend
- [ ] Backend

## 변경 사항

- [x] `apiClient` 가 401 을 만나면 던지기 전에 요청에 실었던 토큰을 알림 (018bf93)
      세션 삭제·이동은 여기서 못 함 — `shared` 는 상위 레이어를 import 할 수 없어
      자리만 비워두고 앱이 채웁니다
- [x] `findRoomCodeByToken` 으로 토큰이 든 방을 되짚음 (b1b9cd8)
- [x] `useUnauthorizedRecovery` 가 그 방 세션만 지우고 입장 화면으로 `replace` 이동.
      `RoomMediaLayout` 에 한 번만 걸어 갤러리·상세·설정이 각자 알아볼 필요가 없음 (600cc09)
- [x] 목이 형식 틀린 토큰을 401 로 거절 — 실서버 `AuthMemberArgumentResolver` 와 같게 (905b952)

## 테스트

- [x] 단위 테스트 작성/통과 — 신규 12개 포함 492개 전부 통과, `tsc --noEmit`·eslint 깨끗함
- [x] 로컬 동작 확인 — dev 서버가 실서버를 보는 상태에서, 깨진 토큰 세션을 심고
      `/rooms/{code}/gallery` 진입 → 진짜 401 → 그 방 세션만 사라지고 입장 화면으로 이동,
      **다른 방 세션은 그대로** 남는 것까지 확인

새 통합 테스트 3개는 `apiClient` 의 알림을 꺼 두면 실제로 실패하는 것까지 확인했습니다.

## 리뷰 요청 사항

- **화면의 방 코드가 아니라 토큰으로 되짚는 것** — 응답이 늦게 오면 그 사이 다른 방으로
   넘어가 있을 수 있어, 화면 코드로 지우면 멀쩡한 세션을 대신 지웁니다. 이미 지운 토큰이
   `null` 로 걸러지는 덕에, 함께 나갔던 요청들이 줄줄이 401 로 돌아와도 새 세션을
   밀어내지 않습니다.