### PR TITLE
chore: 프론트엔드 시멘틱 버저닝 도입

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,6 +27,22 @@ jobs:
     steps:
       - name: 저장소 체크아웃
         uses: actions/checkout@v4
+        with:
+          # 직전 릴리스 태그와 비교해야 하므로 얕은 클론으로는 부족하다.
+          fetch-depth: 0
+
+      # 배포 PR에서만 검사한다. 버전은 사람이 직접 올리고, 여기서는 올렸는지만 확인한다.
+      # 의존성 설치보다 앞에 둬서 빠뜨렸을 때 빌드까지 가지 않고 끝나게 한다.
+      - name: 버전 상승 확인
+        if: github.base_ref == 'deploy'
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          LAST=$(git tag -l 'fe-v*' --sort=-v:refname | head -1 | sed 's/^fe-v//')
+          if [ "$CURRENT" = "$LAST" ]; then
+            echo "::error::프론트 버전이 $LAST 그대로다. package.json 의 version 을 올려야 한다."
+            exit 1
+          fi
+          echo "${LAST:-없음} -> $CURRENT"
 
       - name: pnpm 설정
         uses: pnpm/action-setup@v4

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+# pnpm version 이 커밋과 태그를 임의로 만들지 않게 막는다.
+# 태그는 배포가 성공한 뒤 fe-v<버전> 형식으로 릴리스를 만들면서 붙인다.
+gitTagVersion: false
+
 allowBuilds:
   "@swc/core": true
   esbuild: true


### PR DESCRIPTION
## 작업 내용
프론트엔드 버전을 시멘틱 버저닝으로 관리하기 위한 기준선을 잡고,
배포 PR 에서 버전을 올리지 않으면 CI 가 막도록 검증을 추가했습니다.

버전은 자동으로 올리지 않습니다. 배포 담당자가 직전 릴리스 이후 변경을 보고
`patch` / `minor` / `major` 중 하나를 직접 고르고, CI 는 올렸는지 여부만 확인합니다.

앞으로 배포 절차는 이렇게 됩니다.

    1. cd frontend && pnpm version minor   (판단은 사람이)
    2. bump 커밋 → main PR
    3. main → deploy PR                    ← CI
    4. CodePipeline 배포 성공 확인
    5. Releases 에서 fe-v0.2.0 릴리스 생성  

## 관련 이슈
Closes #176

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] `frontend/package.json` 버전 `1.0.0` → `0.1.0`
- [x] `frontend/pnpm-workspace.yaml` 에 `gitTagVersion: false` 추가
- [x] `frontend-ci.yml` 체크아웃에 `fetch-depth: 0` 추가
- [x] `frontend-ci.yml` 에 버전 상승 확인 스텝 추가

## 테스트
- [ ] 단위 테스트 작성/통과 (해당 없음)
- [x] 로컬 동작 확인

검증 스크립트를 로컬에서 실행해 확인했습니다.

    없음 -> 0.1.0

## 리뷰 요청 사항 (선택)
**`gitTagVersion: false` 인 이유** — `pnpm version` 이 기본으로
   `v0.2.0` 태그와 커밋을 즉시 만듭니다. 이름 규칙에 안 맞고 배포 전에 생기므로 껐습니다.