### PR TITLE
fix: 다운로드 진행 바가 차오르지 않던 문제 해결

### DIFF
--- a/frontend/src/features/download-media/model/downloadMedia.test.ts
+++ b/frontend/src/features/download-media/model/downloadMedia.test.ts
@@ -175,6 +175,29 @@ describe("downloadMedia — zip", () => {
     expect(saveBlobMock.mock.calls[0][0].size).toBeGreaterThan(0);
   });
 
+  it("압축이 끝난 뒤 zip 을 받는 동안에도 진행률이 오른다 — 100% 에 붙어 멈추지 않는다", async () => {
+    const phases: string[] = [];
+    const zipBytes: { loaded: number; total: number }[] = [];
+
+    await downloadMedia({
+      roomId: MOCK_ROOM_ID,
+      targets: [targetOf(5000), targetOf(5001)],
+      mode: "zip",
+      token: TOKEN,
+      onPhase: (phase) => phases.push(phase),
+      onZipBytes: (bytes) => zipBytes.push(bytes),
+    });
+
+    // 서버가 다 묶었다고 알려온 다음이 실제 전송 구간이다. 단계가 따로 있어야 문구도 갈린다.
+    expect(phases).toEqual(["zipping", "receiving"]);
+    expect(zipBytes.length).toBeGreaterThan(0);
+
+    const last = zipBytes[zipBytes.length - 1];
+
+    expect(last.total).toBeGreaterThan(0);
+    expect(last.loaded).toBeGreaterThan(0);
+  });
+
   it("zip 을 고르면 단건 다운로드 요청이 나가지 않는다", async () => {
     const singles: number[] = [];
 

--- a/frontend/src/features/download-media/model/downloadMedia.ts
+++ b/frontend/src/features/download-media/model/downloadMedia.ts
@@ -36,6 +36,8 @@ export interface DownloadMediaParams {
   onPhase?: (phase: DownloadPhase) => void;
   /** 서버 압축 진행률(0~100). zip 일 때만 온다. */
   onZipProgress?: (percent: number) => void;
+  /** 다 묶인 zip 을 내려받는 동안의 바이트. zip 일 때만 온다. */
+  onZipBytes?: (bytes: { loaded: number; total: number }) => void;
 }
 
 interface FetchedMedia {
@@ -119,7 +121,7 @@ const fetchAll = async (
 };
 
 export const downloadMedia = async (params: DownloadMediaParams): Promise<DownloadOutcome> => {
-  const { roomId, targets, mode, token, signal, onPhase, onZipProgress } = params;
+  const { roomId, targets, mode, token, signal, onPhase, onZipProgress, onZipBytes } = params;
   const failed: FailedDownload[] = [];
 
   if (mode === "zip") {
@@ -174,8 +176,19 @@ export const downloadMedia = async (params: DownloadMediaParams): Promise<Downlo
      * `Content-Disposition: attachment` 가 실려 있어 이동만으로 저장되고, 그러면
      * 스토리지 CORS 도 필요 없고 수 GB 짜리 zip 을 메모리에 올리지도 않는다.
      * 지금 받아오는 이유는 목(MSW)이 다른 오리진의 이동을 가로챌 수 없어서다.
+     *
+     * **여기서도 진행률을 흘린다.** 압축이 끝났다고 기다림이 끝난 게 아니다 — 폰에서는
+     * 이 구간이 압축보다 길 때가 많은데, 알리지 않으면 바가 100% 에 붙어 멈춰 보인다.
+     * 분모는 잡이 알려준 원본 합계다. Content-Length 가 오면 `fetchMediaBlob` 이 그쪽을 쓴다.
      */
-    const zip = await fetchMediaBlob({ url: settled.downloadUrl, size: 0, signal });
+    onPhase?.("receiving");
+
+    const zip = await fetchMediaBlob({
+      url: settled.downloadUrl,
+      size: job.totalSize,
+      signal,
+      onProgress: (loaded, total) => onZipBytes?.({ loaded, total }),
+    });
 
     if (zip.type === "aborted") {
       return { type: "aborted" };

--- a/frontend/src/features/download-media/model/downloadProgress.test.ts
+++ b/frontend/src/features/download-media/model/downloadProgress.test.ts
@@ -5,6 +5,8 @@ import {
   withDownloaded,
   withPhase,
   withProgress,
+  withZipBytes,
+  withZipProgress,
 } from "./downloadProgress";
 import type { DownloadTarget } from "./types";
 
@@ -86,5 +88,37 @@ describe("withPhase", () => {
       totalCount: 2,
       percent: 4,
     });
+  });
+});
+
+describe("withZipBytes", () => {
+  it("압축이 100% 로 끝난 뒤에도 바가 계속 움직인다 — 묶인 zip 을 받는 시간이 통째로 남아 있다", () => {
+    let state = withPhase(startDownloadProgress([PHOTO, VIDEO]), "zipping");
+
+    state = withZipProgress(state, 100);
+    expect(percentOf(state)).toBe(100);
+
+    // 서버가 다 묶었다고 알려온 순간부터가 실제 전송이다. 여기서 다시 0 부터 오른다.
+    state = withPhase(state, "receiving");
+    state = withZipBytes(state, { loaded: 0, total: 83_400_000 });
+    expect(percentOf(state)).toBe(0);
+
+    state = withZipBytes(state, { loaded: 41_700_000, total: 83_400_000 });
+    expect(percentOf(state)).toBe(50);
+  });
+
+  it("분모를 모르면 100 으로 둔다 — 0 으로 나누지도, 0% 로 되돌아가지도 않는다", () => {
+    const state = withZipBytes(startDownloadProgress([PHOTO]), { loaded: 0, total: 0 });
+
+    expect(percentOf(state)).toBe(100);
+  });
+
+  it("낱장 받기가 세던 바이트에 가려지지 않는다", () => {
+    let state = startDownloadProgress([PHOTO, VIDEO]);
+
+    state = withDownloaded(state, PHOTO.mediaId);
+    state = withZipBytes(state, { loaded: 20_850_000, total: 83_400_000 });
+
+    expect(snapshotOf(state).percent).toBe(25);
   });
 });

--- a/frontend/src/features/download-media/model/downloadProgress.ts
+++ b/frontend/src/features/download-media/model/downloadProgress.ts
@@ -14,8 +14,12 @@ import type { DownloadTarget } from "./types";
  *
  * 다 받고 나서 zip 으로 묶는 동안은 네트워크가 조용하다. 퍼센트만 보면 100% 에서
  * 멈춘 것처럼 보여서, 그 구간에는 "묶는 중"이라고 말해줘야 한다.
+ *
+ * `zipping` 다음에 `receiving` 이 따로 있는 이유도 같다. 서버가 다 묶었다고 알려온 뒤에도
+ * **그 zip 을 실제로 내려받는 시간이 통째로 남아 있다.** 폰에서는 이쪽이 오히려 더 긴데,
+ * 압축 진행률만 보고 있으면 그 구간 내내 100% 에 붙어 멈춘 것처럼 보인다.
  */
-export type DownloadPhase = "fetching" | "zipping" | "sharing";
+export type DownloadPhase = "fetching" | "zipping" | "receiving" | "sharing";
 
 export interface DownloadProgressState {
   phase: DownloadPhase;
@@ -36,6 +40,11 @@ export interface DownloadProgressState {
    * 받은 바이트로 세는 `loadedByMediaId` 와 분리해 둔다 — 세는 대상이 아예 다르다.
    */
   zipPercent: number | null;
+  /**
+   * 다 묶인 zip 을 내려받는 동안의 바이트. `zipPercent` 와 분리해 둔다 —
+   * 압축이 100% 로 끝난 뒤에 0 부터 다시 시작하는, 세는 대상이 아예 다른 구간이다.
+   */
+  zipBytes: { loaded: number; total: number } | null;
 }
 
 export const startDownloadProgress = (targets: DownloadTarget[]): DownloadProgressState => ({
@@ -46,6 +55,7 @@ export const startDownloadProgress = (targets: DownloadTarget[]): DownloadProgre
   totalByMediaId: Object.fromEntries(targets.map((target) => [target.mediaId, target.size])),
   loadedByMediaId: {},
   zipPercent: null,
+  zipBytes: null,
 });
 
 export const withPhase = (
@@ -83,6 +93,13 @@ export const withZipProgress = (
   percent: number,
 ): DownloadProgressState => ({ ...state, zipPercent: Math.min(Math.max(percent, 0), 100) });
 
+export const withZipBytes = (
+  state: DownloadProgressState,
+  { loaded, total }: { loaded: number; total: number },
+): DownloadProgressState => ({ ...state, zipBytes: { loaded, total } });
+
+const clampPercent = (percent: number) => Math.min(Math.max(percent, 0), 100);
+
 export const loadedBytesOf = (state: DownloadProgressState) =>
   Object.values(state.loadedByMediaId).reduce((sum, loaded) => sum + loaded, 0);
 
@@ -91,6 +108,16 @@ export const loadedBytesOf = (state: DownloadProgressState) =>
  * 3.4MB 사진과 80MB 영상을 같은 한 장으로 세면 바가 영상 구간에서 통째로 멈춘다.
  */
 export const percentOf = (state: DownloadProgressState) => {
+  // 묶인 zip 을 받는 중이라면 그쪽이 지금 움직이는 유일한 값이다. 압축 진행률보다 뒤에 오므로
+  // 먼저 본다 — 이걸 뒤에 두면 100% 로 끝난 `zipPercent` 에 가려 바가 다시 멈춘다.
+  if (state.zipBytes !== null) {
+    if (state.zipBytes.total <= 0) {
+      return 100;
+    }
+
+    return clampPercent(Math.floor((state.zipBytes.loaded / state.zipBytes.total) * 100));
+  }
+
   // zip 은 서버가 진행률을 알려준다. 우리가 받은 바이트로 세면 압축 구간이 통째로 빠진다.
   if (state.zipPercent !== null) {
     return state.zipPercent;
@@ -100,9 +127,7 @@ export const percentOf = (state: DownloadProgressState) => {
     return 0;
   }
 
-  const percent = Math.floor((loadedBytesOf(state) / state.totalBytes) * 100);
-
-  return Math.min(Math.max(percent, 0), 100);
+  return clampPercent(Math.floor((loadedBytesOf(state) / state.totalBytes) * 100));
 };
 
 /** 화면이 실제로 읽는 값. 내부 장부는 바깥으로 나가지 않는다. */

--- a/frontend/src/features/download-media/model/useMediaDownload.ts
+++ b/frontend/src/features/download-media/model/useMediaDownload.ts
@@ -9,6 +9,7 @@ import {
   withDownloaded,
   withPhase,
   withProgress,
+  withZipBytes,
   withZipProgress,
 } from "./downloadProgress";
 import type { DownloadMode, DownloadOutcome, DownloadTarget } from "./types";
@@ -74,6 +75,7 @@ export const useMediaDownload = ({
         onDownloaded: (mediaId) => update((state) => withDownloaded(state, mediaId)),
         onPhase: (phase) => update((state) => withPhase(state, phase)),
         onZipProgress: (percent) => update((state) => withZipProgress(state, percent)),
+        onZipBytes: (bytes) => update((state) => withZipBytes(state, bytes)),
       });
 
       // 밀려난 판의 결말은 알리지 않는다. 업로드와 달리 받기는 서버에 남는 흔적이 없어,

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.styles.ts
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.styles.ts
@@ -76,16 +76,22 @@ export const ActionGroup = styled.div`
   gap: 0;
 `;
 
+/**
+ * 진행률 알약. **채움 띠를 담는 그릇이라 `position` 과 `overflow` 가 붙어 있다** —
+ * 업로드 바(`UploadProgressBar.styles`)의 `Status` 와 같은 이유다.
+ * `overflow: hidden` 이 없으면 채움이 알약 모서리 밖으로 새어 나온다.
+ */
 export const Status = styled.span`
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: ${spacing[8]};
   flex: 1;
   min-width: 0;
   height: 40px;
   padding: 0 14px;
   border-radius: ${radius.full};
+  overflow: hidden;
   background: ${colors.primarySubtle};
   ${typography.caption2}
   white-space: nowrap;
@@ -178,4 +184,31 @@ export const PlainButton = styled.button`
   @media (max-width: 360px) {
     font-size: 11px;
   }
+`;
+
+/**
+ * 퍼센트만큼 차오르는 띠. 업로드 바의 `Fill` 과 같은 값·같은 모양이다 —
+ * 두 바가 같은 자리에 같은 알약으로 뜨는데 한쪽만 차오르면 다른 것으로 읽힌다.
+ * 너비는 진행률 이벤트마다 바뀌므로 클래스가 아니라 인라인 스타일로 준다.
+ */
+export const Fill = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background: ${colors.primary};
+  opacity: 0.18;
+  transition: width 60ms linear;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+/** 채움 위에 얹는다. 같은 칸을 쓰므로 쌓임 순서를 명시한다. */
+export const StatusText = styled.span`
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: ${spacing[8]};
 `;

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.test.tsx
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.test.tsx
@@ -116,6 +116,41 @@ describe("SelectionDownloadBar", () => {
     expect(screen.getByText("2개를 어떻게 받을까요?")).toBeInTheDocument();
   });
 
+  /**
+   * 숫자만 있는 바는 폰에서 거의 안 읽힌다. 업로드 바와 같은 자리에 같은 알약으로 뜨는데
+   * 한쪽만 차오르면 받기가 멈춘 것으로 읽힌다 — 띠와 진행률 의미를 함께 내준다.
+   */
+  it("받는 동안 차오르는 띠를 진행률만큼 그린다", async () => {
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    serveSingle();
+    server.use(
+      http.get(`${API_BASE_URL}/rooms/:roomId/downloads/media/:mediaId`, async () => {
+        await held;
+
+        return new HttpResponse(new Blob(["bytes"]), {
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }),
+    );
+
+    renderBar([targetOf(5000)]);
+    await downloadIndividually();
+
+    const bar = await screen.findByRole("progressbar", { name: "다운로드 진행률" });
+
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+    // 띠는 알약 안에 있고, 너비가 곧 퍼센트다.
+    expect(bar.firstElementChild).toHaveStyle({ width: "0%" });
+
+    release();
+
+    await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+  });
+
   it("다 받으면 고른 상태를 풀어준다", async () => {
     serveSingle();
 

--- a/frontend/src/features/download-media/ui/SelectionDownloadBar.tsx
+++ b/frontend/src/features/download-media/ui/SelectionDownloadBar.tsx
@@ -14,6 +14,7 @@ import { IconButton } from "@/shared/ui/icon-button";
 import { downloadMessageOfError } from "../lib/downloadErrorMessage";
 import { useDownloadFailure } from "../model/useDownloadFailure";
 import { useMediaDownload } from "../model/useMediaDownload";
+import type { DownloadPhase } from "../model/downloadProgress";
 import type { DownloadMode, DownloadOutcome, DownloadTarget } from "../model/types";
 import { DownloadFailureModal } from "./DownloadFailureModal";
 import { DownloadModeSheet } from "./DownloadModeSheet";
@@ -22,11 +23,13 @@ import {
   Count,
   DownloadButton,
   Dock,
+  Fill,
   PlainButton,
   SelectionCheck,
   SelectionLayout,
   SelectionSummary,
   Status,
+  StatusText,
 } from "./SelectionDownloadBar.styles";
 
 /**
@@ -56,9 +59,10 @@ interface SelectionDownloadBarProps {
  * 단계마다 사용자가 기다리는 것이 다르다. 회선을 기다리는지, 서버가 묶기를 기다리는지,
  * 사진첩으로 넘어가기를 기다리는지 — 같은 스피너라도 무엇을 기다리는지는 말해줘야 한다.
  */
-const STATUS_TEXT: Record<string, string> = {
+const STATUS_TEXT: Record<DownloadPhase, string> = {
   fetching: "다운로드 중",
   zipping: "압축 중",
+  receiving: "zip 받는 중",
   sharing: "사진첩으로 보내는 중",
 };
 
@@ -132,11 +136,26 @@ export const SelectionDownloadBar = ({
                     ? `${progress.completedCount} / ${progress.totalCount}`
                     : `${progress.totalCount}장`}
                 </Count>
-                <Status>
-                  <LuLoaderCircle className="spin" />
-                  {STATUS_TEXT[progress.phase]}...
-                  {/* 공유 시트로 넘기는 순간은 길이를 알 수 없다. 나머지는 퍼센트가 실제로 움직인다. */}
-                  {progress.phase !== "sharing" && ` ${progress.percent}%`}
+                {/*
+                  공유 시트로 넘기는 순간은 길이를 알 수 없다 — 그 구간만 퍼센트도 채움도 없이
+                  돌아가는 스피너로 둔다. 나머지 구간은 값이 실제로 움직이므로 업로드 바와
+                  똑같이 숫자와 띠를 함께 보여준다.
+                */}
+                <Status
+                  role="progressbar"
+                  aria-label="다운로드 진행률"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={progress.phase === "sharing" ? undefined : progress.percent}
+                >
+                  {progress.phase !== "sharing" && (
+                    <Fill style={{ width: `${progress.percent}%` }} />
+                  )}
+                  <StatusText>
+                    <LuLoaderCircle className="spin" />
+                    {STATUS_TEXT[progress.phase]}...
+                    {progress.phase !== "sharing" && ` ${progress.percent}%`}
+                  </StatusText>
                 </Status>
                 <PlainButton type="button" onClick={cancel}>
                   취소


### PR DESCRIPTION
## 작업 내용
- 다운로드 진행 바에 **채움 게이지가 없어서** 진행 상황이 눈으로 읽히지 않았습니다. 업로드 바에는 있는 것이 받기 쪽에는 처음부터 없었습니다.
- 두 바는 화면 하단 같은 자리에 같은 알약 모양으로 뜹니다. 사용자에게는 같은 부품인데 올릴 때만 차오르고 받을 때는 글자만 바뀌어서, 받기가 멈춘 것으로 읽혔습니다.
- 게이지를 넣고 보니 **zip 을 실제로 내려받는 구간에서 다시 멈췄습니다.** 서버가 압축을 끝냈다고 알려온 뒤에도 zip 파일을 받는 시간이 통째로 남는데, 그 구간에 진행률을 흘리지 않고 있었습니다. 폰 회선에서는 이쪽이 압축보다 긴 경우가 많습니다.

## 관련 이슈
Closes #174

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] `fix(frontend): zip 받는 구간에서 진행률이 멈추던 문제 해결` — 단계에 `receiving` 을 더하고, 압축 진행률과 세는 대상이 다른 `zipBytes` 를 따로 둬서 100% 로 끝난 `zipPercent` 에 가려지지 않게 했습니다. zip 요청에 진행률 콜백과 분모(`job.totalSize`)를 연결했습니다.
- [x] `feat(frontend): 다운로드 진행 바에 채움 게이지 추가` — 업로드 바와 같은 색·불투명도·전환으로 `Fill` 을 넣고, 알약에 `position`·`overflow` 를 줘서 채움이 모서리 밖으로 새지 않게 했습니다. `role="progressbar"` 와 `aria-valuenow` 도 붙였습니다.

## 테스트
- [x] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

전체 **485개 통과**했고 `tsc --noEmit` 도 통과합니다. 새로 쓴 것은 5개입니다.

| 파일 | 확인하는 것 |
| --- | --- |
| `downloadProgress.test.ts` | 압축이 100% 로 끝난 뒤에도 0→50% 로 계속 오름 / 분모를 모르면 100 / 낱장 바이트에 가려지지 않음 |
| `downloadMedia.test.ts` | zip 모드에서 단계가 `["zipping", "receiving"]` 순으로 오고 바이트가 실제로 보고됨 |
| `SelectionDownloadBar.test.tsx` | 받는 중 `role="progressbar"` 가 있고, 채움 너비가 표시 퍼센트와 일치 |

로컬 확인은 목 서버(`start:mock`)를 375×812 뷰포트로 띄워서 했습니다. 13장 zip 다운로드에서 게이지가 47% 까지 차오르고 `aria-valuenow="47"` 이 붙는 것을 확인했습니다. 콘솔 에러는 없었습니다.

## 리뷰 요청 사항 (선택)
- **`sharing` 단계는 채움도 퍼센트도 그리지 않습니다.** 공유 시트가 언제 닫힐지 알 수 없어서 퍼센트 자체가 없습니다. 지금은 스피너만 돕니다. 불확정 상태용 애니메이션을 따로 넣을지는 이 PR 범위 밖으로 뒀는데, 필요하다고 보시면 별도 이슈로 올리겠습니다.