### PR TITLE
feat(frontend): 방 이벤트 SSE 구독 연동

### DIFF
--- a/frontend/src/features/subscribe-room-events/index.ts
+++ b/frontend/src/features/subscribe-room-events/index.ts
@@ -1,0 +1,1 @@
+export { useRoomEvents } from "./model/useRoomEvents";

--- a/frontend/src/features/subscribe-room-events/model/useRoomEvents.ts
+++ b/frontend/src/features/subscribe-room-events/model/useRoomEvents.ts
@@ -1,0 +1,83 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { photosQueryKey } from "@/entities/media";
+import { API_BASE_URL } from "@/shared/config";
+
+interface UseRoomEventsParams {
+  roomId: number;
+  userId: number;
+  token: string;
+}
+
+const ROOM_EVENT_NAMES = [
+  "media.created",
+  "media.ready",
+  "media.failed",
+  "media.deleted",
+  "media.folders.updated",
+  "folder.created",
+  "folder.updated",
+  "folder.deleted",
+  "room.updated",
+  "room.deleted",
+] as const;
+
+const parseEventData = (data: string) => {
+  try {
+    return JSON.parse(data) as unknown;
+  } catch {
+    return data;
+  }
+};
+
+/** 방에 접속해 있는 동안 media.ready 이벤트를 받아 사진 목록을 갱신한다. */
+export const useRoomEvents = ({ roomId, userId, token }: UseRoomEventsParams) => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (typeof EventSource === "undefined") return;
+
+    const url = new URL(`${API_BASE_URL}/rooms/${roomId}/events`, window.location.origin);
+    url.searchParams.set("token", token);
+
+    const eventSource = new EventSource(url);
+    const refreshPhotos = () => {
+      void queryClient.invalidateQueries({ queryKey: photosQueryKey(roomId, userId) });
+    };
+    const logConnected = () => {
+      console.info(`[SSE] ${roomId}번 방 구독 연결됨`);
+    };
+    const logEvent = (event: Event) => {
+      const message = event as MessageEvent<string>;
+      console.info(`[SSE] ${message.type}`, {
+        eventId: message.lastEventId,
+        data: parseEventData(message.data),
+      });
+    };
+    const logError = () => {
+      console.warn(`[SSE] ${roomId}번 방 연결 오류 또는 재연결 대기`, {
+        readyState: eventSource.readyState,
+      });
+    };
+
+    eventSource.addEventListener("media.ready", refreshPhotos);
+    if (process.env.NODE_ENV === "development") {
+      eventSource.addEventListener("open", logConnected);
+      eventSource.addEventListener("error", logError);
+      ROOM_EVENT_NAMES.forEach((eventName) => eventSource.addEventListener(eventName, logEvent));
+    }
+
+    return () => {
+      eventSource.removeEventListener("media.ready", refreshPhotos);
+      if (process.env.NODE_ENV === "development") {
+        eventSource.removeEventListener("open", logConnected);
+        eventSource.removeEventListener("error", logError);
+        ROOM_EVENT_NAMES.forEach((eventName) =>
+          eventSource.removeEventListener(eventName, logEvent),
+        );
+      }
+      eventSource.close();
+    };
+  }, [queryClient, roomId, token, userId]);
+};

--- a/frontend/src/pages/gallery/ui/GalleryPage.tsx
+++ b/frontend/src/pages/gallery/ui/GalleryPage.tsx
@@ -1,7 +1,8 @@
 import { Navigate, useParams } from "react-router-dom";
 
-import { useRoomQuery } from "@/entities/room";
+import { useRoomQuery, type Room } from "@/entities/room";
 import { readValidRoomSession } from "@/entities/session";
+import { useRoomEvents } from "@/features/subscribe-room-events";
 import { isApiError } from "@/shared/api";
 import { ROUTES } from "@/shared/config";
 import { GalleryContent } from "./GalleryContent";
@@ -10,6 +11,18 @@ import { PageState } from "./GalleryPage.styles";
 const ERROR_MESSAGE: Record<string, string> = {
   INVALID_ROOM_CODE: "방 코드 형식이 올바르지 않아요.",
   ROOM_NOT_FOUND: "존재하지 않는 방이에요.",
+};
+
+interface ActiveGalleryProps {
+  room: Room;
+  accessToken: string;
+  userId: number;
+}
+
+const ActiveGallery = ({ room, accessToken, userId }: ActiveGalleryProps) => {
+  useRoomEvents({ roomId: room.roomId, userId, token: accessToken });
+
+  return <GalleryContent room={room} accessToken={accessToken} userId={userId} />;
 };
 
 export const GalleryPage = () => {
@@ -43,7 +56,7 @@ export const GalleryPage = () => {
   }
 
   return (
-    <GalleryContent
+    <ActiveGallery
       room={roomQuery.data}
       accessToken={session.accessToken}
       userId={session.userId}


### PR DESCRIPTION
## 작업 내용
- 갤러리 진입 시 방 이벤트 SSE를 구독하도록 연동했습니다.
- 미디어 준비 완료 이벤트를 수신하면 사진 목록을 갱신합니다.

## 관련 이슈
Closes #173 

## 작업 영역
- [x] Frontend
- [ ] Backend

## 변경 사항
- [x] `/rooms/{roomId}/events`에 `EventSource` 연결
- [x] `media.ready` 이벤트 수신 시 사진 목록 쿼리 무효화
- [x] 컴포넌트 언마운트 시 이벤트 리스너 및 SSE 연결 정리
- [x] 개발 환경에서 연결 상태와 방 이벤트 로그 출력
- [x] 활성 상태의 방에서만 SSE를 구독하도록 갤러리 구조 분리

## 테스트
- [ ] 단위 테스트 작성/통과
- [x] 로컬 동작 확인

## 리뷰 요청 사항 (선택)
- `media.ready` 수신 시 사진 목록 전체를 무효화하는 방식입니다.
